### PR TITLE
Volume Attachment States

### DIFF
--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -395,6 +395,9 @@ func (r *router) volumeCreate(
 			}
 		}
 
+		if v.AttachmentState == 0 {
+			v.AttachmentState = types.VolumeAvailable
+		}
 		return v, nil
 	}
 
@@ -439,6 +442,9 @@ func (r *router) volumeCopy(
 			}
 		}
 
+		if v.AttachmentState == 0 {
+			v.AttachmentState = types.VolumeAvailable
+		}
 		return v, nil
 	}
 
@@ -517,6 +523,10 @@ func (r *router) volumeAttach(
 			}
 		}
 
+		if v.AttachmentState == 0 {
+			v.AttachmentState = types.VolumeAttached
+		}
+
 		return &types.VolumeAttachResponse{
 			Volume:      v,
 			AttachToken: attTokn,
@@ -567,6 +577,10 @@ func (r *router) volumeDetach(
 			if !ok {
 				return nil, utils.NewNotFoundError(v.ID)
 			}
+		}
+
+		if v.AttachmentState == 0 {
+			v.AttachmentState = types.VolumeAvailable
 		}
 
 		return v, nil
@@ -655,6 +669,10 @@ func (r *router) volumeDetachAll(
 					}
 				}
 
+				if v.AttachmentState == 0 {
+					v.AttachmentState = types.VolumeAvailable
+				}
+
 				volumeMap[v.ID] = v
 			}
 
@@ -733,6 +751,10 @@ func (r *router) volumeDetachAllForService(
 				if !ok {
 					return nil, utils.NewNotFoundError(v.ID)
 				}
+			}
+
+			if v.AttachmentState == 0 {
+				v.AttachmentState = types.VolumeAvailable
 			}
 
 			reply[v.ID] = v

--- a/api/types/types_model.go
+++ b/api/types/types_model.go
@@ -124,10 +124,40 @@ type Snapshot struct {
 	Fields map[string]string `json:"fields,omitempty" yaml:",omitempty"`
 }
 
+// VolumeAttachmentStates is the volume's attachment state possibilities.
+type VolumeAttachmentStates int
+
+const (
+	// VolumeAttachmentStateUnknown indicates the driver has set the state,
+	// but it is explicitly unknown and should not be inferred from the list of
+	// attachments alone.
+	VolumeAttachmentStateUnknown VolumeAttachmentStates = 1
+
+	// VolumeAttached indicates the volume is attached to the instance
+	// specified in the API call that requested the volume information.
+	VolumeAttached VolumeAttachmentStates = 2
+
+	// VolumeAvailable indicates the volume is not attached to any instance.
+	VolumeAvailable VolumeAttachmentStates = 3
+
+	// VolumeUnavailable indicates the volume is attached to some instance
+	// other than the one specified in the API call that requested the
+	// volume information.
+	VolumeUnavailable VolumeAttachmentStates = 4
+)
+
 // Volume provides information about a storage volume.
 type Volume struct {
-	// The volume's attachments.
-	Attachments []*VolumeAttachment `json:"attachments,omitempty" yaml:",omitempty"`
+	// Attachments is information about the instances to which the volume
+	// is attached.
+	Attachments []*VolumeAttachment `json:"attachments,omitempty" yaml:"attachments,omitempty"`
+
+	// AttachmentState indicates whether or not a volume is attached. A client
+	// can surmise the same state stored in this field by inspecting a volume's
+	// Attachments field, but this field provides the server a means of doing
+	// that inspection and storing the result so the client does not have to do
+	// so.
+	AttachmentState VolumeAttachmentStates `json:"attachmentState,omitempty" yaml:"attachmentState,omitempty"`
 
 	// The availability zone for which the volume is available.
 	AvailabilityZone string `json:"availabilityZone,omitempty" yaml:"availabilityZone,omitempty"`
@@ -139,17 +169,17 @@ type Volume struct {
 	IOPS int64 `json:"iops,omitempty" yaml:"iops,omitempty"`
 
 	// The name of the volume.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name,omitempty"`
 
 	// NetworkName is the name the device is known by in order to discover
 	// locally.
 	NetworkName string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
 
 	// The size of the volume.
-	Size int64 `json:"size,omitempty" yaml:",omitempty"`
+	Size int64 `json:"size,omitempty" yaml:"size,omitempty"`
 
 	// The volume status.
-	Status string `json:"status,omitempty" yaml:",omitempty"`
+	Status string `json:"status,omitempty" yaml:"status,omitempty"`
 
 	// ID is a piece of information that uniquely identifies the volume on
 	// the storage platform to which the volume belongs. A volume ID is not
@@ -157,10 +187,10 @@ type Volume struct {
 	ID string `json:"id" yaml:"id"`
 
 	// The volume type.
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 
 	// Fields are additional properties that can be defined for this type.
-	Fields map[string]string `json:"fields,omitempty" yaml:",omitempty"`
+	Fields map[string]string `json:"fields,omitempty" yaml:"fields,omitempty"`
 }
 
 // VolumeName returns the volume's name.

--- a/api/utils/schema/schema_generated.go
+++ b/api/utils/schema/schema_generated.go
@@ -31,6 +31,12 @@ const (
                     "description": "The volume's attachments.",
                     "items": { "$ref": "#/definitions/volumeAttachment" }
                 },
+                "attachmentState": {
+                    "type": "number",
+                    "description": "Indicates the volume's attachment state - 0=none,1=unknown,2=attached,3=available,4=unavailable. A volume is marked as attached if attached to the instance specified in the requesting API call. A volume that is attached but not to the requesting instance is marked as unavailable.",
+                    "minimum": 0,
+                    "maximum": 4
+                },
                 "availabilityZone": {
                     "type": "string",
                     "description": "The zone for which the volume is available."

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -1006,6 +1006,7 @@ const volJSON = `{
         },
         "status":       "attached"
     }],
+	"attachmentState":  2,
     "fields": {
         "owner":        "root@example.com",
         "priority":     "2"
@@ -1019,6 +1020,7 @@ const volNoAttachJSON = `{
     "size":             10240,
     "id":               "vfs-%03[1]d",
     "type":             "myType",
+	"attachmentState":  3,
     "fields": {
         "owner":        "root@example.com",
         "priority":     "2"

--- a/libstorage.json
+++ b/libstorage.json
@@ -27,6 +27,12 @@
                     "description": "The volume's attachments.",
                     "items": { "$ref": "#/definitions/volumeAttachment" }
                 },
+                "attachmentState": {
+                    "type": "number",
+                    "description": "Indicates the volume's attachment state - 0=none,1=unknown,2=attached,3=available,4=unavailable. A volume is marked as attached if attached to the instance specified in the requesting API call. A volume that is attached but not to the requesting instance is marked as unavailable.",
+                    "minimum": 0,
+                    "maximum": 4
+                },
                 "availabilityZone": {
                     "type": "string",
                     "description": "The zone for which the volume is available."


### PR DESCRIPTION
This patch adds the AttachmentState field to the Volume object model to more summarily reflect a volume's attachment state.