### PR TITLE
Add Ceph RBD driver

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -588,6 +588,7 @@ remote storage systems. Currently the following storage drivers are supported:
 [VirtualBox](./storage-providers.md#virtualbox) | virtualbox
 [EBS](./storage-providers.md#aws-ebs) | ebs, ec2
 [EFS](./storage-providers.md#aws-efs) | efs
+[RBD](./storage-providers.md#ceph-rbd) | rbd
 ..more coming|
 
 The `libstorage.server.libstorage.storage.driver` property can be used to
@@ -694,6 +695,7 @@ ScaleIO|Yes
 VirtualBox|Yes
 EBS|Yes
 EFS|No
+RBD|No
 
 #### Ignore Used Count
 By default accounting takes place during operations that are performed

--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -517,3 +517,89 @@ libstorage:
           region:         us-east-1
           tag:            test
 ```
+## Ceph RBD
+The Ceph RBD driver registers a driver named `rbd` with the `libStorage` driver
+manager and is used to connect and mount RADOS Block Devices from a Ceph
+cluster.
+
+### Requirements
+
+* The `ceph` and `rbd` binary executables must be installed on the host
+* The `rbd` kernel module must be installed
+* A `ceph.conf` file must be present in its default location
+  (`/etc/ceph/ceph.conf`)
+* The ceph `admin` key must be present in `/etc/ceph/`
+
+### Configuration
+The following is an example with all possible fields configured. For a running
+example see the `Examples` section.
+
+```yaml
+rbd:
+  defaultPool: rbd
+```
+
+#### Configuration Notes
+
+* The `defaultPool` parameter is optional, and defaults to "rbd". When set, all
+  volume requests that do not reference a specific pool will use the
+  `defaultPool` value as the destination storage pool.
+
+### Runtime behavior
+
+The Ceph RBD driver only works when the client and server are on the same node.
+There is no way for a centralized `libStorage` server to attach volumes to
+clients, therefore the `libStorage` server must be running on each node that
+wishes to mount RBD volumes.
+
+The RBD driver uses the format of `<pool>.<name>` for the volume ID. This allows
+for the use of multiple pools by the driver. During a volume create, if the
+volume ID is given as `<pool>.<name>`, a volume named *name* will be created in
+the *pool* storage pool. If no pool is referenced, the `defaultPool` will be
+used.
+
+When querying volumes, the driver will return all RBDs present in all pools in
+the cluster, prefixing each volume with the appropriate `<pool>.` value.
+
+All RBD creates are done using the default 4MB object size, and using the
+"layering" feature bit to ensure greatest compatibility with the kernel clients.
+
+### Activating the Driver
+To activate the Ceph RBD driver please follow the instructions for
+[activating storage drivers](./config.md#storage-drivers), using `rbd` as the
+driver name.
+
+### Troubleshooting
+
+* Make sure that `ceph` and `rbd` commands work without extra parameters for
+  ID, key, and monitors. All configuration must come from `ceph.conf`.
+* Check status of the ceph cluster with `ceph -s` command.
+
+### Examples
+
+Below is a full `config.yml` that works with RBD
+
+```yaml
+libstorage:
+  server:
+    services:
+      rbd:
+        driver: rbd
+        rbd:
+          defaultPool: rbd
+```
+
+### Caveats
+
+* Snapshot and copy functionality is not yet implemented
+* libStorage Server must be running on each host to mount/attach RBD volumes
+* There is not yet options for using non-admin cephx keys or changing RBD create
+  features
+* Volume pre-emption is not supported. Ceph does not provide a method to
+  forcefully detach a volume from a remote host -- only a host can attach and
+  detach volumes from itself.
+* RBD advisory locks are not yet in use. A volume is returned as "unavailable"
+  if it has a watcher other than the requesting client. Until advisory locks are
+  in place, it may be possible for a client to attach a volume that is already
+  attached to another node. Mounting and writing to such a volume could lead to
+  data corruption.

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@ BUILD_TAGS +=   libstorage_storage_driver \
 endif
 endif
 
+RBD_BUILD_TAGS := gofig \
+		pflag \
+		libstorage_integration_driver_docker \
+		libstorage_storage_driver \
+		libstorage_storage_driver_rbd \
+		libstorage_storage_executor \
+		libstorage_storage_executor_rbd
+
 all:
 # if docker is running, then let's use docker to build it
 ifneq (,$(shell if docker version &> /dev/null; then echo -; fi))
@@ -1061,6 +1069,10 @@ test:
 
 test-debug:
 	env LIBSTORAGE_DEBUG=true $(MAKE) test
+
+test-rbd:
+	env BUILD_TAGS="$(RBD_BUILD_TAGS)" $(MAKE) deps
+	env BUILD_TAGS="$(RBD_BUILD_TAGS)" $(MAKE) ./drivers/storage/rbd/tests/rbd.test
 
 clean: $(GO_CLEAN)
 

--- a/drivers/storage/rbd/executor/rbd_executor.go
+++ b/drivers/storage/rbd/executor/rbd_executor.go
@@ -1,0 +1,201 @@
+// +build !libstorage_storage_executor libstorage_storage_executor_rbd
+
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"net"
+	"os/exec"
+	"strings"
+
+	gofig "github.com/akutz/gofig/types"
+	"github.com/akutz/goof"
+	"github.com/akutz/gotil"
+
+	"github.com/codedellemc/libstorage/api/registry"
+	"github.com/codedellemc/libstorage/api/types"
+	"github.com/codedellemc/libstorage/drivers/storage/rbd"
+	"github.com/codedellemc/libstorage/drivers/storage/rbd/utils"
+)
+
+type driver struct {
+	config gofig.Config
+}
+
+func init() {
+	registry.RegisterStorageExecutor(rbd.Name, newdriver)
+}
+
+func newdriver() types.StorageExecutor {
+	return &driver{}
+}
+
+func (d *driver) Init(context types.Context, config gofig.Config) error {
+	d.config = config
+	return nil
+}
+
+func (d *driver) Name() string {
+	return rbd.Name
+}
+
+func (d *driver) Supported(
+	ctx types.Context,
+	opts types.Store) (bool, error) {
+
+	if !gotil.FileExistsInPath("ceph") {
+		return false, nil
+	}
+
+	if !gotil.FileExistsInPath("rbd") {
+		return false, nil
+	}
+
+	if !gotil.FileExistsInPath("ip") {
+		return false, nil
+	}
+
+	if err := exec.Command("modprobe", "rbd").Run(); err != nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// NextDevice returns the next available device.
+func (d *driver) NextDevice(
+	ctx types.Context,
+	opts types.Store) (string, error) {
+
+	return "", types.ErrNotImplemented
+}
+
+// LocalDevices returns a map of the system's local devices.
+func (d *driver) LocalDevices(
+	ctx types.Context,
+	opts *types.LocalDevicesOpts) (*types.LocalDevices, error) {
+
+	devMap, err := utils.GetMappedRBDs()
+	if err != nil {
+		return nil, err
+	}
+
+	ld := &types.LocalDevices{Driver: d.Name()}
+	if len(devMap) > 0 {
+		ld.DeviceMap = devMap
+	}
+
+	return ld, nil
+}
+
+// InstanceID returns the local system's InstanceID.
+func (d *driver) InstanceID(
+	ctx types.Context,
+	opts types.Store) (*types.InstanceID, error) {
+
+	return GetInstanceID(nil, nil)
+}
+
+// GetInstanceID returns the instance ID object
+func GetInstanceID(
+	monIPs []net.IP,
+	localIntfs []net.Addr) (*types.InstanceID, error) {
+	/* Ceph doesn't have only one unique identifier per client, it can have
+	   several. With the way the RBD driver is used, we will see multiple
+	   identifiers used, and therefore returning any of those identifiers
+	   is actually confusing rather than helpful. Instead, we use the client
+	   IP address that is on the interface that can reach the monitors.
+
+	   We loop through all the monitor IPs, looking for a local interface
+	   that is on the same L2 segment. If these all fail, We are on an L3
+	   segment so we grab the IP from the default route.
+	*/
+
+	var err error
+	if nil == monIPs {
+		monIPs, err = getCephMonIPs()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(monIPs) == 0 {
+		return nil, goof.New("No Ceph Monitors found")
+	}
+
+	if nil == localIntfs {
+		localIntfs, err = net.InterfaceAddrs()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	iid := &types.InstanceID{Driver: rbd.Name}
+	for _, intf := range localIntfs {
+		localIP, localNet, _ := net.ParseCIDR(intf.String())
+		for _, monIP := range monIPs {
+			if localNet.Contains(monIP) {
+				// Monitor reachable over L2
+				iid.ID = localIP.String()
+				return iid, nil
+			}
+		}
+	}
+
+	// No luck finding L2 match, check for default/static route to monitor
+	localIP, err := getSrcIP(monIPs[0].String())
+	if err != nil {
+		return nil, err
+	}
+	iid.ID = localIP
+
+	return iid, nil
+}
+
+func getCephMonIPs() ([]net.IP, error) {
+	out, err := exec.Command("ceph-conf", "--lookup", "mon_host").Output()
+	if err != nil {
+		return nil, goof.WithError("Unable to get Ceph monitors", err)
+	}
+
+	monStrings := strings.Split(strings.TrimSpace(string(out)), ",")
+
+	monIps := make([]net.IP, 0, 4)
+
+	for _, mon := range monStrings {
+		ip := net.ParseIP(mon)
+		if ip != nil {
+			monIps = append(monIps, ip)
+		} else {
+			ipSlice, err := net.LookupIP(mon)
+			if err == nil {
+				monIps = append(monIps, ipSlice...)
+			}
+		}
+	}
+
+	return monIps, nil
+}
+
+func getSrcIP(destIP string) (string, error) {
+	out, err := exec.Command(
+		"ip", "-oneline", "route", "get", destIP).Output()
+	if err != nil {
+		return "", goof.WithError("Unable get IP routes", err)
+	}
+
+	byteReader := bytes.NewReader(out)
+	scanner := bufio.NewScanner(byteReader)
+	scanner.Split(bufio.ScanWords)
+	found := false
+	for scanner.Scan() {
+		if !found {
+			if scanner.Text() == "src" {
+				found = true
+				continue
+			}
+		}
+		return scanner.Text(), nil
+	}
+	return "", goof.New("Unable to parse ip output")
+}

--- a/drivers/storage/rbd/rbd.go
+++ b/drivers/storage/rbd/rbd.go
@@ -1,0 +1,23 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_rbd
+
+package rbd
+
+import (
+	gofigCore "github.com/akutz/gofig"
+	gofig "github.com/akutz/gofig/types"
+)
+
+const (
+	// Name is the name of the storage driver
+	Name = "rbd"
+)
+
+func init() {
+	registerConfig()
+}
+
+func registerConfig() {
+	r := gofigCore.NewRegistration("RBD")
+	r.Key(gofig.String, "", "rbd", "", "rbd.defaultPool")
+	gofigCore.Register(r)
+}

--- a/drivers/storage/rbd/storage/rbd_storage.go
+++ b/drivers/storage/rbd/storage/rbd_storage.go
@@ -1,0 +1,434 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_rbd
+
+package storage
+
+import (
+	"regexp"
+
+	log "github.com/Sirupsen/logrus"
+
+	gofig "github.com/akutz/gofig/types"
+	"github.com/akutz/goof"
+
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/registry"
+	"github.com/codedellemc/libstorage/api/types"
+	"github.com/codedellemc/libstorage/drivers/storage/rbd"
+	"github.com/codedellemc/libstorage/drivers/storage/rbd/utils"
+)
+
+const (
+	rbdDefaultOrder = 22
+	bytesPerGiB     = 1024 * 1024 * 1024
+)
+
+var (
+	featureLayering   = "layering"
+	defaultObjectSize = "4M"
+)
+
+type driver struct {
+	config gofig.Config
+}
+
+func init() {
+	registry.RegisterStorageDriver(rbd.Name, newDriver)
+}
+
+func newDriver() types.StorageDriver {
+	return &driver{}
+}
+
+func (d *driver) Name() string {
+	return rbd.Name
+}
+
+// Init initializes the driver.
+func (d *driver) Init(context types.Context, config gofig.Config) error {
+	d.config = config
+	log.Info("storage driver initialized")
+	return nil
+}
+
+func (d *driver) Type(ctx types.Context) (types.StorageType, error) {
+	return types.Block, nil
+}
+
+func (d *driver) NextDeviceInfo(
+	ctx types.Context) (*types.NextDeviceInfo, error) {
+	return nil, nil
+}
+
+func (d *driver) InstanceInspect(
+	ctx types.Context,
+	opts types.Store) (*types.Instance, error) {
+
+	iid := context.MustInstanceID(ctx)
+	return &types.Instance{
+		InstanceID: iid,
+	}, nil
+}
+
+func (d *driver) Volumes(
+	ctx types.Context,
+	opts *types.VolumesOpts) ([]*types.Volume, error) {
+
+	// Get all Volumes in all pools
+	pools, err := utils.GetRadosPools()
+	if err != nil {
+		return nil, err
+	}
+
+	var volumes []*types.Volume
+
+	for _, pool := range pools {
+		images, err := utils.GetRBDImages(pool)
+		if err != nil {
+			return nil, err
+		}
+
+		vols, err := d.toTypeVolumes(
+			ctx, images, opts.Attachments)
+		if err != nil {
+			/* Should we try to continue instead? */
+			return nil, err
+		}
+		volumes = append(volumes, vols...)
+	}
+
+	return volumes, nil
+}
+
+func (d *driver) VolumeInspect(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeInspectOpts) (*types.Volume, error) {
+
+	pool, image, err := d.parseVolumeID(&volumeID)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := utils.GetRBDInfo(pool, image)
+	if err != nil {
+		return nil, err
+	}
+
+	// no volume returned
+	if info == nil {
+		return nil, nil
+	}
+
+	/* GetRBDInfo returns more details about an image than what we get back
+	   from GetRBDImages. We could just use that and then grab the image we
+	   want, but using GetRBDInfo() instead in case we ever want to send
+	   back  more detaild information from VolumeInspect() than Volumes() */
+	images := []*utils.RBDImage{
+		&utils.RBDImage{
+			Name: info.Name,
+			Size: info.Size,
+			Pool: info.Pool,
+		},
+	}
+
+	vols, err := d.toTypeVolumes(ctx, images, opts.Attachments)
+	if err != nil {
+		return nil, err
+	}
+
+	return vols[0], nil
+}
+
+func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+
+	fields := map[string]interface{}{
+		"driverName": d.Name(),
+		"volumeName": volumeName,
+		"opts.size":  *opts.Size,
+	}
+
+	log.WithFields(fields).Debug("creating volume")
+
+	pool, imageName, err := d.parseVolumeID(&volumeName)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := utils.GetRBDInfo(pool, imageName)
+	if err != nil {
+		return nil, err
+	}
+
+	// volume already exists
+	if info != nil {
+		return nil, goof.New("Volume already exists")
+	}
+
+	//TODO: config options for order and features?
+
+	features := []*string{&featureLayering}
+
+	err = utils.RBDCreate(
+		pool,
+		imageName,
+		opts.Size,
+		&defaultObjectSize,
+		features,
+	)
+	if err != nil {
+		return nil, goof.WithError("Failed to create new volume", err)
+	}
+
+	volumeID := utils.GetVolumeID(pool, imageName)
+	return d.VolumeInspect(ctx, *volumeID,
+		&types.VolumeInspectOpts{
+			Attachments: types.VolAttNone,
+		},
+	)
+}
+
+func (d *driver) VolumeCreateFromSnapshot(
+	ctx types.Context,
+	snapshotID, volumeName string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+	return nil, types.ErrNotImplemented
+}
+
+func (d *driver) VolumeCopy(
+	ctx types.Context,
+	volumeID, volumeName string,
+	opts types.Store) (*types.Volume, error) {
+	return nil, types.ErrNotImplemented
+}
+
+func (d *driver) VolumeSnapshot(
+	ctx types.Context,
+	volumeID, snapshotName string,
+	opts types.Store) (*types.Snapshot, error) {
+	return nil, types.ErrNotImplemented
+}
+
+func (d *driver) VolumeRemove(
+	ctx types.Context,
+	volumeID string,
+	opts types.Store) error {
+
+	fields := map[string]interface{}{
+		"driverName": d.Name(),
+		"volumeID":   volumeID,
+	}
+
+	log.WithFields(fields).Debug("deleting volume")
+
+	pool, imageName, err := d.parseVolumeID(&volumeID)
+	if err != nil {
+		return goof.WithError("Unable to set image name", err)
+	}
+
+	err = utils.RBDRemove(pool, imageName)
+	if err != nil {
+		return goof.WithError("Error while deleting RBD image", err)
+	}
+	log.WithFields(fields).Debug("removed volume")
+
+	return nil
+}
+
+func (d *driver) VolumeAttach(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
+
+	fields := map[string]interface{}{
+		"driverName": d.Name(),
+		"volumeID":   volumeID,
+	}
+
+	log.WithFields(fields).Debug("attaching volume")
+
+	pool, imageName, err := d.parseVolumeID(&volumeID)
+	if err != nil {
+		return nil, "", goof.WithError("Unable to set image name", err)
+	}
+
+	_, err = utils.RBDMap(pool, imageName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	vol, err := d.VolumeInspect(ctx, volumeID,
+		&types.VolumeInspectOpts{
+			Attachments: types.VolAttReqTrue,
+		},
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return vol, volumeID, nil
+}
+
+func (d *driver) VolumeDetach(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeDetachOpts) (*types.Volume, error) {
+
+	fields := map[string]interface{}{
+		"driverName": d.Name(),
+		"volumeID":   volumeID,
+	}
+
+	log.WithFields(fields).Debug("detaching volume")
+
+	// Can't rely on local devices header, so get local attachments
+	localAttachMap, err := utils.GetMappedRBDs()
+	if err != nil {
+		return nil, err
+	}
+
+	dev, found := localAttachMap[volumeID]
+	if !found {
+		return nil, goof.New("Volume not attached")
+	}
+
+	err = utils.RBDUnmap(&dev)
+	if err != nil {
+		return nil, goof.WithError("Unable to detach volume", err)
+	}
+
+	return d.VolumeInspect(
+		ctx, volumeID, &types.VolumeInspectOpts{
+			Attachments: types.VolAttReqTrue,
+		},
+	)
+}
+
+func (d *driver) VolumeDetachAll(
+	ctx types.Context,
+	volumeID string,
+	opts types.Store) error {
+	return types.ErrNotImplemented
+}
+
+func (d *driver) Snapshots(
+	ctx types.Context,
+	opts types.Store) ([]*types.Snapshot, error) {
+	return nil, types.ErrNotImplemented
+}
+
+func (d *driver) SnapshotInspect(
+	ctx types.Context,
+	snapshotID string,
+	opts types.Store) (*types.Snapshot, error) {
+	return nil, types.ErrNotImplemented
+}
+
+func (d *driver) SnapshotCopy(
+	ctx types.Context,
+	snapshotID, snapshotName, destinationID string,
+	opts types.Store) (*types.Snapshot, error) {
+	return nil, types.ErrNotImplemented
+}
+
+func (d *driver) SnapshotRemove(
+	ctx types.Context,
+	snapshotID string,
+	opts types.Store) error {
+	return types.ErrNotImplemented
+}
+
+func (d *driver) defaultPool() string {
+	return d.config.GetString("rbd.defaultPool")
+}
+
+func (d *driver) toTypeVolumes(
+	ctx types.Context,
+	images []*utils.RBDImage,
+	getAttachments types.VolumeAttachmentsTypes) ([]*types.Volume, error) {
+
+	lsVolumes := make([]*types.Volume, len(images))
+
+	var localAttachMap map[string]string
+
+	// Even though this will be the same as LocalDevices header, we can't
+	// rely on that being present unless getAttachments.Devices is set
+	if getAttachments.Requested() {
+		var err error
+		localAttachMap, err = utils.GetMappedRBDs()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for i, image := range images {
+		rbdID := utils.GetVolumeID(&image.Pool, &image.Name)
+		lsVolume := &types.Volume{
+			Name: image.Name,
+			ID:   *rbdID,
+			Type: image.Pool,
+			Size: int64(image.Size / bytesPerGiB),
+		}
+
+		if getAttachments.Requested() && localAttachMap != nil {
+			// Set volumeAttachmentState to Unknown, because this
+			// driver (currently) has no way of knowing if an image
+			// is attached anywhere else but to the caller
+			lsVolume.AttachmentState = types.VolumeAttachmentStateUnknown
+			var attachments []*types.VolumeAttachment
+			if _, found := localAttachMap[*rbdID]; found {
+				lsVolume.AttachmentState = types.VolumeAttached
+				attachment := &types.VolumeAttachment{
+					VolumeID:   *rbdID,
+					InstanceID: context.MustInstanceID(ctx),
+				}
+				if getAttachments.Devices() {
+					ld, ok := context.LocalDevices(ctx)
+					if ok {
+						attachment.DeviceName = ld.DeviceMap[*rbdID]
+					} else {
+						log.Warnf("Unable to get local device map for volume %s", *rbdID)
+					}
+				}
+				attachments = append(attachments, attachment)
+				lsVolume.Attachments = attachments
+			} else {
+				//Check if RBD has watchers to infer attachment
+				//to a different host
+				b, err := utils.RBDHasWatchers(
+					&image.Pool, &image.Name,
+				)
+				if err == nil {
+					if b {
+						lsVolume.AttachmentState = types.VolumeUnavailable
+					} else {
+						lsVolume.AttachmentState = types.VolumeAvailable
+					}
+				}
+			}
+		}
+		lsVolumes[i] = lsVolume
+	}
+
+	return lsVolumes, nil
+}
+
+func (d *driver) parseVolumeID(name *string) (*string, *string, error) {
+
+	// Look for <pool>.<name>
+	re, _ := regexp.Compile(`^(\w+)\.(\w+)$`)
+	res := re.FindStringSubmatch(*name)
+	if len(res) == 3 {
+		// Name includes pool already
+		return &res[1], &res[2], nil
+	}
+
+	// make sure <name> is valid
+	re, _ = regexp.Compile(`^\w+$`)
+	if !re.MatchString(*name) {
+		return nil, nil, goof.New("Invalid VolumeID")
+	}
+
+	pool := d.defaultPool()
+	return &pool, name, nil
+}

--- a/drivers/storage/rbd/tests/.gitignore
+++ b/drivers/storage/rbd/tests/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+*.vdi

--- a/drivers/storage/rbd/tests/README.md
+++ b/drivers/storage/rbd/tests/README.md
@@ -1,0 +1,108 @@
+# RBD Driver Testing
+This package includes two different kinds of tests for the RBD storage driver:
+
+Test Type | Description
+----------|------------
+Unit/Integration | The unit/integration tests are provided and executed via the standard Go test pattern, in a file named `rbd_test.go`. These tests are designed to test the storage driver's and executor's functions at a low-level, ensuring, given the proper input, the expected output is received.
+Test Execution Plan | The test execution plan operates above the code-level, using a Vagrantfile to deploy a complete implementation of the RBD storage driver in order to run real-world, end-to-end test scenarios.
+
+## Unit/Integration Tests
+The unit/integration tests must be executed on a node that has access to a Ceph
+cluster. In order to execute the tests either compile the test binary locally or
+on the instance. From the root of the libStorage project execute the following:
+
+```bash
+GOOS=linux make test-rbd
+```
+
+Once the test binary is compiled, if it was built locally, copy it to the node
+where testing can occur
+
+Using an SSH session to connect to the node, the tests may now be executed as
+root with the following command:
+
+```bash
+sudo ./rbd.test
+```
+
+An exit code of `0` means the tests completed successfully. If there are errors
+then it may be useful to run the tests once more with increased logging:
+
+```bash
+sudo LIBSTORAGE_LOGGING_LEVEL=debug ./rbd.test -test.v
+```
+
+## Test Execution Plan
+In addition to the low-level unit/integration tests, the RBD storage driver
+provides a test execution plan automated with Vagrant:
+
+```
+vagrant up --provider=virtualbox
+```
+
+The above command brings up a Vagrant environment using VirtualBox virtual
+machines in order to test the RBD driver. If the command completes successfully
+then the environment was brought online without issue and indicates that the
+test execution plan succeeded as well.
+
+The following sections outline dependencies, settings, and different execution
+scenarios that may be required or useful for using the Vagrantfile.
+
+### Test Plan Dependencies
+The following dependencies are required in order to execute the included test
+execution plan:
+
+  * [Vagrant](https://www.vagrantup.com/) 1.8.4+
+  * [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager)
+
+Once Vagrant is installed the required plug-ins may be installed with the
+following commands:
+
+```bash
+vagrant plugin install vagrant-hostmanager
+```
+
+**NOTE**: The VMs contain the default Vagrant insecure SSH public key, such that
+`vagrant ssh` works by default. However, the `ceph-admin` VM needs to be able to
+SSH to the other VMs in order to configure Ceph via `ceph-deploy`. In order to
+do this, the Vagrant SSH private key must be in your local SSH agent. The most
+typical way to accomplish this on a nix-like machine is by running the command:
+
+```
+ssh-add ~/.vagrant.d/insecure_private_key
+```
+
+Configuration of the Ceph cluster will not work without this step.
+
+### Test Plan Nodes
+The `Vagrantfile` deploys a Ceph cluster and two RBD/rexray clients named:
+
+  * libstorage-rbd-test-server1
+  * libstorage-rbd-test-server2
+  * libstorage-ebs-test-admin
+  * libstorage-ebs-test-client
+
+The "admin" node is identical to client, except it is also use to configure
+the Ceph cluster using `ceph-deploy`.
+
+### Test Plan Scripts
+This package includes several test scripts that act as the primary executors
+of the test plan:
+
+  * `server-tests.sh`
+  * `client0-tests.sh`
+  * `client1-tests.sh`
+
+The above files are copied to their respective instances and executed
+as soon as the instance is online. That means the `server-tests.sh` script is
+executed before the client nodes are even online since the server node is
+brought online first.
+
+### Test Plan Cleanup
+Once the test plan has been executed, successfully or otherwise, it's important
+to remember to clean up the VirtualBox resources that may have been created
+along the way. To do so simply execute the following command:
+
+```bash
+vagrant destroy -f
+```

--- a/drivers/storage/rbd/tests/Vagrantfile
+++ b/drivers/storage/rbd/tests/Vagrantfile
@@ -1,0 +1,151 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Number of Ceph server nodes
+server_nodes = 2
+
+# /24 network to use for private network
+network = "172.21.13"
+
+# Flags to control which REX-Ray to install
+# Setting all options to false will use whatever rexray is already present
+install_latest_stable_rex = true
+install_latest_staged_rex = false
+install_rex_from_source = false
+
+# Script to build rexray from source
+$build_rexray = <<SCRIPT
+export GOPATH=~/go
+SRC_DIR=${GOPATH}/src/github.com/codedellemc
+REX_REPO=https://github.com/codedellemc/rexray
+REX_BRANCH=master
+DEFAULT_LIBSTORAGE=false
+LS_REPO=https://github.com/codenrhoden/libstorage
+LS_BRANCH=feature/rbd
+sudo yum -y install golang
+mkdir -p ${SRC_DIR}
+cd ${SRC_DIR}
+if [ ${DEFAULT_LIBSTORAGE} = false ]; then
+	git clone ${LS_REPO} --branch ${LS_BRANCH}
+fi
+git clone ${REX_REPO} --branch ${REX_BRANCH}
+cd rexray
+if [ ${DEFAULT_LIBSTORAGE} = false ]; then
+	sysctl -w net.ipv4.ip_forward=1
+	DLOCAL_IMPORTS="github.com/codedellemc/libstorage" DGOOS=linux make && \
+	cp rexray /usr/bin
+else
+	make deps && make build && cp ${GOPATH}/bin/rexray /usr/bin
+fi
+SCRIPT
+
+Vagrant.configure("2") do |config|
+
+  # some shared setup
+  config.vm.box = "codedellemc/ceph_rexray"
+  config.vm.box_url = "https://rawgit.com/codedellemc/vagrant/master/ceph/packer/vagrant_ceph_rexray.json"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.ssh.forward_agent = true
+  config.ssh.insert_key = false
+  config.hostmanager.enabled = true
+
+  file_root = File.dirname(File.expand_path(__FILE__))
+
+  # We provision nodes to be Ceph servers
+  (1..server_nodes).each do |i|
+    config.vm.define "libstorage-rbd-test-server#{i}" do |config|
+      config.vm.hostname = "libstorage-rbd-test-server#{i}"
+      config.vm.network "private_network", ip: "#{network}.#{i+10}"
+      config.vm.provider "virtualbox" do |vb|
+        vb.customize ["modifyvm", :id, "--macaddress1", "auto"]
+	vb.customize ["storagectl", :id, "--add", "sata", "--controller", "IntelAhci", "--name", "SATA", "--portcount", 30, "--hostiocache", "on"]
+        file_to_disk = File.join(file_root, "ceph#{i}osd.vdi")
+        unless File.exist?(file_to_disk)
+          vb.customize [
+            'createhd',
+            '--filename', file_to_disk,
+            '--format', 'VDI',
+            '--size', 10 * 1024
+          ]
+        end
+        vb.customize [
+          'storageattach', :id,
+          '--storagectl', 'SATA',
+          '--port', 1, '--device', 0,
+          '--type', 'hdd', '--medium',
+          file_to_disk
+        ]
+      end
+
+      # work around bug in Vagrant 1.9.1
+      config.vm.provision "shell", privileged: true, inline: <<-SHELL
+        service network restart
+      SHELL
+    end
+  end
+
+  # We need a Ceph client machine
+  config.vm.define "libstorage-rbd-test-client" do |client|
+    client.vm.hostname = "libstorage-rbd-test-client"
+    client.vm.network "private_network", ip: "#{network}.9"
+    client.vm.provider :virtualbox do |vb|
+      vb.customize ["modifyvm", :id, "--macaddress1", "auto"]
+    end
+
+    client.vm.provision "shell", privileged: false, path: "rexconfig.sh"
+
+    # work around bug in Vagrant 1.9.1
+    config.vm.provision "shell", privileged: true, inline: <<-SHELL
+      service network restart
+    SHELL
+  end
+
+  # We need one Ceph admin machine to manage the cluster and act as a second
+  # client
+  config.vm.define "libstorage-rbd-test-admin" do |admin|
+    admin.vm.hostname = "libstorage-rbd-test-admin"
+    admin.vm.network "private_network", ip: "#{network}.10"
+    admin.vm.provider :virtualbox do |vb|
+      vb.customize ["modifyvm", :id, "--macaddress1", "auto"]
+      vb.customize ["storagectl", :id, "--add", "sata", "--controller", "IntelAhci", "--name", "SATA", "--portcount", 30, "--hostiocache", "on"]
+    end
+
+    if install_latest_stable_rex
+      admin.vm.provision "shell", privileged: true, inline: <<-SHELL
+        curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -s stable
+      SHELL
+    end
+
+    if install_latest_staged_rex
+      admin.vm.provision "shell", privileged: true, inline: <<-SHELL
+        curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -s staged
+      SHELL
+    end
+
+    if install_rex_from_source
+      admin.vm.provision "shell" do |s|
+        s.name = "build rexray"
+        s.privileged = true
+        s.inline = $build_rexray
+      end
+    end
+
+    # work around bug in Vagrant 1.9.1
+    config.vm.provision "shell", privileged: true, inline: <<-SHELL
+      service network restart
+    SHELL
+
+    admin.vm.provision "shell", privileged: false, path: "cephconfig.sh", args: server_nodes
+    admin.vm.provision "shell", privileged: false, path: "rexconfig.sh"
+    admin.vm.provision "shell", privileged: true, inline: <<-SHELL
+      systemctl restart rexray
+    SHELL
+    admin.vm.provision "copyrex", type: "shell", privileged: false, inline: <<-SHELL
+      scp /usr/bin/rexray libstorage-rbd-test-client:
+      ssh libstorage-rbd-test-client "sudo mv ~vagrant/rexray /usr/bin && sudo systemctl restart rexray"
+    SHELL
+
+    # Run the tests
+    admin.vm.provision "tests", type: "shell", privileged: false, path: "tests.sh"
+  end
+end

--- a/drivers/storage/rbd/tests/cephconfig.sh
+++ b/drivers/storage/rbd/tests/cephconfig.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -x
+
+NUM_NODES=$1
+
+if [ -e /etc/ceph/ceph.conf ]; then
+  echo "skipping Ceph config because it's been done before"
+  exit 0
+fi
+
+tee ~/.ssh/config << EOF
+Host *
+   StrictHostKeyChecking no
+   UserKnownHostsFile=/dev/null
+EOF
+
+chmod 0600 ~/.ssh/config
+
+#Configure Ceph
+
+if [ $NUM_NODES -ge 3 ]; then
+	ceph-deploy new libstorage-rbd-test-server1 libstorage-rbd-test-server2 libstorage-rbd-test-server3
+else
+	ceph-deploy new libstorage-rbd-test-server1
+fi
+
+if [ $NUM_NODES == 1 ]; then
+	tee -a ceph.conf << EOF
+osd pool default size = 1
+osd pool default min size = 1
+osd crush chooseleaf type = 0
+EOF
+
+elif [ $NUM_NODES == 2 ]; then
+	tee -a ceph.conf << EOF
+osd pool default size = 2
+osd pool default min size = 1
+EOF
+
+fi
+
+ceph-deploy mon create-initial
+for x in $(seq 1 $NUM_NODES); do
+	ceph-deploy osd create --zap-disk libstorage-rbd-test-server$x:/dev/sdb
+done
+ceph-deploy admin localhost libstorage-rbd-test-client

--- a/drivers/storage/rbd/tests/coverage.mk
+++ b/drivers/storage/rbd/tests/coverage.mk
@@ -1,0 +1,2 @@
+RBD_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/rbd
+TEST_COVERPKG_./drivers/storage/rbd/tests := $(RBD_COVERPKG),$(RBD_COVERPKG)/executor

--- a/drivers/storage/rbd/tests/rbd_test.go
+++ b/drivers/storage/rbd/tests/rbd_test.go
@@ -1,0 +1,385 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_rbd
+
+package rbd
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	gofig "github.com/akutz/gofig/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/codedellemc/libstorage/api/server"
+	apitests "github.com/codedellemc/libstorage/api/tests"
+	"github.com/codedellemc/libstorage/api/types"
+
+	// load the  driver
+	"github.com/codedellemc/libstorage/drivers/storage/rbd"
+	rbdx "github.com/codedellemc/libstorage/drivers/storage/rbd/executor"
+)
+
+const (
+	defaultPool = "rbd"
+)
+
+var (
+	configYAML = []byte(`
+rbd:
+  defaultPool: rbd
+`)
+)
+
+var volumeName string
+var volumeName2 string
+
+func skipTests() bool {
+	travis, _ := strconv.ParseBool(os.Getenv("TRAVIS"))
+	noTest, _ := strconv.ParseBool(os.Getenv("TEST_SKIP_RBD"))
+	return travis || noTest
+}
+
+func init() {
+	uuid, _ := types.NewUUID()
+	uuids := strings.Split(uuid.String(), "-")
+	volumeName = uuids[0]
+	volumeName2 = uuids[1]
+}
+
+func TestMain(m *testing.M) {
+	server.CloseOnAbort()
+	ec := m.Run()
+	os.Exit(ec)
+}
+
+// Test that the default behavior just works -- reads a real config file
+// and the real IP/route information from machine under test
+func TestInstanceID(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	iid, err := rbdx.GetInstanceID(nil, nil)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed TestInstanceID")
+		t.FailNow()
+	}
+
+	assert.NotEqual(t, iid, "")
+
+	apitests.Run(
+		t, rbd.Name, configYAML,
+		(&apitests.InstanceIDTest{
+			Driver:   rbd.Name,
+			Expected: iid,
+		}).Test)
+}
+
+// Seed the function with known addresses to verify that the right ones
+// are selected
+type testIPInput struct {
+	monIPs     []net.IP
+	interfaces []net.Addr
+	iid        net.IP
+}
+
+type dummyAddr struct {
+	ip net.IP
+}
+
+func (a *dummyAddr) Network() string {
+	return "dummy"
+}
+
+func (a *dummyAddr) String() string {
+	return fmt.Sprintf("%s/24", a.ip.String())
+}
+
+var (
+	ipZeroDotTwo    = net.ParseIP("192.168.0.2")
+	ipOneDotTwo     = net.ParseIP("192.168.1.2")
+	ipZeroDotTen    = net.ParseIP("192.168.0.10")
+	ipZeroDotTwenty = net.ParseIP("192.168.0.20")
+	ipZeroDotThirty = net.ParseIP("192.168.0.30")
+)
+
+var testIPs = []testIPInput{
+	// Test direct L2 connection with single monitor
+	{
+		monIPs:     []net.IP{ipZeroDotTen},
+		interfaces: []net.Addr{&dummyAddr{ipZeroDotTwo}},
+		iid:        ipZeroDotTwo,
+	},
+	// Test direct L2 connection with multiple monitors,
+	// multiple local networks
+	{
+		monIPs: []net.IP{
+			ipZeroDotTen, ipZeroDotTwenty, ipZeroDotThirty,
+		},
+		interfaces: []net.Addr{
+			&dummyAddr{ipOneDotTwo}, &dummyAddr{ipZeroDotTwo},
+		},
+		iid: ipZeroDotTwo,
+	},
+	// Test L3 connection (routing required)
+	{
+		monIPs: []net.IP{
+			ipZeroDotTen, ipZeroDotTwenty, ipZeroDotThirty,
+		},
+		interfaces: []net.Addr{&dummyAddr{ipOneDotTwo}},
+		iid:        nil,
+	},
+}
+
+func TestInstanceIDSimulatedIPs(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	for _, test := range testIPs {
+		iid, err := rbdx.GetInstanceID(test.monIPs, test.interfaces)
+
+		assert.NoError(t, err)
+		if err != nil {
+			t.Error("failed TestInstanceIDSimulatedIPs")
+			t.FailNow()
+		}
+		assert.NotEqual(t, iid, "")
+		if test.iid != nil {
+			assert.True(t, test.iid.Equal(net.ParseIP(iid.ID)))
+		}
+	}
+}
+
+func TestServices(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		reply, err := client.API().Services(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, len(reply), 1)
+
+		_, ok := reply[rbd.Name]
+		assert.True(t, ok)
+	}
+	apitests.Run(t, rbd.Name, configYAML, tf)
+}
+
+func volumeCreate(
+	t *testing.T,
+	client types.Client,
+	volumeName string,
+	pool string) *types.Volume {
+
+	log.WithField("volumeName", volumeName).Info("creating volume")
+	size := int64(8)
+
+	opts := map[string]interface{}{
+		"priority": 2,
+		"owner":    "root@example.com",
+	}
+
+	volumeCreateRequest := &types.VolumeCreateRequest{
+		Name: volumeName,
+		Size: &size,
+		Opts: opts,
+	}
+
+	reply, err := client.API().VolumeCreate(nil, rbd.Name, volumeCreateRequest)
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+		t.Error("failed volumeCreate")
+	}
+	apitests.LogAsJSON(reply, t)
+
+	assert.Equal(t, volumeName, reply.Name)
+	assert.Equal(t, size, reply.Size)
+	assert.Equal(t, pool, reply.Type)
+	assert.Equal(t, pool+"."+volumeName, reply.ID)
+	return reply
+}
+
+func volumeRemove(t *testing.T, client types.Client, volumeID string) {
+	log.WithField("volumeID", volumeID).Info("removing volume")
+	err := client.API().VolumeRemove(
+		nil, rbd.Name, volumeID)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeRemove")
+		t.FailNow()
+	}
+}
+
+func TestVolumeCreateRemove(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		vol := volumeCreate(t, client, volumeName, defaultPool)
+		volumeRemove(t, client, vol.ID)
+	}
+	apitests.Run(t, rbd.Name, configYAML, tf)
+}
+
+func volumeByName(
+	t *testing.T, client types.Client, volumeName string) *types.Volume {
+
+	log.WithField("volumeName", volumeName).Info("get volume name")
+	vols, err := client.API().Volumes(nil, 0)
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+	}
+	assert.Contains(t, vols, rbd.Name)
+	for _, vol := range vols[rbd.Name] {
+		if vol.Name == volumeName {
+			return vol
+		}
+	}
+	t.FailNow()
+	t.Error("failed volumeByName")
+	return nil
+}
+
+func TestVolumes(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		_ = volumeCreate(t, client, volumeName, defaultPool)
+		_ = volumeCreate(t, client, volumeName2, defaultPool)
+
+		vol1 := volumeByName(t, client, volumeName)
+		vol2 := volumeByName(t, client, volumeName2)
+
+		volumeRemove(t, client, vol1.ID)
+		volumeRemove(t, client, vol2.ID)
+	}
+	apitests.Run(t, rbd.Name, configYAML, tf)
+}
+
+func volumeAttach(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("attaching volume")
+	reply, token, err := client.API().VolumeAttach(
+		nil, rbd.Name, volumeID, &types.VolumeAttachRequest{})
+
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeAttach")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.NotEqual(t, token, "")
+
+	return reply
+}
+
+func volumeDetach(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("detaching volume")
+	reply, err := client.API().VolumeDetach(
+		nil, rbd.Name, volumeID, &types.VolumeDetachRequest{})
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeDetach")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.Len(t, reply.Attachments, 0)
+	return reply
+}
+
+func volumeInspect(
+	t *testing.T,
+	client types.Client,
+	volumeID string,
+	attachFlag types.VolumeAttachmentsTypes) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("inspecting volume")
+	reply, err := client.API().VolumeInspect(
+		nil, rbd.Name, volumeID, attachFlag)
+	assert.NoError(t, err)
+
+	if err != nil {
+		t.Error("failed volumeInspect")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	return reply
+}
+
+func volumeInspectAttached(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	reply := volumeInspect(t, client, volumeID, types.VolAttReqForInstance)
+	assert.Len(t, reply.Attachments, 1)
+	assert.Equal(t, "", reply.Attachments[0].DeviceName)
+	return reply
+}
+
+func volumeInspectNoAttachments(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	reply := volumeInspect(t, client, volumeID, types.VolAttFalse)
+	assert.Len(t, reply.Attachments, 0)
+	return reply
+}
+
+func volumeInspectAttachedDevices(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	reply := volumeInspect(t, client, volumeID,
+		types.VolAttReqWithDevMapForInstance)
+	assert.Len(t, reply.Attachments, 1)
+	assert.NotEqual(t, "", reply.Attachments[0].DeviceName)
+	return reply
+}
+
+func volumeInspectDetached(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	reply := volumeInspect(t, client, volumeID, types.VolAttReq)
+	assert.Len(t, reply.Attachments, 0)
+	return reply
+}
+
+func volumeInspectAvailable(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	reply := volumeInspect(t, client, volumeID,
+		types.VolAttReqOnlyUnattachedVols)
+	assert.Len(t, reply.Attachments, 0)
+	return reply
+}
+
+func TestVolumeAttach(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+	var vol *types.Volume
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		vol = volumeCreate(t, client, volumeName, defaultPool)
+		_ = volumeAttach(t, client, vol.ID)
+		_ = volumeInspectAttached(t, client, vol.ID)
+		_ = volumeInspectAttachedDevices(t, client, vol.ID)
+		_ = volumeInspectNoAttachments(t, client, vol.ID)
+		_ = volumeDetach(t, client, vol.ID)
+		_ = volumeInspectDetached(t, client, vol.ID)
+		_ = volumeInspectAvailable(t, client, vol.ID)
+		volumeRemove(t, client, vol.ID)
+	}
+	apitests.Run(t, rbd.Name, configYAML, tf)
+}

--- a/drivers/storage/rbd/tests/rexconfig.sh
+++ b/drivers/storage/rbd/tests/rexconfig.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+sudo tee /etc/rexray/config.yml << EOF
+rexray:
+  logLevel: warn
+libstorage:
+  service: rbd
+  volume:
+    mount:
+      preempt: false
+EOF

--- a/drivers/storage/rbd/tests/tests.sh
+++ b/drivers/storage/rbd/tests/tests.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Show everything
+set -x
+
+# Exit on error
+set -e
+
+# install jq to make json parsing easy
+sudo yum install -y jq
+
+# start with a clean slate
+EXISTING=$(docker ps --filter 'name=rbdtest' -q)
+if [ ! ${EXISTING} == "" ]; then
+	docker stop ${EXISTING} && docker rm ${EXISTING}
+fi
+EXISTING=$(docker volume ls -q)
+if [ ! ${EXISTING} == "" ]; then
+	docker volume rm ${EXISTING}
+fi
+
+# Make sure we can create a volume via docker plugin
+docker volume create --driver rexray --name rbd_test
+
+# Make sure we can inspect it
+docker volume inspect rbd_test
+
+docker volume rm rbd_test
+
+# Create a volume with custom size and make sure its correct
+docker volume create --driver rexray --name rbd_test --opt size=4
+
+SIZE=$(docker volume inspect rbd_test -f '{{ .Status.size }}')
+if [ ! ${SIZE} -eq 4 ]; then
+	exit 1
+fi
+
+docker volume rm rbd_test
+
+# Create an implicit volume and make sure it shows up as attached in rexray
+docker run -d --volume-driver rexray -v rbd_test:/test --name rbdtest busybox tail -f /dev/null
+docker volume inspect rbd_test
+ATTACH_STATE=$(sudo rexray volume get rbd_test --format json | jq -r '.[0].attachmentState')
+if [ ! ${ATTACH_STATE} -eq 2 ]; then
+	exit 1
+fi
+
+# Check that volume is listed as unavailabe on remote hostmanager
+ATTACH_STATE=$(ssh libstorage-rbd-test-client sudo rexray volume get rbd_test --format json | jq -r '.[0].attachmentState')
+if [ ! ${ATTACH_STATE} -eq 4 ]; then
+	exit 1
+fi
+
+# Stop docker container and verify volume is now available
+docker stop rbdtest && docker rm rbdtest
+ATTACH_STATE=$(sudo rexray volume get rbd_test --format json | jq -r '.[0].attachmentState')
+if [ ! ${ATTACH_STATE} -eq 3 ]; then
+	exit 1
+fi
+
+docker volume rm rbd_test

--- a/drivers/storage/rbd/utils/utils.go
+++ b/drivers/storage/rbd/utils/utils.go
@@ -1,0 +1,343 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_rbd
+
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/akutz/goof"
+)
+
+const (
+	cephCmd   = "ceph"
+	rbdCmd    = "rbd"
+	formatOpt = "--format"
+	jsonArg   = "json"
+	poolOpt   = "--pool"
+
+	bytesPerGiB = 1024 * 1024 * 1024
+)
+
+type rbdMappedEntry struct {
+	Device string `json:"device"`
+	Name   string `json:"name"`
+	Pool   string `json:"pool"`
+	Snap   string `json:"snap"`
+}
+
+//RBDImage holds details about an RBD image
+type RBDImage struct {
+	Name   string `json:"image"`
+	Size   int64  `json:"size"`
+	Format uint   `json:"format"`
+	Pool   string
+}
+
+//RBDInfo holds low-level details about an RBD image
+type RBDInfo struct {
+	Name            string   `json:"name"`
+	Size            int64    `json:"size"`
+	Objects         int64    `json:"objects"`
+	Order           int64    `json:"order"`
+	ObjectSize      int64    `json:"object_size"`
+	BlockNamePrefix string   `json:"block_name_prefix"`
+	Format          int64    `json:"format"`
+	Features        []string `json:"features"`
+	Pool            string
+}
+
+//GetRadosPools returns a slice containing all the pool names
+func GetRadosPools() ([]*string, error) {
+
+	cmd := exec.Command(cephCmd, "osd", "pool", "ls", formatOpt, jsonArg)
+	log.Debugf("running command: %v", cmd.Args)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exiterr.Stderr)
+			log.Errorf("Unable to get pools: %s", stderr)
+			return nil,
+				goof.Newf("Unable to get pools: %s", stderr)
+		}
+		return nil, goof.WithError("Unable to get pools", err)
+	}
+
+	var pools []string
+	err = json.Unmarshal(out, &pools)
+	if err != nil {
+		return nil, goof.WithError(
+			"Unable to parse ceph lspools", err)
+	}
+
+	return ConvStrArrayToPtr(pools), nil
+}
+
+//GetRBDImages returns a slice of RBD image info
+func GetRBDImages(pool *string) ([]*RBDImage, error) {
+
+	cmd := exec.Command(rbdCmd, "ls", "-p", *pool, "-l", formatOpt, jsonArg)
+	log.Debugf("running command: %v", cmd.Args)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exiterr.Stderr)
+			log.Errorf("Unable to get rbd images: %s", stderr)
+			return nil,
+				goof.Newf("Unable to get rbd images: %s",
+					stderr)
+		}
+		return nil, goof.WithError("Unable to get rbd images", err)
+	}
+
+	var rbdList []*RBDImage
+
+	err = json.Unmarshal(out, &rbdList)
+	if err != nil {
+		return nil, goof.WithError(
+			"Unable to parse rbd ls", err)
+	}
+
+	for _, info := range rbdList {
+		info.Pool = *pool
+	}
+
+	return rbdList, nil
+}
+
+//GetRBDInfo gets low-level details about an RBD image
+func GetRBDInfo(pool *string, name *string) (*RBDInfo, error) {
+
+	cmd := exec.Command(
+		rbdCmd, "info", "-p", *pool, *name, formatOpt, jsonArg)
+
+	log.Debugf("running command: %v", cmd.Args)
+
+	out, err := cmd.Output()
+
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				if status.ExitStatus() == 2 {
+					// image does not exist
+					return nil, nil
+				}
+			}
+			stderr := string(exiterr.Stderr)
+			log.Errorf("Unable to get rbd info: %s", stderr)
+			return nil,
+				goof.Newf("Unable to get rbd info: %s",
+					stderr)
+		}
+		return nil, goof.WithError("Unable to get rbd info", err)
+	}
+
+	info := &RBDInfo{}
+
+	err = json.Unmarshal(out, info)
+	if err != nil {
+		return nil, goof.WithError(
+			"Unable to parse rbd info", err)
+	}
+
+	info.Pool = *pool
+
+	return info, nil
+}
+
+//GetVolumeID returns an RBD Volume formatted as <pool>.<imageName>
+func GetVolumeID(pool, image *string) *string {
+
+	volumeID := fmt.Sprintf("%s.%s", *pool, *image)
+	return &volumeID
+}
+
+//GetMappedRBDs returns a map of RBDs currently mapped to the *local* host
+func GetMappedRBDs() (map[string]string, error) {
+
+	out, err := exec.Command(
+		rbdCmd, "showmapped", formatOpt, jsonArg).Output()
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exiterr.Stderr)
+			log.Errorf("Unable to get rbd map: %s", stderr)
+			return nil,
+				goof.Newf("Unable to get RBD map: %s",
+					stderr)
+		}
+		return nil, goof.WithError("Unable to get RBD map", err)
+	}
+
+	devMap := map[string]string{}
+	rbdMap := map[string]*rbdMappedEntry{}
+
+	err = json.Unmarshal(out, &rbdMap)
+	if err != nil {
+		return nil, goof.WithError(
+			"Unable to parse rbd showmapped", err)
+	}
+
+	for _, mapped := range rbdMap {
+		volumeID := GetVolumeID(&mapped.Pool, &mapped.Name)
+		devMap[*volumeID] = mapped.Device
+	}
+
+	return devMap, nil
+}
+
+//RBDCreate creates a new RBD volume on the cluster
+func RBDCreate(
+	pool *string,
+	image *string,
+	sizeGB *int64,
+	objectSize *string,
+	features []*string) error {
+
+	cmd := exec.Command(
+		rbdCmd, "create", poolOpt, *pool,
+		"--object-size", *objectSize,
+		"--size", strconv.FormatInt(*sizeGB, 10)+"G",
+	)
+
+	for _, feature := range features {
+		cmd.Args = append(cmd.Args, "--image-feature")
+		cmd.Args = append(cmd.Args, *feature)
+	}
+
+	cmd.Args = append(cmd.Args, *image)
+	log.Debugf("running command: %v", cmd.Args)
+
+	err := cmd.Run()
+
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exiterr.Stderr)
+			log.Errorf("Unable to create RBD: %s", stderr)
+			return goof.Newf("Unable to create RBD: %s",
+				stderr)
+		}
+		return goof.WithError("Unable to create RBD", err)
+	}
+
+	return nil
+}
+
+//RBDRemove deletes the RBD volume on the cluster
+func RBDRemove(pool *string, image *string) error {
+	cmd := exec.Command(rbdCmd, "rm", poolOpt, *pool, "--no-progress",
+		*image,
+	)
+	log.Debugf("running command: %v", cmd.Args)
+
+	err := cmd.Run()
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exiterr.Stderr)
+			log.Errorf("Unable to delete RBD: %s", stderr)
+			return goof.Newf("Error deleting RBD: %s",
+				stderr)
+		}
+		return goof.WithError("Error deleting RBD", err)
+	}
+
+	return nil
+}
+
+//RBDMap attaches the given RBD image to the *local* host
+func RBDMap(pool, image *string) (string, error) {
+
+	cmd := exec.Command(rbdCmd, "map", poolOpt, *pool, *image)
+	log.Debugf("running command: %v", cmd.Args)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exiterr.Stderr)
+			log.Errorf("Unable to map RBD: %s", stderr)
+			return "",
+				goof.Newf("Unable to map RBD: %s",
+					stderr)
+		}
+		return "", goof.WithError("Unable to map RBD", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+//RBDUnmap detaches the given RBD device from the *local* host
+func RBDUnmap(device *string) error {
+
+	cmd := exec.Command(rbdCmd, "unmap", *device)
+	log.Debugf("running command: %v", cmd.Args)
+
+	err := cmd.Run()
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exiterr.Stderr)
+			log.Errorf("Unable to unmap RBD: %s", stderr)
+			return goof.Newf("Unable to unmap RBD: %s",
+				stderr)
+		}
+		return goof.WithError("Unable to unmap RBD", err)
+	}
+
+	return nil
+}
+
+//GetRBDStatus returns a map of RBD status info
+func GetRBDStatus(pool, image *string) (map[string]interface{}, error) {
+
+	cmd := exec.Command(
+		rbdCmd, "status", poolOpt, *pool, *image, formatOpt, jsonArg,
+	)
+	log.Debugf("running command: %v", cmd.Args)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exiterr.Stderr)
+			log.Errorf("Unable to get RBD status: %s", stderr)
+			return nil, goof.Newf("Unable to get RBD status: %s",
+				stderr)
+		}
+		return nil, goof.WithError("Unable to get RBD status", err)
+	}
+
+	watcherMap := map[string]interface{}{}
+
+	err = json.Unmarshal(out, &watcherMap)
+	if err != nil {
+		return nil, goof.WithError(
+			"Unable to parse rbd status", err)
+	}
+
+	return watcherMap, nil
+}
+
+//RBDHasWatchers returns true if RBD image has watchers
+func RBDHasWatchers(pool *string, image *string) (bool, error) {
+
+	m, err := GetRBDStatus(pool, image)
+	if err != nil {
+		return false, err
+	}
+
+	return len(m["watchers"].(map[string]interface{})) > 0, nil
+}
+
+//ConvStrArrayToPtr converts the slice of strings to a slice of pointers to str
+func ConvStrArrayToPtr(strArr []string) []*string {
+	ptrArr := make([]*string, len(strArr))
+	for i := range strArr {
+		ptrArr[i] = &strArr[i]
+	}
+	return ptrArr
+}

--- a/imports/executors/imports_executor.go
+++ b/imports/executors/imports_executor.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/codedellemc/libstorage/drivers/storage/ebs/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/efs/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/isilon/executor"
+	_ "github.com/codedellemc/libstorage/drivers/storage/rbd/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/scaleio/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/vbox/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/vfs/executor"

--- a/imports/executors/imports_executor_rbd.go
+++ b/imports/executors/imports_executor_rbd.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_executor,libstorage_storage_executor_rbd
+
+package executors
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/rbd/executor"
+)

--- a/imports/remote/imports_remote.go
+++ b/imports/remote/imports_remote.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/codedellemc/libstorage/drivers/storage/ebs/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/efs/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/isilon/storage"
+	_ "github.com/codedellemc/libstorage/drivers/storage/rbd/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/scaleio/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/vbox/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/vfs/storage"

--- a/imports/remote/imports_remote_rbd.go
+++ b/imports/remote/imports_remote_rbd.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_driver,libstorage_storage_driver_rbd
+
+package remote
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/rbd/storage"
+)


### PR DESCRIPTION
This PR introduces the "rbd" storage driver, for interace with Ceph RBD devices.

This implementation does not use `go-ceph`, and therefore does not introduce new external dependencies. Instead it execs calls to the `rbd` executable, and parses the `json` output.