### PR TITLE
Update Handling of Vols w Unknown Att State

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.a
 *.d
 *.out
+got
 libstorage.paw
 .site/
 site/

--- a/api/types/types_model.go
+++ b/api/types/types_model.go
@@ -1,5 +1,7 @@
 package types
 
+import "strconv"
+
 // StorageType is the type of storage a driver provides.
 type StorageType string
 
@@ -145,6 +147,23 @@ const (
 	// volume information.
 	VolumeUnavailable VolumeAttachmentStates = 4
 )
+
+// String returns the string represntation of a VolumeAttachmentStates value.
+func (s VolumeAttachmentStates) String() string {
+	switch s {
+	case 0:
+		return "0"
+	case VolumeAttachmentStateUnknown:
+		return "unknown"
+	case VolumeAttached:
+		return "attached"
+	case VolumeAvailable:
+		return "available"
+	case VolumeUnavailable:
+		return "unavailable"
+	}
+	return strconv.Itoa(int(s))
+}
 
 // Volume provides information about a storage volume.
 type Volume struct {

--- a/drivers/storage/vfs/storage/vfs_storage.go
+++ b/drivers/storage/vfs/storage/vfs_storage.go
@@ -150,6 +150,9 @@ func (d *driver) Volumes(
 		if err != nil {
 			return nil, err
 		}
+		if opts.Attachments > 0 {
+			v.AttachmentState = 0
+		}
 		volumes = append(volumes, v)
 	}
 
@@ -166,6 +169,9 @@ func (d *driver) VolumeInspect(
 	v, err := d.getVolumeByID(volumeID)
 	if err != nil {
 		return nil, err
+	}
+	if opts.Attachments > 0 {
+		v.AttachmentState = 0
 	}
 	return v, nil
 }

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -997,7 +997,7 @@ const volJSON = `{
         },
         "status":       "attached"
     }],
-	"attachmentState":  2,
+    "attachmentState":  2,
     "fields": {
         "owner":        "root@example.com",
         "priority":     "2"
@@ -1011,7 +1011,7 @@ const volNoAttachJSON = `{
     "size":             10240,
     "id":               "vfs-%03[1]d",
     "type":             "myType",
-	"attachmentState":  3,
+    "attachmentState":  3,
     "fields": {
         "owner":        "root@example.com",
         "priority":     "2"


### PR DESCRIPTION
This patch updates the way volumes with an unknown attachment state are handled. If a driver sets a volume's attachment state to unknown and only available or unavailable volumes are requested, a volume with an unknown attachment state will not be returned.

Hi @codenrhoden, this is in response to the issue you raised in Slack:

> One thing I am seeing on the latest RC, now that “attachmentState = unknown” volumes get returned, is that when a client requests “unattached/available” volumes, the Unknown volumes are included.
> 
> ```
> INFO[0004]     -------------------------- HTTP REQUEST (SERVER) --------------------------
> INFO[0004]     GET /volumes/rbd?attachments=17 HTTP/1.1
> INFO[0004]     Host: libstorage-server
> INFO[0004]     Accept-Encoding: gzip
> INFO[0004]     Libstorage-Instanceid: rbd=172.21.12.10
> INFO[0004]     Libstorage-Localdevices: rbd=rbd.travis2::/dev/rbd0,rbd.travis3::/dev/rbd1
> INFO[0004]     Libstorage-Tx: txID=4d39eabd-e3bf-4725-45bb-0203f692a691, txCR=1477224066
> INFO[0004]     User-Agent: Go-http-client/1.1
> INFO[0004]
> INFO[0004]     -------------------------- HTTP RESPONSE (SERVER) -------------------------
> INFO[0004]     Content-Type=application/json
> INFO[0004]
> INFO[0004]     {
> INFO[0004]       "rbd.rex3": {
> INFO[0004]         "attachmentState": 1,
> INFO[0004]         "name": "rex3",
> INFO[0004]         "size": 10,
> INFO[0004]         "id": "rbd.rex3",
> INFO[0004]         "type": "rbd"
> INFO[0004]       },
> INFO[0004]       "rbd.rex5": {
> INFO[0004]         "attachmentState": 1,
> INFO[0004]         "name": "rex5",
> INFO[0004]         "size": 10,
> INFO[0004]         "id": "rbd.rex5",
> INFO[0004]         "type": "rbd"
> INFO[0004]       }
> INFO[0004]     }
> ```
>
> I’m wondering what the best way to handle this is. Should it be up to the framework to filter out those volumes, or should it be up to the client to confirm that when it requests available volumes, that it doesn’t operate on one in an “unknown” state? I could see either way. Let me know what you think and I’ll propose a fix (to either REX-Ray or LS).

I believe this updated logic should make it such that if available or unavailable volumes are explicitly requested then unknown volumes will be omitted.

I also think the diff view of this PR doesn't quite provide a good overview of things. [Here](https://github.com/akutz/libstorage/blob/dc57f35326b26e7ea83334b84cd8172fa130f810/api/server/router/volume/volume_routes.go#L131-L213) is a link to the updated function as a whole to give you a more clear idea.