### PR TITLE
Updated Build Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,16 @@ go_import_path: github.com/codedellemc/libstorage
 language: go
 go:
   - 1.6.3
-  - 1.7.3
+  - 1.7.4
   - tip
 
 os:
   - linux
-  - osx
 
 matrix:
   allow_failures:
+    - go: 1.6.3
     - go: tip
-    - os: osx
   fast_finish: true
 
 before_install:


### PR DESCRIPTION
This updates the libStorage build matrix to no longer build OS X as a stand-alone OS build as it's build via Go cross-compilation. Additionally, the build matrix now targets Go 1.6.3, 1.7.4, and the tip with only 1.7.4's success being required to have a successful build.