### PR TITLE
Missing AWS Config Support for EBS driver

### DIFF
--- a/drivers/storage/ebs/ebs.go
+++ b/drivers/storage/ebs/ebs.go
@@ -8,8 +8,11 @@ const (
 	// Name is the provider's name.
 	Name = "ebs"
 
-	// OldName is the provider's old name.
-	OldName = "ec2"
+	// NameEC2 is the provider's old EC2 name.
+	NameEC2 = "ec2"
+
+	// NameAWS is the provider's old AWS name.
+	NameAWS = "aws"
 
 	// TagDelimiter separates tags from volume or snapshot names
 	TagDelimiter = "/"
@@ -56,11 +59,19 @@ func registerConfig() {
 	r.Key(gofig.String, "", "", "", Name+"."+Endpoint)
 	r.Key(gofig.Int, "", DefaultMaxRetries, "", Name+"."+MaxRetries)
 	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", Name+"."+Tag)
-	r.Key(gofig.String, "", "", "", OldName+"."+AccessKey)
-	r.Key(gofig.String, "", "", "", OldName+"."+SecretKey)
-	r.Key(gofig.String, "", "", "", OldName+"."+Region)
-	r.Key(gofig.String, "", "", "", OldName+"."+Endpoint)
-	r.Key(gofig.Int, "", DefaultMaxRetries, "", OldName+"."+MaxRetries)
-	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", OldName+"."+Tag)
+
+	r.Key(gofig.String, "", "", "", NameEC2+"."+AccessKey)
+	r.Key(gofig.String, "", "", "", NameEC2+"."+SecretKey)
+	r.Key(gofig.String, "", "", "", NameEC2+"."+Region)
+	r.Key(gofig.String, "", "", "", NameEC2+"."+Endpoint)
+	r.Key(gofig.Int, "", DefaultMaxRetries, "", NameEC2+"."+MaxRetries)
+	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", NameEC2+"."+Tag)
+
+	r.Key(gofig.String, "", "", "", NameAWS+"."+AccessKey)
+	r.Key(gofig.String, "", "", "", NameAWS+"."+SecretKey)
+	r.Key(gofig.String, "", "", "", NameAWS+"."+Region)
+	r.Key(gofig.String, "", "", "", NameAWS+"."+Endpoint)
+	r.Key(gofig.Int, "", DefaultMaxRetries, "", NameAWS+"."+MaxRetries)
+	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", NameAWS+"."+Tag)
 	gofig.Register(r)
 }

--- a/drivers/storage/ebs/ebs_config_compat.go
+++ b/drivers/storage/ebs/ebs_config_compat.go
@@ -6,67 +6,107 @@ import (
 )
 
 const (
-	//ConfigEBS is a config key.
+	// ConfigEBS is a config key.
 	ConfigEBS = "ebs"
 
-	//ConfigEBSAccessKey is a config key.
+	// ConfigEBSAccessKey is a config key.
 	ConfigEBSAccessKey = ConfigEBS + "." + AccessKey
 
-	//ConfigEBSSecretKey is a config key.
+	// ConfigEBSSecretKey is a config key.
 	ConfigEBSSecretKey = ConfigEBS + "." + SecretKey
 
-	//ConfigEBSRegion is a config key.
+	// ConfigEBSRegion is a config key.
 	ConfigEBSRegion = ConfigEBS + "." + Region
 
-	//ConfigEBSEndpoint is a config key.
+	// ConfigEBSEndpoint is a config key.
 	ConfigEBSEndpoint = ConfigEBS + "." + Endpoint
 
-	//ConfigEBSMaxRetries is a config key.
+	// ConfigEBSMaxRetries is a config key.
 	ConfigEBSMaxRetries = ConfigEBS + "." + MaxRetries
 
-	//ConfigEBSTag is a config key.
+	// ConfigEBSTag is a config key.
 	ConfigEBSTag = ConfigEBS + "." + Tag
 
-	//ConfigEBSRexrayTag is a config key.
+	// ConfigEBSRexrayTag is a config key.
 	ConfigEBSRexrayTag = ConfigEBS + ".rexrayTag"
 
-	//ConfigOldEBS is a config key.
-	ConfigOldEBS = "ec2"
+	// ConfigEC2 is a config key.
+	ConfigEC2 = "ec2"
 
-	//ConfigOldEBSAccessKey is a config key.
-	ConfigOldEBSAccessKey = ConfigOldEBS + "." + AccessKey
+	// ConfigEC2AccessKey is a config key.
+	ConfigEC2AccessKey = ConfigEC2 + "." + AccessKey
 
-	//ConfigOldEBSSecretKey is a config key.
-	ConfigOldEBSSecretKey = ConfigOldEBS + "." + SecretKey
+	// ConfigEC2SecretKey is a config key.
+	ConfigEC2SecretKey = ConfigEC2 + "." + SecretKey
 
-	//ConfigOldEBSRegion is a config key.
-	ConfigOldEBSRegion = ConfigOldEBS + "." + Region
+	// ConfigEC2Region is a config key.
+	ConfigEC2Region = ConfigEC2 + "." + Region
 
-	//ConfigOldEBSEndpoint is a config key.
-	ConfigOldEBSEndpoint = ConfigOldEBS + "." + Endpoint
+	// ConfigEC2Endpoint is a config key.
+	ConfigEC2Endpoint = ConfigEC2 + "." + Endpoint
 
-	//ConfigOldEBSMaxRetries is a config key.
-	ConfigOldEBSMaxRetries = ConfigOldEBS + "." + MaxRetries
+	// ConfigEC2MaxRetries is a config key.
+	ConfigEC2MaxRetries = ConfigEC2 + "." + MaxRetries
 
-	//ConfigOldEBSTag is a config key.
-	ConfigOldEBSTag = ConfigOldEBS + "." + Tag
+	// ConfigEC2Tag is a config key.
+	ConfigEC2Tag = ConfigEC2 + "." + Tag
 
-	//ConfigOldEBSRexrayTag is a config key.
-	ConfigOldEBSRexrayTag = ConfigOldEBS + ".rexrayTag"
+	// ConfigEC2RexrayTag is a config key.
+	ConfigEC2RexrayTag = ConfigEC2 + ".rexrayTag"
+
+	// ConfigAWS is a config key.
+	ConfigAWS = "aws"
+
+	// ConfigAWSAccessKey is a config key.
+	ConfigAWSAccessKey = ConfigAWS + "." + AccessKey
+
+	// ConfigAWSSecretKey is a config key.
+	ConfigAWSSecretKey = ConfigAWS + "." + SecretKey
+
+	// ConfigAWSRegion is a config key.
+	ConfigAWSRegion = ConfigAWS + "." + Region
+
+	// ConfigAWSEndpoint is a config key.
+	ConfigAWSEndpoint = ConfigAWS + "." + Endpoint
+
+	// ConfigAWSMaxRetries is a config key.
+	ConfigAWSMaxRetries = ConfigAWS + "." + MaxRetries
+
+	// ConfigAWSTag is a config key.
+	ConfigAWSTag = ConfigAWS + "." + Tag
+
+	// ConfigAWSRexrayTag is a config key.
+	ConfigAWSRexrayTag = ConfigAWS + ".rexrayTag"
 )
 
 // BackCompat ensures keys can be used from old configurations.
 func BackCompat(config gofig.Config) {
-	checks := [][]string{
-		{ConfigEBSAccessKey, ConfigOldEBSAccessKey},
-		{ConfigEBSSecretKey, ConfigOldEBSSecretKey},
-		{ConfigEBSRegion, ConfigOldEBSRegion},
-		{ConfigEBSEndpoint, ConfigOldEBSEndpoint},
-		{ConfigEBSMaxRetries, ConfigOldEBSMaxRetries},
-		{ConfigEBSTag, ConfigOldEBSTag},
-		{ConfigEBSRexrayTag, ConfigOldEBSRexrayTag},
+	ec2Checks := [][]string{
+		{ConfigEBSAccessKey, ConfigEC2AccessKey},
+		{ConfigEBSSecretKey, ConfigEC2SecretKey},
+		{ConfigEBSRegion, ConfigEC2Region},
+		{ConfigEBSEndpoint, ConfigEC2Endpoint},
+		{ConfigEBSMaxRetries, ConfigEC2MaxRetries},
+		{ConfigEBSTag, ConfigEC2Tag},
+		{ConfigEBSRexrayTag, ConfigEC2RexrayTag},
 	}
-	for _, check := range checks {
+	for _, check := range ec2Checks {
+		if !config.IsSet(check[0]) && config.IsSet(check[1]) {
+			log.Debug(config.Get(check[1]))
+			config.Set(check[0], config.Get(check[1]))
+		}
+	}
+
+	awsChecks := [][]string{
+		{ConfigEBSAccessKey, ConfigAWSAccessKey},
+		{ConfigEBSSecretKey, ConfigAWSSecretKey},
+		{ConfigEBSRegion, ConfigAWSRegion},
+		{ConfigEBSEndpoint, ConfigAWSEndpoint},
+		{ConfigEBSMaxRetries, ConfigAWSMaxRetries},
+		{ConfigEBSTag, ConfigAWSTag},
+		{ConfigEBSRexrayTag, ConfigAWSRexrayTag},
+	}
+	for _, check := range awsChecks {
 		if !config.IsSet(check[0]) && config.IsSet(check[1]) {
 			log.Debug(config.Get(check[1]))
 			config.Set(check[0], config.Get(check[1]))

--- a/drivers/storage/ebs/executor/ebs_executor.go
+++ b/drivers/storage/ebs/executor/ebs_executor.go
@@ -27,15 +27,15 @@ type driver struct {
 func init() {
 	registry.RegisterStorageExecutor(ebs.Name, newDriver)
 	// backwards compatibility for ec2 executor
-	registry.RegisterStorageExecutor(ebs.OldName, newOldDriver)
+	registry.RegisterStorageExecutor(ebs.NameEC2, newEC2Driver)
 }
 
 func newDriver() types.StorageExecutor {
 	return &driver{name: ebs.Name}
 }
 
-func newOldDriver() types.StorageExecutor {
-	return &driver{name: ebs.OldName}
+func newEC2Driver() types.StorageExecutor {
+	return &driver{name: ebs.NameEC2}
 }
 
 func (d *driver) Init(ctx types.Context, config gofig.Config) error {

--- a/drivers/storage/ebs/storage/ebs_storage.go
+++ b/drivers/storage/ebs/storage/ebs_storage.go
@@ -47,15 +47,17 @@ type driver struct {
 func init() {
 	registry.RegisterStorageDriver(ebs.Name, newDriver)
 	// Backwards compatibility for ec2 driver
-	registry.RegisterStorageDriver(ebs.OldName, newOldDriver)
+	registry.RegisterStorageDriver(ebs.NameEC2, newEC2Driver)
+	// Backwards compatibility for ec2 driver
+	registry.RegisterStorageDriver(ebs.NameEC2, newEC2Driver)
 }
 
 func newDriver() types.StorageDriver {
 	return &driver{name: ebs.Name}
 }
 
-func newOldDriver() types.StorageDriver {
-	return &driver{name: ebs.OldName}
+func newEC2Driver() types.StorageDriver {
+	return &driver{name: ebs.NameEC2}
 }
 
 func (d *driver) Name() string {
@@ -1309,7 +1311,11 @@ func (d *driver) getAccessKey() string {
 		ebs.ConfigEBSAccessKey); accessKey != "" {
 		return accessKey
 	}
-	return d.config.GetString(ebs.ConfigOldEBSAccessKey)
+	if accessKey := d.config.GetString(
+		ebs.ConfigAWSAccessKey); accessKey != "" {
+		return accessKey
+	}
+	return d.config.GetString(ebs.ConfigEC2AccessKey)
 }
 
 func (d *driver) secretKey() string {
@@ -1317,35 +1323,51 @@ func (d *driver) secretKey() string {
 		ebs.ConfigEBSSecretKey); secretKey != "" {
 		return secretKey
 	}
-	return d.config.GetString(ebs.ConfigOldEBSSecretKey)
+	if secretKey := d.config.GetString(
+		ebs.ConfigAWSSecretKey); secretKey != "" {
+		return secretKey
+	}
+	return d.config.GetString(ebs.ConfigEC2SecretKey)
 }
 
 func (d *driver) getRegion() string {
 	if region := d.config.GetString(ebs.ConfigEBSRegion); region != "" {
 		return region
 	}
-	return d.config.GetString(ebs.ConfigOldEBSRegion)
+	if region := d.config.GetString(ebs.ConfigAWSRegion); region != "" {
+		return region
+	}
+	return d.config.GetString(ebs.ConfigEC2Region)
 }
 
 func (d *driver) getEndpoint() string {
 	if endpoint := d.config.GetString(ebs.ConfigEBSEndpoint); endpoint != "" {
 		return endpoint
 	}
-	return d.config.GetString(ebs.ConfigOldEBSEndpoint)
+	if endpoint := d.config.GetString(ebs.ConfigAWSEndpoint); endpoint != "" {
+		return endpoint
+	}
+	return d.config.GetString(ebs.ConfigEC2Endpoint)
 }
 
 func (d *driver) getMaxRetries() int {
 	if d.config.IsSet(ebs.ConfigEBSMaxRetries) {
 		return d.config.GetInt(ebs.ConfigEBSMaxRetries)
 	}
-	return d.config.GetInt(ebs.ConfigOldEBSMaxRetries)
+	if d.config.IsSet(ebs.ConfigAWSMaxRetries) {
+		return d.config.GetInt(ebs.ConfigAWSMaxRetries)
+	}
+	return d.config.GetInt(ebs.ConfigEC2MaxRetries)
 }
 
 func (d *driver) tag() string {
 	if tag := d.config.GetString(ebs.ConfigEBSTag); tag != "" {
 		return tag
 	}
-	return d.config.GetString(ebs.ConfigOldEBSTag)
+	if tag := d.config.GetString(ebs.ConfigAWSTag); tag != "" {
+		return tag
+	}
+	return d.config.GetString(ebs.ConfigEC2Tag)
 }
 
 // TODO rexrayTag


### PR DESCRIPTION
This patch reintroduces support for the "aws" config namespace that used to exist in pre-0.4 versions of REX-Ray. For example:

```yaml
aws:
  accessKey: 123
  secretKey: 456
```

The above is now valid once again. This PR handles REX-Ray issue [\#617](https://github.com/codedellemc/rexray/issues/617). Many thanks to @kbeckman for discovering the issue.