### PR TITLE
Custom Encryption Key

### DIFF
--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -338,6 +338,7 @@ ebs:
   accessKey:      XXXXXXXXXX
   secretKey:      XXXXXXXXXX
   region:         us-east-1
+  kmsKeyID:       arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef
 ```
 
 #### Configuration Notes
@@ -349,6 +350,8 @@ access credentials, like environment variables or instance profile IAM permissio
 See official AWS documentation for list of supported regions.
 <!-- - `tag` is used to partition multiple services within single AWS account and is
 used as prefix for EBS names in format `[tagprefix]/volumeName`. -->
+- If the `kmsKeyID` field is specified it will be used as the encryption key for
+all volumes that are created with a truthy encryption request field.
 
 For information on the equivalent environment variable and CLI flag names
 please see the section on how non top-level configuration properties are

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -410,6 +410,7 @@ func (r *router) volumeCreate(
 				Size:             store.GetInt64Ptr("size"),
 				Type:             store.GetStringPtr("type"),
 				Encrypted:        store.GetBoolPtr("encrypted"),
+				EncryptionKey:    store.GetStringPtr("encryptionKey"),
 				Opts:             store,
 			})
 

--- a/api/types/types_drivers_storage.go
+++ b/api/types/types_drivers_storage.go
@@ -228,6 +228,7 @@ type VolumeCreateOpts struct {
 	Size             *int64
 	Type             *string
 	Encrypted        *bool
+	EncryptionKey    *string
 	Opts             Store
 }
 

--- a/api/types/types_http_requests.go
+++ b/api/types/types_http_requests.go
@@ -9,6 +9,7 @@ type VolumeCreateRequest struct {
 	Name             string                 `json:"name"`
 	AvailabilityZone *string                `json:"availabilityZone,omitempty"`
 	Encrypted        *bool                  `json:"encrypted,omitempty"`
+	EncryptionKey    *string                `json:"encryptionKey,omitempty"`
 	IOPS             *int64                 `json:"iops,omitempty"`
 	Size             *int64                 `json:"size,omitempty"`
 	Type             *string                `json:"type,omitempty"`

--- a/api/utils/schema/schema_generated.go
+++ b/api/utils/schema/schema_generated.go
@@ -436,6 +436,9 @@ const (
                 "encrypted": {
                     "type": "boolean"
                 },
+                "encryptionKey": {
+                    "type": "string"
+                },
                 "iops": {
                     "type": "number"
                 },

--- a/drivers/storage/ebs/ebs.go
+++ b/drivers/storage/ebs/ebs.go
@@ -46,6 +46,20 @@ const (
 
 	// Tag is a key constant.
 	Tag = "tag"
+
+	// KmsKeyID is the full ARN of the AWS Key Management Service (AWS KMS)
+	// customer master key (CMK) to use when creating the encrypted volume.
+	//
+	// This parameter is only required if you want to use a non-default CMK;
+	// if this parameter is not specified, the default CMK for EBS is used.
+	// The ARN contains the arn:aws:kms namespace, followed by the region of
+	// the CMK, the AWS account ID of the CMK owner, the key namespace, and
+	// then the CMK ID. For example,
+	// arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef.
+	//
+	// If a KmsKeyID is specified, all volumes will be created with their
+	// Encrypted flag set to true.
+	KmsKeyID = "kmsKeyID"
 )
 
 func init() {
@@ -56,6 +70,7 @@ func init() {
 	r.Key(gofig.String, "", "", "", Name+"."+Endpoint)
 	r.Key(gofig.Int, "", DefaultMaxRetries, "", Name+"."+MaxRetries)
 	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", Name+"."+Tag)
+	r.Key(gofig.String, "", "", "", Name+"."+KmsKeyID)
 
 	r.Key(gofig.String, "", "", "", NameEC2+"."+AccessKey)
 	r.Key(gofig.String, "", "", "", NameEC2+"."+SecretKey)
@@ -63,6 +78,7 @@ func init() {
 	r.Key(gofig.String, "", "", "", NameEC2+"."+Endpoint)
 	r.Key(gofig.Int, "", DefaultMaxRetries, "", NameEC2+"."+MaxRetries)
 	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", NameEC2+"."+Tag)
+	r.Key(gofig.String, "", "", "", NameEC2+"."+KmsKeyID)
 
 	r.Key(gofig.String, "", "", "", NameAWS+"."+AccessKey)
 	r.Key(gofig.String, "", "", "", NameAWS+"."+SecretKey)
@@ -70,5 +86,7 @@ func init() {
 	r.Key(gofig.String, "", "", "", NameAWS+"."+Endpoint)
 	r.Key(gofig.Int, "", DefaultMaxRetries, "", NameAWS+"."+MaxRetries)
 	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", NameAWS+"."+Tag)
+	r.Key(gofig.String, "", "", "", NameAWS+"."+KmsKeyID)
+
 	gofigCore.Register(r)
 }

--- a/drivers/storage/ebs/ebs_config_compat.go
+++ b/drivers/storage/ebs/ebs_config_compat.go
@@ -30,6 +30,9 @@ const (
 	// ConfigEBSRexrayTag is a config key.
 	ConfigEBSRexrayTag = ConfigEBS + ".rexrayTag"
 
+	// ConfigEBSKmsKeyID is a config key.
+	ConfigEBSKmsKeyID = ConfigEBS + "." + KmsKeyID
+
 	// ConfigEC2 is a config key.
 	ConfigEC2 = "ec2"
 
@@ -54,6 +57,9 @@ const (
 	// ConfigEC2RexrayTag is a config key.
 	ConfigEC2RexrayTag = ConfigEC2 + ".rexrayTag"
 
+	// ConfigEC2KmsKeyID is a config key.
+	ConfigEC2KmsKeyID = ConfigEC2 + "." + KmsKeyID
+
 	// ConfigAWS is a config key.
 	ConfigAWS = "aws"
 
@@ -77,6 +83,9 @@ const (
 
 	// ConfigAWSRexrayTag is a config key.
 	ConfigAWSRexrayTag = ConfigAWS + ".rexrayTag"
+
+	// ConfigAWSKmsKeyID is a config key.
+	ConfigAWSKmsKeyID = ConfigAWS + "." + KmsKeyID
 )
 
 // BackCompat ensures keys can be used from old configurations.
@@ -89,6 +98,7 @@ func BackCompat(config gofig.Config) {
 		{ConfigEBSMaxRetries, ConfigEC2MaxRetries},
 		{ConfigEBSTag, ConfigEC2Tag},
 		{ConfigEBSRexrayTag, ConfigEC2RexrayTag},
+		{ConfigEBSKmsKeyID, ConfigEC2KmsKeyID},
 	}
 	for _, check := range ec2Checks {
 		if !config.IsSet(check[0]) && config.IsSet(check[1]) {
@@ -105,6 +115,7 @@ func BackCompat(config gofig.Config) {
 		{ConfigEBSMaxRetries, ConfigAWSMaxRetries},
 		{ConfigEBSTag, ConfigAWSTag},
 		{ConfigEBSRexrayTag, ConfigAWSRexrayTag},
+		{ConfigEBSKmsKeyID, ConfigAWSKmsKeyID},
 	}
 	for _, check := range awsChecks {
 		if !config.IsSet(check[0]) && config.IsSet(check[1]) {

--- a/libstorage.apib
+++ b/libstorage.apib
@@ -934,6 +934,8 @@ Create a new volume.
 
         + name (string, required) - The volume name
         + availabilityZone (string, optional) - The zone for which the volume is available
+        + encrypted (boolean, optional) - A flag that indicates whether or not to request volume encryption.
+        + encryptionKey (string, optional) - The encryption key to use when encrypting the volume.
         + iops (number, optional) - The volume IOPs
         + size (number, optional) - The volume size (GB)
         + type (string, optional) - The volume type

--- a/libstorage.json
+++ b/libstorage.json
@@ -432,6 +432,9 @@
                 "encrypted": {
                     "type": "boolean"
                 },
+                "encryptionKey": {
+                    "type": "string"
+                },
                 "iops": {
                     "type": "number"
                 },


### PR DESCRIPTION
This patch adds the ability to specify a custom encryption key when creating a new volume using the field `EncryptionKey`. The EBS driver also supports specifying this key in the central configuration file using the property `ebs.kmsKeyID`.

@codenrhoden I'd appreciate it if you could review this PR if you have time. Thanks!