### PR TITLE
Request devmap for integration volume unmount

### DIFF
--- a/drivers/integration/docker/docker.go
+++ b/drivers/integration/docker/docker.go
@@ -326,7 +326,7 @@ func (d *driver) Unmount(
 
 	vol, err := d.volumeInspectByIDOrName(
 		ctx, volumeID, volumeName,
-		types.VolAttReqOnlyVolsAttachedToInstance, opts)
+		types.VolAttReqWithDevMapOnlyVolsAttachedToInstance, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When the integration driver does an unmount, it first does a volume
inspect on the requested volume ID. It was not requesting a devmap for
the attachments, but then expected the attachment.DeviceName to be
filled in, which it should not be.

Fix this by using the mask `VolAttReqWithDevMapOnlyVolsAttachedToInstance`
instead.