### PR TITLE
Volume Attachment Filtering Logic

### DIFF
--- a/api/server/handlers/handlers_query_params.go
+++ b/api/server/handlers/handlers_query_params.go
@@ -49,7 +49,9 @@ func (h *queryParamsHandler) Handle(
 			if len(v[0]) == 0 {
 				store.Set(k, true)
 			} else {
-				if b, err := strconv.ParseBool(v[0]); err == nil {
+				if i, err := strconv.ParseInt(v[0], 10, 64); err == nil {
+					store.Set(k, i)
+				} else if b, err := strconv.ParseBool(v[0]); err == nil {
 					store.Set(k, b)
 				} else {
 					store.Set(k, v[0])

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/akutz/goof"
 
 	"github.com/codedellemc/libstorage/api/context"
@@ -127,6 +128,66 @@ func (r *router) volumesForService(
 		http.StatusOK)
 }
 
+func handleVolAttachments(
+	ctx types.Context,
+	lf log.Fields,
+	iid *types.InstanceID,
+	vol *types.Volume,
+	attachments types.VolumeAttachmentsTypes) bool {
+
+	if attachments == 0 {
+		vol.Attachments = nil
+		return true
+	}
+
+	if lf == nil {
+		lf = log.Fields{}
+	}
+
+	// if only the requesting instance's attachments are requested then
+	// filter the volume's attachments list
+	if attachments.Mine() {
+		atts := []*types.VolumeAttachment{}
+		for _, a := range vol.Attachments {
+			alf := log.Fields{
+				"attDeviceName": a.DeviceName,
+				"attDountPoint": a.MountPoint,
+				"attVolumeID":   a.VolumeID,
+			}
+			if strings.EqualFold(iid.ID, a.InstanceID.ID) {
+				atts = append(atts, a)
+				ctx.WithFields(lf).WithFields(alf).Debug(
+					"including volume attachment")
+			} else {
+				ctx.WithFields(lf).WithFields(alf).Debug(
+					"omitting volume attachment")
+			}
+		}
+		vol.Attachments = atts
+		ctx.WithFields(lf).Debug("included volume attached to instance")
+	}
+
+	// if the volume has no attachments and the mask indicates that
+	// only attached volumes should be returned then omit this volume
+	if len(vol.Attachments) == 0 &&
+		attachments.Attached() &&
+		!attachments.Unattached() {
+		ctx.WithFields(lf).Debug("omitting unattached volume")
+		return false
+	}
+
+	// if the volume has attachments and the mask indicates that
+	// only unattached volumes should be returned then omit this volume
+	if len(vol.Attachments) > 0 &&
+		!attachments.Attached() &&
+		attachments.Unattached() {
+		ctx.WithFields(lf).Debug("omitting attached volume")
+		return false
+	}
+
+	return true
+}
+
 func getFilteredVolumes(
 	ctx types.Context,
 	req *http.Request,
@@ -147,6 +208,8 @@ func getFilteredVolumes(
 		return nil, utils.NewMissingInstanceIDError(storSvc.Name())
 	}
 
+	ctx.WithField("attachments", opts.Attachments).Debug("querying volumes")
+
 	objs, err := storSvc.Driver().Volumes(ctx, opts)
 	if err != nil {
 		return nil, err
@@ -160,34 +223,26 @@ func getFilteredVolumes(
 
 	for _, obj := range objs {
 
+		lf := log.Fields{
+			"attachments": opts.Attachments,
+			"volumeID":    obj.ID,
+			"volumeName":  obj.Name,
+		}
+
 		if filterOp == types.FilterEqualityMatch && filterLeft == "name" {
+			ctx.WithFields(lf).Debug("checking name filter")
 			if !strings.EqualFold(obj.Name, filterRight) {
+				ctx.WithFields(lf).Debug("omitted volume due to name filter")
 				continue
 			}
 		}
 
-		// if only the requesting instance's attachments are requested then
-		// filter the volume's attachments list
-		if opts.Attachments.Mine() {
-			atts := []*types.VolumeAttachment{}
-			for _, a := range obj.Attachments {
-				if strings.EqualFold(iid.ID, a.InstanceID.ID) {
-					atts = append(atts, a)
-				}
-			}
-			obj.Attachments = atts
-		}
-
-		if opts.Attachments.Attached() && len(obj.Attachments) == 0 {
-			continue
-		}
-
-		if opts.Attachments.Unattached() && len(obj.Attachments) > 0 {
+		if !handleVolAttachments(ctx, lf, iid, obj, opts.Attachments) {
 			continue
 		}
 
 		if OnVolume != nil {
-			ctx.Debug("invoking OnVolume handler")
+			ctx.WithFields(lf).Debug("invoking OnVolume handler")
 			ok, err := OnVolume(ctx, req, store, obj)
 			if err != nil {
 				return nil, err
@@ -212,8 +267,8 @@ func (r *router) volumeInspect(
 	attachments := store.GetAttachments()
 
 	service := context.MustService(ctx)
-	if _, ok := context.InstanceID(ctx); !ok &&
-		attachments.RequiresInstanceID() {
+	iid, iidOK := context.InstanceID(ctx)
+	if !iidOK && attachments.RequiresInstanceID() {
 		return utils.NewMissingInstanceIDError(service.Name())
 	}
 
@@ -239,10 +294,12 @@ func (r *router) volumeInspect(
 				return nil, err
 			}
 
-			volID := strings.ToLower(store.GetString("volumeID"))
+			volID := store.GetString("volumeID")
 			for _, v := range vols {
-				if strings.ToLower(v.Name) == volID {
-
+				if strings.EqualFold(v.Name, volID) {
+					if !handleVolAttachments(ctx, nil, iid, v, attachments) {
+						return nil, utils.NewNotFoundError(volID)
+					}
 					if OnVolume != nil {
 						ok, err := OnVolume(ctx, req, store, v)
 						if err != nil {
@@ -271,6 +328,10 @@ func (r *router) volumeInspect(
 
 			if err != nil {
 				return nil, err
+			}
+
+			if !handleVolAttachments(ctx, nil, iid, v, attachments) {
+				return nil, utils.NewNotFoundError(v.ID)
 			}
 
 			if OnVolume != nil {

--- a/drivers/integration/docker/docker.go
+++ b/drivers/integration/docker/docker.go
@@ -168,7 +168,7 @@ func (d *driver) Mount(
 		"opts":       opts}).Info("mounting volume")
 
 	vol, err := d.volumeInspectByIDOrName(
-		ctx, volumeID, volumeName, types.VolumeAttachmentsTrue, opts.Opts)
+		ctx, volumeID, volumeName, types.VolAttReqTrue, opts.Opts)
 	if isErrNotFound(err) && d.volumeCreateImplicit() {
 		var err error
 		if vol, err = d.Create(ctx, volumeName, &types.VolumeCreateOpts{
@@ -223,7 +223,7 @@ func (d *driver) Mount(
 		}
 
 		vol, err = d.volumeInspectByIDOrName(
-			ctx, vol.ID, "", types.VolumeAttachmentsTrue, opts.Opts)
+			ctx, vol.ID, "", types.VolAttReqTrue, opts.Opts)
 		if err != nil {
 			return "", nil, err
 		}
@@ -322,7 +322,7 @@ func (d *driver) Unmount(
 	}
 
 	vol, err := d.volumeInspectByIDOrName(
-		ctx, volumeID, volumeName, types.VolumeAttachmentsTrue, opts)
+		ctx, volumeID, volumeName, types.VolAttReqTrue, opts)
 	if err != nil {
 		return err
 	}
@@ -400,7 +400,7 @@ func (d *driver) Path(
 		"opts":       opts}).Info("getting path to volume")
 
 	vol, err := d.volumeInspectByIDOrName(
-		ctx, volumeID, volumeName, types.VolumeAttachmentsTrue, opts)
+		ctx, volumeID, volumeName, types.VolAttReqTrue, opts)
 	if err != nil {
 		return "", err
 	} else if vol == nil {

--- a/drivers/integration/docker/docker_utils.go
+++ b/drivers/integration/docker/docker_utils.go
@@ -50,7 +50,7 @@ func (d *driver) volumeInspectByIDOrName(
 	if volumeID != "" {
 		var err error
 		obj, err = d.volumeInspectByID(
-			ctx, volumeID, types.VolumeAttachmentsTrue, opts)
+			ctx, volumeID, types.VolAttReqTrue, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -64,7 +64,7 @@ func (d *driver) volumeInspectByIDOrName(
 			if strings.EqualFold(volumeName, o.Name) {
 				if attachments.Requested() {
 					obj, err = d.volumeInspectByID(
-						ctx, o.ID, types.VolumeAttachmentsTrue, opts)
+						ctx, o.ID, types.VolAttReqTrue, opts)
 					if err != nil {
 						return nil, err
 					}

--- a/drivers/storage/ebs/storage/ebs_storage.go
+++ b/drivers/storage/ebs/storage/ebs_storage.go
@@ -331,7 +331,7 @@ func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
 	}
 	// Return the volume created
 	return d.VolumeInspect(ctx, *vol.VolumeId, &types.VolumeInspectOpts{
-		Attachments: types.VolumeAttachmentsTrue,
+		Attachments: types.VolAttReqTrue,
 	})
 }
 
@@ -582,7 +582,7 @@ func (d *driver) VolumeAttach(
 		return nil, "", goof.WithError("error getting volume", err)
 	}
 	volumes, convErr := d.toTypesVolume(
-		ctx, ec2vols, types.VolumeAttachmentsTrue)
+		ctx, ec2vols, types.VolAttReqTrue)
 	if convErr != nil {
 		return nil, "", goof.WithError(
 			"error converting to types.Volume", convErr)
@@ -634,7 +634,7 @@ func (d *driver) VolumeAttach(
 	// Check if successful attach
 	attachedVol, err := d.VolumeInspect(
 		ctx, volumeID, &types.VolumeInspectOpts{
-			Attachments: types.VolumeAttachmentsTrue,
+			Attachments: types.VolAttReqTrue,
 			Opts:        opts.Opts,
 		})
 	if err != nil {
@@ -659,7 +659,7 @@ func (d *driver) VolumeDetach(
 		return nil, goof.WithError("error getting volume", err)
 	}
 	volumes, convErr := d.toTypesVolume(
-		ctx, ec2vols, types.VolumeAttachmentsTrue)
+		ctx, ec2vols, types.VolAttReqTrue)
 	if convErr != nil {
 		return nil, goof.WithError("error converting to types.Volume", convErr)
 	}
@@ -696,7 +696,7 @@ func (d *driver) VolumeDetach(
 	// check if successful detach
 	detachedVol, err := d.VolumeInspect(
 		ctx, volumeID, &types.VolumeInspectOpts{
-			Attachments: types.VolumeAttachmentsTrue,
+			Attachments: types.VolAttReqTrue,
 			Opts:        opts.Opts,
 		})
 	if err != nil {

--- a/drivers/storage/ebs/tests/ebs_test.go
+++ b/drivers/storage/ebs/tests/ebs_test.go
@@ -464,7 +464,7 @@ func volumeInspectAttached(
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
 		nil, ebs.Name, volumeID,
-		types.VolumeAttachmentsTrue)
+		types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {
@@ -482,7 +482,7 @@ func volumeInspectDetached(
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
 		nil, ebs.Name, volumeID,
-		types.VolumeAttachmentsTrue)
+		types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {

--- a/drivers/storage/efs/storage/efs_storage.go
+++ b/drivers/storage/efs/storage/efs_storage.go
@@ -389,7 +389,7 @@ func (d *driver) VolumeAttach(
 	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
 
 	vol, err := d.VolumeInspect(ctx, volumeID,
-		&types.VolumeInspectOpts{Attachments: types.VolumeAttachmentsTrue})
+		&types.VolumeInspectOpts{Attachments: types.VolAttReqTrue})
 	if err != nil {
 		return nil, "", err
 	}

--- a/drivers/storage/efs/tests/efs_test.go
+++ b/drivers/storage/efs/tests/efs_test.go
@@ -246,7 +246,7 @@ func volumeInspectAttached(
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
 		nil, efs.Name, volumeID,
-		types.VolumeAttachmentsTrue)
+		types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {
@@ -265,7 +265,7 @@ func volumeInspectDetached(
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
 		nil, efs.Name, volumeID,
-		types.VolumeAttachmentsTrue)
+		types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {

--- a/drivers/storage/isilon/storage/isilon_storage.go
+++ b/drivers/storage/isilon/storage/isilon_storage.go
@@ -240,7 +240,7 @@ func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
 	opts *types.VolumeCreateOpts) (*types.Volume, error) {
 
 	vol, err := d.VolumeInspect(ctx, volumeName,
-		&types.VolumeInspectOpts{Attachments: types.VolumeAttachmentsTrue})
+		&types.VolumeInspectOpts{Attachments: types.VolAttReqTrue})
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +329,7 @@ func (d *driver) VolumeAttach(
 
 	// ensure the volume exists and is exported
 	vol, err := d.VolumeInspect(ctx, volumeID,
-		&types.VolumeInspectOpts{Attachments: types.VolumeAttachmentsTrue})
+		&types.VolumeInspectOpts{Attachments: types.VolAttReqTrue})
 	if err != nil {
 		return nil, "", err
 	}
@@ -390,7 +390,7 @@ func (d *driver) VolumeAttach(
 	}
 
 	vol, err = d.VolumeInspect(ctx, volumeID,
-		&types.VolumeInspectOpts{Attachments: types.VolumeAttachmentsTrue})
+		&types.VolumeInspectOpts{Attachments: types.VolAttReqTrue})
 	if err != nil {
 		return nil, "", err
 	}
@@ -452,7 +452,7 @@ func (d *driver) VolumeDetach(
 	}
 
 	return d.VolumeInspect(ctx, volumeID, &types.VolumeInspectOpts{
-		Attachments: types.VolumeAttachmentsTrue,
+		Attachments: types.VolAttReqTrue,
 	})
 }
 

--- a/drivers/storage/isilon/tests/isilon_test.go
+++ b/drivers/storage/isilon/tests/isilon_test.go
@@ -230,7 +230,7 @@ func volumeInspectAttached(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, isilon.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, isilon.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {
@@ -248,7 +248,7 @@ func volumeInspectAttachedFail(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, isilon.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, isilon.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {
@@ -265,7 +265,7 @@ func volumeInspectDetached(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, isilon.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, isilon.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {

--- a/drivers/storage/rackspace/storage/rackspace_storage.go
+++ b/drivers/storage/rackspace/storage/rackspace_storage.go
@@ -138,7 +138,7 @@ func (d *driver) Volumes(
 	ctx types.Context,
 	opts *types.VolumesOpts) ([]*types.Volume, error) {
 	// always return attachments to align against other drivers for now
-	return d.getVolume(ctx, "", "", types.VolumeAttachmentsTrue)
+	return d.getVolume(ctx, "", "", types.VolAttReqTrue)
 }
 
 // 	// VolumeInspect inspects a single volume.
@@ -311,7 +311,7 @@ func (d *driver) VolumeDetach(
 	if volumeID == "" {
 		return nil, goof.WithFields(fields, "volumeId is required for VolumeDetach")
 	}
-	vols, err := d.getVolume(ctx, volumeID, "", types.VolumeAttachmentsTrue)
+	vols, err := d.getVolume(ctx, volumeID, "", types.VolAttReqTrue)
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +586,7 @@ func (d *driver) createVolume(
 				"error waiting for volume creation to complete", err)
 	}
 	log.WithFields(fields).Debug("created volume")
-	return translateVolume(resp, types.VolumeAttachmentsTrue), nil
+	return translateVolume(resp, types.VolAttReqTrue), nil
 }
 
 //Reformats from volumes.Volume to types.Volume credit to github.com/MatMaul
@@ -660,7 +660,7 @@ func (d *driver) volumeAttached(ctx types.Context,
 	}
 	volume, err := d.VolumeInspect(
 		ctx, volumeID, &types.VolumeInspectOpts{
-			Attachments: types.VolumeAttachmentsTrue})
+			Attachments: types.VolAttReqTrue})
 	if err != nil {
 		return true, goof.WithFieldsE(fields, "error getting volume when waiting", err)
 	}
@@ -711,7 +711,7 @@ func (d *driver) waitVolumeAttachStatus(
 	for {
 		volume, err := d.VolumeInspect(
 			ctx, volumeID,
-			&types.VolumeInspectOpts{Attachments: types.VolumeAttachmentsTrue})
+			&types.VolumeInspectOpts{Attachments: types.VolAttReqTrue})
 		if err != nil {
 			return nil, goof.WithFieldsE(fields, "error getting volume when waiting", err)
 		}

--- a/drivers/storage/rackspace/tests/rackspace_test.go
+++ b/drivers/storage/rackspace/tests/rackspace_test.go
@@ -242,7 +242,7 @@ func volumeInspectAttached(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, rackspace.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, rackspace.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {
@@ -259,7 +259,7 @@ func volumeInspectAttachedFail(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, rackspace.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, rackspace.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {
@@ -276,7 +276,7 @@ func volumeInspectDetached(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, rackspace.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, rackspace.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {

--- a/drivers/storage/scaleio/storage/scaleio_storage.go
+++ b/drivers/storage/scaleio/storage/scaleio_storage.go
@@ -374,7 +374,7 @@ func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
 	}
 
 	return d.VolumeInspect(ctx, vol.ID, &types.VolumeInspectOpts{
-		Attachments: types.VolumeAttachmentsTrue,
+		Attachments: types.VolAttReqTrue,
 	})
 }
 
@@ -406,7 +406,7 @@ func (d *driver) VolumeCreateFromSnapshot(
 	}
 
 	volumeInspectOpts := &types.VolumeInspectOpts{
-		Attachments: types.VolumeAttachmentsTrue,
+		Attachments: types.VolAttReqTrue,
 		Opts:        opts.Opts,
 	}
 
@@ -478,7 +478,7 @@ func (d *driver) VolumeAttach(
 
 	vol, err := d.VolumeInspect(
 		ctx, volumeID, &types.VolumeInspectOpts{
-			Attachments: types.VolumeAttachmentsTrue,
+			Attachments: types.VolAttReqTrue,
 		})
 	if err != nil {
 		return nil, "", goof.WithError("error getting volume", err)
@@ -505,7 +505,7 @@ func (d *driver) VolumeAttach(
 
 	attachedVol, err := d.VolumeInspect(
 		ctx, volumeID, &types.VolumeInspectOpts{
-			Attachments: types.VolumeAttachmentsTrue,
+			Attachments: types.VolAttReqTrue,
 			Opts:        opts.Opts,
 		})
 	if err != nil {
@@ -551,7 +551,7 @@ func (d *driver) VolumeDetach(
 	}
 
 	vol, err := d.VolumeInspect(ctx, volumeID, &types.VolumeInspectOpts{
-		Attachments: types.VolumeAttachmentsTrue,
+		Attachments: types.VolAttReqTrue,
 	})
 	if err != nil {
 		return nil, err

--- a/drivers/storage/scaleio/tests/scaleio_test.go
+++ b/drivers/storage/scaleio/tests/scaleio_test.go
@@ -222,7 +222,7 @@ func volumeInspectAttached(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, sio.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, sio.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {
@@ -239,7 +239,7 @@ func volumeInspectAttachedFail(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, sio.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, sio.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {
@@ -256,7 +256,7 @@ func volumeInspectDetached(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, sio.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, sio.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {

--- a/drivers/storage/vbox/storage/vbox_storage.go
+++ b/drivers/storage/vbox/storage/vbox_storage.go
@@ -356,7 +356,7 @@ func (d *driver) VolumeAttach(
 		)
 	}
 
-	volumes, err = d.getVolume(ctx, volumeID, "", types.VolumeAttachmentsTrue)
+	volumes, err = d.getVolume(ctx, volumeID, "", types.VolAttReqTrue)
 	if err != nil {
 		return nil, "", err
 	}
@@ -403,7 +403,7 @@ func (d *driver) VolumeDetach(
 	ctx.Info("detached volume", volumeID)
 	return d.VolumeInspect(
 		ctx, volumeID, &types.VolumeInspectOpts{
-			Attachments: types.VolumeAttachmentsTrue})
+			Attachments: types.VolAttReqTrue})
 }
 
 func (d *driver) VolumeDetachAll(

--- a/drivers/storage/vbox/tests/vbox_test.go
+++ b/drivers/storage/vbox/tests/vbox_test.go
@@ -221,7 +221,7 @@ func volumeInspectAttached(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, vbox.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, vbox.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {
@@ -238,7 +238,7 @@ func volumeInspectAttachedFail(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, vbox.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, vbox.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {
@@ -255,7 +255,7 @@ func volumeInspectDetached(
 
 	log.WithField("volumeID", volumeID).Info("inspecting volume")
 	reply, err := client.API().VolumeInspect(
-		nil, vbox.Name, volumeID, types.VolumeAttachmentsTrue)
+		nil, vbox.Name, volumeID, types.VolAttReqTrue)
 	assert.NoError(t, err)
 
 	if err != nil {

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -122,7 +122,7 @@ func TestStorageDriverVolumes(t *testing.T) {
 				context.Background().WithValue(
 					context.ServiceKey, vfs.Name),
 				&types.VolumesOpts{
-					Attachments: types.VolumeAttachmentsTrue,
+					Attachments: types.VolAttReqTrue,
 					Opts:        utils.NewStore()})
 			assert.NoError(t, err)
 			assert.Len(t, vols, 2)
@@ -132,11 +132,12 @@ func TestStorageDriverVolumes(t *testing.T) {
 func TestVolumes(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
 	tf := func(config gofig.Config, client types.Client, t *testing.T) {
-		reply, err := client.API().Volumes(nil, 0)
+		reply, err := client.API().Volumes(nil, types.VolAttNone)
 		if err != nil {
 			t.Fatal(err)
 		}
 		for volumeID, volume := range vols {
+			volume.Attachments = nil
 			assert.NotNil(t, reply["vfs"][volumeID])
 			assert.EqualValues(t, volume, reply["vfs"][volumeID])
 		}
@@ -145,10 +146,10 @@ func TestVolumes(t *testing.T) {
 	apitests.RunWithClientType(t, types.ControllerClient, vfs.Name, tc, tf)
 }
 
-func TestVolumesWithAttachments(t *testing.T) {
+func TestVolumesWithAttachmentsTrue(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
 	tf := func(config gofig.Config, client types.Client, t *testing.T) {
-		reply, err := client.API().Volumes(nil, types.VolumeAttachmentsTrue)
+		reply, err := client.API().Volumes(nil, types.VolAttReqTrue)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -162,11 +163,149 @@ func TestVolumesWithAttachments(t *testing.T) {
 	apitests.Run(t, vfs.Name, tc, tf)
 }
 
+func TestVolumesWithAttachmentsRequested(t *testing.T) {
+	tc, _, vols, _ := newTestConfigAll(t)
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		reply, err := client.API().Volumes(nil, types.VolAttReq)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.NotNil(t, reply["vfs"]["vfs-000"])
+		assert.NotNil(t, reply["vfs"]["vfs-001"])
+		assert.NotNil(t, reply["vfs"]["vfs-002"])
+		assert.EqualValues(t, vols["vfs-000"], reply["vfs"]["vfs-000"])
+		assert.EqualValues(t, vols["vfs-001"], reply["vfs"]["vfs-001"])
+		assert.Len(t, reply["vfs"]["vfs-002"].Attachments, 0)
+	}
+	apitests.Run(t, vfs.Name, tc, tf)
+}
+
+func TestVolumesWithAttachmentsNone(t *testing.T) {
+	tc, _, _, _ := newTestConfigAll(t)
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		reply, err := client.API().Volumes(nil, types.VolAttNone)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.NotNil(t, reply["vfs"]["vfs-000"])
+		assert.NotNil(t, reply["vfs"]["vfs-001"])
+		assert.NotNil(t, reply["vfs"]["vfs-002"])
+		assert.Len(t, reply["vfs"]["vfs-000"].Attachments, 0)
+		assert.Len(t, reply["vfs"]["vfs-001"].Attachments, 0)
+		assert.Len(t, reply["vfs"]["vfs-002"].Attachments, 0)
+	}
+	apitests.Run(t, vfs.Name, tc, tf)
+}
+
+func TestVolumesWithAttachmentsAttached(t *testing.T) {
+	tc, _, vols, _ := newTestConfigAll(t)
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		reply, err := client.API().Volumes(nil, types.VolAttReqOnlyAttachedVols)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.NotNil(t, reply["vfs"]["vfs-000"])
+		assert.NotNil(t, reply["vfs"]["vfs-001"])
+		assert.Nil(t, reply["vfs"]["vfs-002"])
+		assert.EqualValues(t, vols["vfs-000"], reply["vfs"]["vfs-000"])
+		assert.EqualValues(t, vols["vfs-001"], reply["vfs"]["vfs-001"])
+	}
+	apitests.Run(t, vfs.Name, tc, tf)
+}
+
+func TestVolumesWithAttachmentsUnattached(t *testing.T) {
+	tc, _, _, _ := newTestConfigAll(t)
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		reply, err := client.API().Volumes(nil,
+			types.VolAttReqOnlyUnattachedVols)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Nil(t, reply["vfs"]["vfs-000"])
+		assert.Nil(t, reply["vfs"]["vfs-001"])
+		assert.NotNil(t, reply["vfs"]["vfs-002"])
+		assert.Len(t, reply["vfs"]["vfs-002"].Attachments, 0)
+	}
+	apitests.Run(t, vfs.Name, tc, tf)
+}
+
+func TestVolumesWithAttachmentsAttachedAndUnattached(t *testing.T) {
+	tc, _, vols, _ := newTestConfigAll(t)
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		reply, err := client.API().Volumes(nil,
+			types.VolAttReqOnlyAttachedVols|types.VolAttReqOnlyUnattachedVols)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.NotNil(t, reply["vfs"]["vfs-000"])
+		assert.NotNil(t, reply["vfs"]["vfs-001"])
+		assert.NotNil(t, reply["vfs"]["vfs-002"])
+		assert.EqualValues(t, vols["vfs-000"], reply["vfs"]["vfs-000"])
+		assert.EqualValues(t, vols["vfs-001"], reply["vfs"]["vfs-001"])
+	}
+	apitests.Run(t, vfs.Name, tc, tf)
+}
+
+func TestVolumesWithAttachmentsMineWithNotMyInstanceID(
+	t *testing.T) {
+	tc, _, _, _ := newTestConfigAll(t)
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+
+		ctx := context.Background()
+		iidm := types.InstanceIDMap{
+			"vfs": &types.InstanceID{ID: "none", Driver: "vfs"},
+		}
+		ctx = ctx.WithValue(context.AllInstanceIDsKey, iidm)
+
+		reply, err := client.API().Volumes(ctx, types.VolAttReqForInstance)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.NotNil(t, reply["vfs"]["vfs-000"])
+		assert.NotNil(t, reply["vfs"]["vfs-001"])
+		assert.NotNil(t, reply["vfs"]["vfs-002"])
+		assert.Len(t, reply["vfs"]["vfs-000"].Attachments, 0)
+		assert.Len(t, reply["vfs"]["vfs-001"].Attachments, 0)
+		assert.Len(t, reply["vfs"]["vfs-002"].Attachments, 0)
+	}
+	apitests.RunWithClientType(t, types.ControllerClient, vfs.Name, tc, tf)
+}
+
+func TestVolumesWithAttachmentsAttachedAndMineWithNotMyInstanceID(
+	t *testing.T) {
+	tc, _, _, _ := newTestConfigAll(t)
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+
+		ctx := context.Background()
+		iidm := types.InstanceIDMap{
+			"vfs": &types.InstanceID{ID: "none", Driver: "vfs"},
+		}
+		ctx = ctx.WithValue(context.AllInstanceIDsKey, iidm)
+
+		reply, err := client.API().Volumes(ctx,
+			types.VolAttReqOnlyVolsAttachedToInstance)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Nil(t, reply["vfs"]["vfs-000"])
+		assert.Nil(t, reply["vfs"]["vfs-001"])
+		assert.Nil(t, reply["vfs"]["vfs-002"])
+	}
+	apitests.RunWithClientType(t, types.ControllerClient, vfs.Name, tc, tf)
+}
+
 func TestVolumesWithAttachmentsWithControllerClient(t *testing.T) {
 	tc, _, _, _ := newTestConfigAll(t)
 	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 
-		_, err := client.API().Volumes(nil, types.VolumeAttachmentsTrue)
+		_, err := client.API().Volumes(nil, types.VolAttReqTrue)
 		assert.Error(t, err)
 		assert.Equal(t, "batch processing error", err.Error())
 	}
@@ -182,6 +321,7 @@ func TestVolumesByService(t *testing.T) {
 			t.Fatal(err)
 		}
 		for volumeID, volume := range vols {
+			volume.Attachments = nil
 			assert.NotNil(t, reply[volumeID])
 			assert.EqualValues(t, volume, reply[volumeID])
 		}
@@ -193,7 +333,7 @@ func TestVolumesByServiceWithAttachments(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
 	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().VolumesByService(
-			nil, "vfs", types.VolumeAttachmentsTrue)
+			nil, "vfs", types.VolAttReqTrue)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -213,6 +353,7 @@ func TestVolumeInspect(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		vols[reply.ID].Attachments = nil
 		assert.NotNil(t, reply)
 		assert.EqualValues(t, vols[reply.ID], reply)
 	}
@@ -223,7 +364,7 @@ func TestVolumeInspectWithAttachments(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
 	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 		reply, err := client.API().VolumeInspect(
-			nil, "vfs", "vfs-000", types.VolumeAttachmentsTrue)
+			nil, "vfs", "vfs-000", types.VolAttReqTrue)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -407,7 +548,7 @@ func TestVolumeCreateFromSnapshot(t *testing.T) {
 	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 
 		ogVol, err := client.API().VolumeInspect(
-			nil, "vfs", "vfs-000", types.VolumeAttachmentsTrue)
+			nil, "vfs", "vfs-000", types.VolAttReqTrue)
 		assert.NoError(t, err)
 
 		volumeName := "Volume 003"
@@ -535,7 +676,7 @@ func TestVolumeDetachAllForService(t *testing.T) {
 		assert.EqualValues(t, vols, reply)
 
 		reply, err = client.API().VolumesByService(
-			nil, vfs.Name, types.VolumeAttachmentsTrue)
+			nil, vfs.Name, types.VolAttReqTrue)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(reply))
 
@@ -573,7 +714,7 @@ func TestVolumeDetachAll(t *testing.T) {
 		assert.Equal(t, 3, len(reply[vfs.Name]))
 		assert.EqualValues(t, vols, reply[vfs.Name])
 
-		reply, err = client.API().Volumes(nil, types.VolumeAttachmentsTrue)
+		reply, err = client.API().Volumes(nil, types.VolAttReqTrue)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(reply))
 		assert.Equal(t, 0, len(reply[vfs.Name]))


### PR DESCRIPTION
This patch updates the volume attachment filtering logic so that it can return both attached and unattached volumes in the same query if both bits are set in the mask. Additionally, if bit 2 is set it does not restrict the volumes being returned to only those attached to the provided instance unless the mask also includes bit 8.

Per [this conversation](https://github.com/codedellemc/rexray/pull/619#discussion_r86922502), I think the following helps to explain the purpose and reasoning behind the attachment flags and logic of how they are intended to function:

---

Hi @codenrhoden,

So I hear you and I understand. I think part of the issue is that I want to be able to do this, that, and the other with a single query. Meaning I'd like to be able to say "get all volumes and their attachments" or "get all volumes that are attached" or "get all volumes that are not attached" or "get all volumes that are attached to me and all volumes that are not attached".

What I don't want is for people to have to worry about is performing multiple queries to get what they want. Let's review the values here:

```
const (
	// VolumeAttachmentsRequested indicates attachment information is requested.
	VolumeAttachmentsRequested VolumeAttachmentsTypes = 1 << iota // 1

	// VolumeAttachmentsMine indicates attachment information should
	// be returned for volumes attached to the instance specified in the
	// instance ID request header. If this bit is set then the instance ID
	// header is required.
	VolumeAttachmentsMine // 2

	// VolumeAttachmentsDevices indicates an attempt should made to map devices
	// provided via the local devices request header to the appropriate
	// attachment information. If this bit is set then the instance ID and
	// local device headers are required.
	VolumeAttachmentsDevices // 4

	// VolumeAttachmentsAttached indicates only volumes that are attached
	// should be returned.
	VolumeAttachmentsAttached // 8

	// VolumeAttachmentsUnattached indicates only volumes that are unattached
	// should be returned.
	VolumeAttachmentsUnattached // 16
)
```

As I see it, here are the valid masks:

Mask | Components | Description
------|--------------|------------
`0`| `0` | The default value. This indicates no attachment information is requested.
`1` | `1` | Request attachment information for all retrieved volumes
`3` | `1\|2` | Request attachment information for volumes attached to the instance provided in the instance ID
`7` | `1\|2\|4` | Request attachment information for volumes attached to the instance provided in the instance ID and perform device mappings where possible.
`9` | `1\|8` | Request attachment information for all retrieved volumes and return only volumes that are attached to some instance.
`17` | `1\|16` | Request attachment information for all retrieved volumes and return only volumes that are not attached to any instance.

Here's where it gets a little more interesting:

Mask | Components | Description
------|--------------|------------
`11` | `1\|2\|8` | Request attachment information for all retrieved volumes and return only volumes that attached to the instance provided in the instance ID.
`15` | `1\|2\|4\|8` | Request attachment information for all retrieved volumes and return only volumes that attached to the instance provided in the instance ID and perform device mappings where possible.
`27` | `1\|2\|8\|16` | Request attachment information for all retrieved volumes and return only volumes that attached to the instance provided in the instance ID *or* are not attached to any instance at all. tl;dr - _Attached To Me or Available_
`31` | `1\|2\|4\|8\|16` | Request attachment information for all retrieved volumes and return only volumes that attached to the instance provided in the instance ID *or* are not attached to any instance at all and perform device mappings where possible. tl;dr - _Attached To Me With Device Mappings or Available_

---

Hi @codenrhoden,

I got cut off above (hit enter too soon). I may be totally off base above, but can you see what I was attempting with the above mask?

One thing to note, and in regards to something you said:

> Why use the bitmask at all, then, instead of just `Requested`?

Because to do any of the mapping to an instance or device mapping requires that clients send in the request headers the instance ID and local device information. The mask provides the ability to retrieve volumes without also requiring the presence of the instance ID and/or local device information in the headers.

Previously I assumed drivers would check to see if the instance ID was present, and if so, automatically return volume attachment information for only that instance. 

However that was too constricting as it didn't leave us the ability to create a client that automatically handles sending the instance ID for a user. Additionally, it meant for some drivers we could not request volumes that are both attached to a provided instance but also available (unattached to any other instance). 

See what I mean?

Or am I totally missing something obvious here? I could be. What are your thoughts?

FWIW, see [these tests](https://github.com/akutz/libstorage/blob/bugfix/attachment-filtering-logic/drivers/storage/vfs/tests/vfs_test.go#L166-L312) I added to showcase the various ways to use the mask. Each test asserts the return values are what they are expected to be.

---

Hi @codenrhoden,

One last thing -- I think the reason this is confusing is because I'm using a mask for what is ultimately two purposes:

1. Which data to retrieve
2. Filtering a separate, but related, data set

That is the mask is used to indicate which attachment information to retrieve, but also which volumes to return, filtered by the retrieved attachment data.

This is perhaps not the best way to use a mask -- we should ultimately have a true filtering capability. I was just trying to combine two things into one for now for the sake of simplicity since I have yet to fully implement the LDAP BNF search grammar I implemented for simplistic querying in libStorage [`#0730430`](https://github.com/codedellemc/libstorage/commit/0730430da9d9009dd6ff6d330cf706908b5c7d0f).

For more information on the LDAP search syntax see [RFC 4515](https://tools.ietf.org/search/rfc4515) and this [article](http://matt.might.net/articles/grammars-bnf-ebnf/) on Backus-Naur Form (BNF).

---

Hi @codenrhoden,

I just noticed this after re-reading your comments:

> This makes sense on its own, but gives Mine precedence over Attached and Unattached.

Well, `mine` has no precedence over `unattached` as `mine` only has any effect if a volume has attachments.

And yes, `mine` has precedence over `attached`, but if you take a close look at the tables above you'll notice there is no attempt of the following:

> Request attachment information for all retrieved volumes and return only volumes that attached to the instance provided in the instance ID or are not attached to any instance at all or **are attached at all**.

The above would be what you described -- a mask that's the same as saying get all attachments for all volumes, right?

As it is, the logic is such to enable requesting all volumes attached to the provided instance or all volumes not attached to any instance, aka. volumes available to be attached.

The order of the server logic is specifically designed to enable this. That's why the `attached` bit only removes unattached volumes if the `unattached` bit is not set. That's why the `unattached` bit only removed attached volumes if the`attached` bit is not set.

Again, I do have [these tests](https://github.com/akutz/libstorage/blob/bugfix/attachment-filtering-logic/drivers/storage/vfs/tests/vfs_test.go#L166-L312) that validate the desired logic. 

I'm fully willing to admit I'm off base on all of this, but I also think it's possible I just did a **supremely** shitty job describing the purpose and implementation of these things with which to begin, and it's lead to much confusion.

