### PR TITLE
Opt In Integration Driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ before_install:
 
 script:
   - make gometalinter-all
-  - BUILD_TAGS="gofig pflag" make -j build
-  - BUILD_TAGS="gofig pflag" make -j test
+  - make -j build
+  - make -j test
   - VFS_INSTANCEID_USE_FIELDS=true ./drivers/storage/vfs/tests/vfs.test
   - go clean -i ./client && go build ./client
 

--- a/api/registry/registry_integration.go
+++ b/api/registry/registry_integration.go
@@ -60,7 +60,7 @@ func (d *idm) initPathCache(ctx types.Context) {
 		return
 	}
 
-	if _, ok := context.ServiceName(ctx); !ok {
+	if name, ok := context.ServiceName(ctx); !ok || name == "" {
 		ctx.Info("path cache initializion disabled; no service name in ctx")
 		return
 	}

--- a/imports/config/imports_config.go
+++ b/imports/config/imports_config.go
@@ -1,1 +1,0 @@
-package config

--- a/imports/config/imports_config_00.go
+++ b/imports/config/imports_config_00.go
@@ -1,0 +1,5 @@
+package config
+
+var (
+	defaultIntDriver = ""
+)

--- a/imports/config/imports_config_11_int_docker.go
+++ b/imports/config/imports_config_11_int_docker.go
@@ -1,0 +1,7 @@
+// +build libstorage_integration_driver_docker
+
+package config
+
+func init() {
+	defaultIntDriver = "docker"
+}

--- a/imports/config/imports_config_99_gofig.go
+++ b/imports/config/imports_config_99_gofig.go
@@ -48,16 +48,14 @@ func init() {
 	}
 
 	defaultAEM := types.UnixEndpoint.String()
-	defaultOSDriver := runtime.GOOS
 	defaultStorageDriver := types.LibStorageDriverName
-	defaultIntDriver := "docker"
 	defaultLogLevel := logLevel.String()
 	defaultClientType := types.IntegrationClient.String()
 
 	rk(gofig.String, "", "", types.ConfigHost)
 	rk(gofig.String, "", "", types.ConfigService)
 	rk(gofig.String, defaultAEM, "", types.ConfigServerAutoEndpointMode)
-	rk(gofig.String, defaultOSDriver, "", types.ConfigOSDriver)
+	rk(gofig.String, runtime.GOOS, "", types.ConfigOSDriver)
 	rk(gofig.String, defaultStorageDriver, "", types.ConfigStorageDriver)
 	rk(gofig.String, defaultIntDriver, "", types.ConfigIntegrationDriver)
 	rk(gofig.String, defaultClientType, "", types.ConfigClientType)

--- a/imports/local/imports_local.go
+++ b/imports/local/imports_local.go
@@ -6,11 +6,4 @@ import (
 
 	// load the libStorage storage driver
 	_ "github.com/codedellemc/libstorage/drivers/storage/libstorage"
-
-	// load the os drivers
-	_ "github.com/codedellemc/libstorage/drivers/os/darwin"
-	_ "github.com/codedellemc/libstorage/drivers/os/linux"
-
-	// load the integration drivers
-	_ "github.com/codedellemc/libstorage/drivers/integration/docker"
 )

--- a/imports/local/imports_local_gofig.go
+++ b/imports/local/imports_local_gofig.go
@@ -3,6 +3,6 @@
 package local
 
 import (
-	// load the client drivers
+	// load the packages
 	_ "github.com/codedellemc/libstorage/drivers/storage/vfs/client"
 )

--- a/imports/local/imports_local_int_docker.go
+++ b/imports/local/imports_local_int_docker.go
@@ -1,0 +1,8 @@
+// +build libstorage_integration_driver_docker
+
+package local
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/integration/docker"
+)

--- a/imports/local/imports_local_os_darwin.go
+++ b/imports/local/imports_local_os_darwin.go
@@ -1,0 +1,6 @@
+package local
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/os/darwin"
+)

--- a/imports/local/imports_local_os_linux.go
+++ b/imports/local/imports_local_os_linux.go
@@ -1,0 +1,6 @@
+package local
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/os/linux"
+)


### PR DESCRIPTION
This patch makes it so that the integration driver is opt-in via a build tag. Currently the in-tree tags available to introduce an integration driver at build time are:

* `libstorage_integration_driver_docker`

The tag `libstorage_integration_driver_docker` will build libStorage with the Docker integration driver. Omitting this tag means libStorage is not built with any integration driver and one must be supplied by the embedding project.

Additionally, the OS driver for the OS that matches the `GOOS` variable is the only one loaded by default when building libStorage. It is still possible to load other OS drivers by importing them manually.