### PR TITLE
Return volume from Docker integration Unmount()

### DIFF
--- a/api/registry/registry_integration.go
+++ b/api/registry/registry_integration.go
@@ -162,7 +162,7 @@ func (d *idm) Mount(
 func (d *idm) Unmount(
 	ctx types.Context,
 	volumeID, volumeName string,
-	opts types.Store) error {
+	opts types.Store) (*types.Volume, error) {
 
 	fields := log.Fields{
 		"volumeName": volumeName,
@@ -180,7 +180,7 @@ func (d *idm) Unmount(
 	}
 
 	d.decCount(volumeName)
-	return nil
+	return nil, nil
 }
 
 func (d *idm) Path(

--- a/api/types/types_drivers_integration.go
+++ b/api/types/types_drivers_integration.go
@@ -60,7 +60,7 @@ type IntegrationDriver interface {
 	Unmount(
 		ctx Context,
 		volumeID, volumeName string,
-		opts Store) error
+		opts Store) (*Volume, error)
 
 	// Path will return the mounted path of the volumeName or volumeID.
 	Path(

--- a/drivers/integration/docker/docker.go
+++ b/drivers/integration/docker/docker.go
@@ -313,7 +313,7 @@ func (d *driver) Mount(
 func (d *driver) Unmount(
 	ctx types.Context,
 	volumeID, volumeName string,
-	opts types.Store) error {
+	opts types.Store) (*types.Volume, error) {
 
 	ctx.WithFields(log.Fields{
 		"volumeName": volumeName,
@@ -321,25 +321,25 @@ func (d *driver) Unmount(
 		"opts":       opts}).Info("unmounting volume")
 
 	if volumeName == "" && volumeID == "" {
-		return goof.New("missing volume name or ID")
+		return nil, goof.New("missing volume name or ID")
 	}
 
 	vol, err := d.volumeInspectByIDOrName(
 		ctx, volumeID, volumeName,
 		types.VolAttReqOnlyVolsAttachedToInstance, opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if len(vol.Attachments) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	client := context.MustClient(ctx)
 
 	inst, err := client.Storage().InstanceInspect(ctx, utils.NewStore())
 	if err != nil {
-		return goof.New("problem getting instance ID")
+		return nil, goof.New("problem getting instance ID")
 	}
 	var ma *types.VolumeAttachment
 	for _, att := range vol.Attachments {
@@ -350,17 +350,17 @@ func (d *driver) Unmount(
 	}
 
 	if ma == nil {
-		return goof.New("no attachment found for instance")
+		return nil, goof.New("no attachment found for instance")
 	}
 
 	if ma.DeviceName == "" {
-		return goof.New("no device name found for attachment")
+		return nil, goof.New("no device name found for attachment")
 	}
 
 	mounts, err := client.OS().Mounts(
 		ctx, ma.DeviceName, "", opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, mount := range mounts {
@@ -372,24 +372,24 @@ func (d *driver) Unmount(
 			ctx.WithField("mount", mount).Debug("unmounting mount point")
 			err = client.OS().Unmount(ctx, mount.MountPoint, opts)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
 
-	_, err = client.Storage().VolumeDetach(ctx, vol.ID,
+	vol, err = client.Storage().VolumeDetach(ctx, vol.ID,
 		&types.VolumeDetachOpts{
 			Force: opts.GetBool("force"),
 			Opts:  utils.NewStore(),
 		})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	ctx.WithFields(log.Fields{
 		"vol": vol}).Info("unmounted and detached volume")
 
-	return nil
+	return vol, nil
 }
 
 // Path will return the mounted path of the volumeName or volumeID.


### PR DESCRIPTION
This patch updates the IntegrationDriver types Unmount() method to
return a pointer to a Volume object. The unmount command is already
querying Libstorage to get an updated volume object after a detach has
occured, but it is not returning it.

Clients (like rexray) can use this returned value to display more up to
date status about the unmounted/detached volume without querying for it
a second time.


@akutz: this PR is a companion to https://github.com/codedellemc/rexray/pull/628. I fully expect you won't take it as-is since it makes a change to an existing Type. But I at least wanted to make the case for implementing something to this end, so that correct status can be shown in rexray.  If/when that happens, it may be better targeted for LS 0.4.x rather than 0.3.x.