### PR TITLE
Fix for Path Initialization Logging

### DIFF
--- a/api/types/types_paths.go
+++ b/api/types/types_paths.go
@@ -293,7 +293,9 @@ func checkPerms(k fileKey, mustPerm bool) bool {
 			log.WithField("path", p).Debug("file exists")
 		}
 	} else {
-		log.WithFields(fields).Info("making libStorage directory")
+		if Debug {
+			log.WithFields(fields).Info("making libStorage directory")
+		}
 		noPermMkdirErr := fmt.Sprintf("mkdir %s: permission denied", p)
 		if err := os.MkdirAll(p, k.perms()); err != nil {
 			if err.Error() == noPermMkdirErr {


### PR DESCRIPTION
This patch wraps part of the path initialization logging inside a logic branch that requires the `LIBSTORAGE_DEBUG` environment variable to be set to true to prevent the initialization logging from occurring at all times.