### PR TITLE
EFS Updates

### DIFF
--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -47,7 +47,7 @@ The following items are configurable specific to this driver.
    be created and removed.
  * `nfsHost` is the configurable NFS server hostname or IP (often a
    SmartConnect name) used when mounting exports
- * `dataSubnet` is the subnet the REX-Ray driver is running on. This is used 
+ * `dataSubnet` is the subnet the REX-Ray driver is running on. This is used
    for the NFS export host ACLs.
 
 ### Optional Parameters
@@ -429,9 +429,13 @@ example see the `Examples` section.
 efs:
   accessKey:      XXXXXXXXXX
   secretKey:      XXXXXXXXXX
-  securityGroups: sg-XXXXXXX,sg-XXXXXX0,sg-XXXXXX1
-  region:         us-east-1
-  tag:            test
+  securityGroups:
+  - sg-XXXXXXX
+  - sg-XXXXXX0
+  - sg-XXXXXX1
+  region:              us-east-1
+  tag:                 test
+  disableSessionCache: false
 ```
 
 #### Configuration Notes
@@ -445,6 +449,9 @@ documentation for list of supported regions.
 If no security groups are provided the default VPC security group is used.
 - `tag` is used to partition multiple services within single AWS account and is
 used as prefix for EFS names in format `[tagprefix]/volumeName`.
+- `disableSessionCache` is a flag that can be used to disable the session cache.
+If the session cache is disabled then a new AWS connection is established with
+every API call.
 
 For information on the equivalent environment variable and CLI flag names
 please see the section on how non top-level configuration properties are
@@ -500,7 +507,10 @@ libstorage:
         efs:
           accessKey:      XXXXXXXXXX
           secretKey:      XXXXXXXXXX
-          securityGroups: sg-XXXXXXX,sg-XXXXXX0,sg-XXXXXX1
+          securityGroups:
+          - sg-XXXXXXX
+          - sg-XXXXXX0
+          - sg-XXXXXX1
           region:         us-east-1
           tag:            test
 ```

--- a/drivers/storage/efs/efs.go
+++ b/drivers/storage/efs/efs.go
@@ -9,6 +9,12 @@ const (
 	// Name is the provider's name.
 	Name = "efs"
 
+	// TagDelimiter separates tags from volume or snapshot names
+	TagDelimiter = "/"
+
+	// DefaultMaxRetries is the max number of times to retry failed operations
+	DefaultMaxRetries = 10
+
 	// InstanceIDFieldRegion is the key to retrieve the region value from the
 	// InstanceID Field map.
 	InstanceIDFieldRegion = "region"
@@ -16,15 +22,97 @@ const (
 	// InstanceIDFieldAvailabilityZone is the key to retrieve the availability
 	// zone value from the InstanceID Field map.
 	InstanceIDFieldAvailabilityZone = "availabilityZone"
+
+	// InstanceIDFieldSecurityGroups is the key to retrieve the default security
+	// group value from the InstanceID Field map.
+	InstanceIDFieldSecurityGroups = "securityGroups"
+
+	// AccessKey is a key constant.
+	AccessKey = "accessKey"
+
+	// SecretKey is a key constant.
+	SecretKey = "secretKey"
+
+	// Region is a key constant.
+	Region = "region"
+
+	// SecurityGroups is a key constant.
+	SecurityGroups = "securityGroups"
+
+	// Endpoint is a key constant.
+	Endpoint = "endpoint"
+
+	// EndpointEC2 is a key constant.
+	EndpointEC2 = "endpointEC2"
+
+	// EndpointFormat is a key constant.
+	EndpointFormat = "endpointFormat"
+
+	// EndpointEC2Format is a key constant.
+	EndpointEC2Format = "endpointEC2Format"
+
+	// MaxRetries is a key constant.
+	MaxRetries = "maxRetries"
+
+	// Tag is a key constant.
+	Tag = "tag"
+
+	// DisableSessionCache is a key constant.
+	DisableSessionCache = "disableSessionCache"
+)
+
+const (
+	// ConfigEFS is a config key.
+	ConfigEFS = Name
+
+	// ConfigEFSAccessKey is a config key.
+	ConfigEFSAccessKey = ConfigEFS + "." + AccessKey
+
+	// ConfigEFSSecretKey is a config key.
+	ConfigEFSSecretKey = ConfigEFS + "." + SecretKey
+
+	// ConfigEFSRegion is a config key.
+	ConfigEFSRegion = ConfigEFS + "." + Region
+
+	// ConfigEFSSecGroups is a config key.
+	ConfigEFSSecGroups = ConfigEFS + "." + SecurityGroups
+
+	// ConfigEFSEndpoint is a config key.
+	ConfigEFSEndpoint = ConfigEFS + "." + Endpoint
+
+	// ConfigEFSEndpointEC2 is a config key.
+	ConfigEFSEndpointEC2 = ConfigEFS + "." + EndpointEC2
+
+	// ConfigEFSEndpointFormat is a config key.
+	ConfigEFSEndpointFormat = ConfigEFS + "." + EndpointFormat
+
+	// ConfigEFSEndpointEC2Format is a config key.
+	ConfigEFSEndpointEC2Format = ConfigEFS + "." + EndpointEC2Format
+
+	// ConfigEFSMaxRetries is a config key.
+	ConfigEFSMaxRetries = ConfigEFS + "." + MaxRetries
+
+	// ConfigEFSTag is a config key.
+	ConfigEFSTag = ConfigEFS + "." + Tag
+
+	// ConfigEFSDisableSessionCache is a config key.
+	ConfigEFSDisableSessionCache = ConfigEFS + "." + DisableSessionCache
 )
 
 func init() {
 	r := gofigCore.NewRegistration("EFS")
-	r.Key(gofig.String, "", "", "", "efs.accessKey")
-	r.Key(gofig.String, "", "", "", "efs.secretKey")
-	r.Key(gofig.String, "", "",
-		"Comma separated security group ids", "efs.securityGroups")
-	r.Key(gofig.String, "", "", "AWS region", "efs.region")
-	r.Key(gofig.String, "", "", "Tag prefix for EFS naming", "efs.tag")
+	r.Key(gofig.String, "", "", "AWS access key", ConfigEFSAccessKey)
+	r.Key(gofig.String, "", "", "AWS secret key", ConfigEFSSecretKey)
+	r.Key(gofig.String, "", "", "List of security groups", ConfigEFSSecGroups)
+	r.Key(gofig.String, "", "", "AWS region", ConfigEFSRegion)
+	r.Key(gofig.String, "", "", "AWS EFS endpoint", ConfigEFSEndpoint)
+	r.Key(gofig.String, "", "", "AWS EC2 endpoint", ConfigEFSEndpointEC2)
+	r.Key(gofig.String, "", `elasticfilesystem.%s.amazonaws.com`,
+		"AWS EFS endpoint format", ConfigEFSEndpointFormat)
+	r.Key(gofig.String, "", `ec2.%s.amazonaws.com`,
+		"AWS EC2 endpoint format", ConfigEFSEndpointEC2Format)
+	r.Key(gofig.String, "", "", "Tag prefix for EFS naming", ConfigEFSTag)
+	r.Key(gofig.Bool, "", false,
+		"A flag that disables the session cache", ConfigEFSDisableSessionCache)
 	gofigCore.Register(r)
 }

--- a/drivers/storage/efs/utils/utils_test.go
+++ b/drivers/storage/efs/utils/utils_test.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/codedellemc/libstorage/api/context"
+)
+
+func skipTest(t *testing.T) {
+	if ok, _ := strconv.ParseBool(os.Getenv("EFS_UTILS_TEST")); !ok {
+		t.Skip()
+	}
+}
+
+func TestInstanceID(t *testing.T) {
+	skipTest(t)
+	iid, err := InstanceID(context.Background())
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	t.Logf("instanceID=%s", iid.String())
+}


### PR DESCRIPTION
This patch updates EFS to use the Login interface for the storage driver as well as calculate the full instance ID on the client-side. Additionally, the new configuration keys `efs.endpoint` and `efs.endpointFormat` are introduced to enable custom endpoint URLs outside the scope of `*.amazonaws.com` per this [REX-Ray PR/issue](https://github.com/codedellemc/rexray/pull/625). 

A subsequent update will occur to add the new `endpointFormat` key to the EBS driver as well. 

This is a WiP PR. I'd appreciate it if @codenrhoden, @mhrabovcin, and @kasisnu could all please take a look and share their thoughts. 