### PR TITLE
Only set Vol AttachmentState if not set by driver

### DIFF
--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -185,7 +185,11 @@ func handleVolAttachments(
 		return false
 	}
 
-	// determine a volume's attachment state
+	// determine a volume's attachment state if it hasn't been set already
+	if vol.AttachmentState > 0 {
+		return true
+	}
+
 	if len(vol.Attachments) == 0 {
 		vol.AttachmentState = types.VolumeAvailable
 	} else if iid != nil {


### PR DESCRIPTION
@akutz Since another RC is in the works for 0.3.3, I wonder if you'd consider this patch. Per our previous conversations, `types.VolumeAttachmentStateUnknown` is available to drivers in order to indicate that a volume's state is truly unknown or cannot be determined. This is a feature I am using. But I noticed today that if an `AttachmentState` is set by the driver, it is *always* overriden by the framework. I don't think that's what we wanted. So this patch wraps that bit of code in an `if` statement to only figure one out if `AttachmentState` is `0`, meaning that it hasn't been set by a driver. Let me know what you think.

>The framework can automatically set a volume's attachment state, but
a driver can also explicitly set it to "unknown" -- something that
only a driver can determine. That driver-set value was always
being overriden by the framework.

>This patch makes it so that the framework only determines attachment
state if a driver has not already set a value.