### PR TITLE
Update Travis Builds to Go 1.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go_import_path: github.com/codedellemc/libstorage
 language: go
 go:
   - 1.6.3
-  - 1.7.1
+  - 1.7.3
   - tip
 
 os:


### PR DESCRIPTION
This patch updates the Travis builds to use Go 1.7.3.