### PR TITLE
Update AWS SDK Go Dependency

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9957abf364507053076e0827f364dd687db1008ba7e55db6658e3bf2e28aecb3
-updated: 2016-11-07T11:04:04.811693042-06:00
+hash: bfed9a1798d05ab23243875113ae9bc97fdb346ac25be707c05d31e2e00c0915
+updated: 2016-11-17T13:57:46.85843333-06:00
 imports:
 - name: github.com/akutz/gofig
   version: 862741cad5edced279c57d1981e8e3e9fa54e8d5
@@ -20,7 +20,7 @@ imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/aws/aws-sdk-go
-  version: caee6e866bf437a6bef0777a3bf141cdd3aa022d
+  version: 6627523f8671f323edb36dfc56cc0b47c810211f
   repo: https://github.com/aws/aws-sdk-go
   subpackages:
   - aws
@@ -31,6 +31,8 @@ imports:
   - aws/corehandlers
   - aws/credentials
   - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
   - aws/defaults
   - aws/ec2metadata
   - aws/request
@@ -41,6 +43,7 @@ imports:
   - private/protocol/ec2query
   - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
+  - private/protocol/query
   - private/protocol/query/queryutil
   - private/protocol/rest
   - private/protocol/restjson
@@ -48,6 +51,7 @@ imports:
   - private/waiter
   - service/ec2
   - service/efs
+  - service/sts
 - name: github.com/cesanta/ucl
   version: 97c016fce90e6af1b14558563ac46852167e6a76
 - name: github.com/cesanta/validate-json

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,6 +5,10 @@ import:
 ##                           Framework Dependencies                           ##
 ################################################################################
 
+  - package: github.com/spf13/pflag
+    ref:     5ccb023bc27df288a957c5e994cd44fd19619465
+  - package: github.com/spf13/viper
+    ref:     651d9d916abc3c3d6a91a12549495caba5edffd2
   - package: github.com/Sirupsen/logrus
     ref:     feature/logrus-aware-types
     repo:    https://github.com/akutz/logrus
@@ -55,7 +59,7 @@ import:
 
 ### EFS and EBS
   - package: github.com/aws/aws-sdk-go
-    version: v1.2.2
+    version: v1.5.6
     repo:    https://github.com/aws/aws-sdk-go
 
 ### Rackspace


### PR DESCRIPTION
This patch updates the AWS SDK Go dependency from 1.2.2 to 1.5.6.