### PR TITLE
Build Tag Activated Drivers/Executors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,19 @@ go:
 os:
   - linux
 
+env:
+  - BUILD_TAGS="gofig pflag libstorage_integration_driver_docker libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
+  - BUILD_TAGS="gofig pflag libstorage_integration_driver_docker"
+  - BUILD_TAGS=""
+
 matrix:
   allow_failures:
-    - go: 1.6.3
-    - go: tip
+    - go:  1.6.3
+    - go:  tip
   fast_finish: true
 
 before_install:
+  - if [ "$BUILD_TAGS" = "$DEFAULT_BUILD_TAGS" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ]; then echo coverage enabled; fi
   - git config --global 'url.https://gopkg.in/yaml.v1.insteadof' 'https://gopkg.in/yaml.v1/'
   - git config --global 'url.https://gopkg.in/yaml.v2.insteadof' 'https://gopkg.in/yaml.v2/'
   - git config --global 'url.https://gopkg.in/fsnotify.v1.insteadof' 'https://gopkg.in/fsnotify.v1/'
@@ -28,12 +34,11 @@ before_install:
 script:
   - make gometalinter-all
   - make -j build
-  - make -j test
-  - VFS_INSTANCEID_USE_FIELDS=true ./drivers/storage/vfs/tests/vfs.test
-  - go clean -i ./client && go build ./client
+  - if [ "$BUILD_TAGS" = "$DEFAULT_BUILD_TAGS" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ]; then make -j test; fi
+  - if [ "$BUILD_TAGS" = "$DEFAULT_BUILD_TAGS" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ]; then VFS_INSTANCEID_USE_FIELDS=true ./drivers/storage/vfs/tests/vfs.test; fi
 
 after_success:
-  - make -j cover
+  - if [ "$BUILD_TAGS" = "$DEFAULT_BUILD_TAGS" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ]; then make -j cover; fi
 
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 SHELL := /bin/bash
 
 ifeq (undefined,$(origin BUILD_TAGS))
-BUILD_TAGS := gofig pflag libstorage_integration_driver_docker
+BUILD_TAGS :=   gofig \
+				pflag \
+				libstorage_integration_driver_docker
+ifneq (true,$(TRAVIS))
+BUILD_TAGS +=   libstorage_storage_driver \
+				libstorage_storage_driver_vfs \
+				libstorage_storage_executor \
+				libstorage_storage_executor_vfs
+endif
 endif
 
 all:
@@ -184,7 +192,7 @@ else
 GOVERSION := $(shell go version | awk '{print $$3}' | cut -c3-)
 endif
 
-ifeq (1.7.1,$(TRAVIS_GO_VERSION))
+ifeq (1.7.4,$(TRAVIS_GO_VERSION))
 ifeq (linux,$(TRAVIS_OS_NAME))
 COVERAGE_ENABLED := 1
 endif

--- a/drivers/storage/ebs/ebs.go
+++ b/drivers/storage/ebs/ebs.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_ebs
+
 package ebs
 
 import (

--- a/drivers/storage/ebs/ebs_config_compat.go
+++ b/drivers/storage/ebs/ebs_config_compat.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_ebs
+
 package ebs
 
 import (

--- a/drivers/storage/ebs/executor/ebs_executor.go
+++ b/drivers/storage/ebs/executor/ebs_executor.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_executor libstorage_storage_executor_ebs
+
 package executor
 
 import (

--- a/drivers/storage/ebs/storage/ebs_storage.go
+++ b/drivers/storage/ebs/storage/ebs_storage.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_ebs
+
 package storage
 
 import (

--- a/drivers/storage/ebs/tests/ebs_test.go
+++ b/drivers/storage/ebs/tests/ebs_test.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_ebs
+
 package ebs
 
 import (

--- a/drivers/storage/ebs/utils/utils.go
+++ b/drivers/storage/ebs/utils/utils.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_ebs
+
 package utils
 
 import (

--- a/drivers/storage/ebs/utils/utils_go17.go
+++ b/drivers/storage/ebs/utils/utils_go17.go
@@ -1,4 +1,5 @@
 // +build go1.7
+// +build !libstorage_storage_driver libstorage_storage_driver_ebs
 
 package utils
 

--- a/drivers/storage/ebs/utils/utils_pre_go17.go
+++ b/drivers/storage/ebs/utils/utils_pre_go17.go
@@ -1,4 +1,5 @@
 // +build !go1.7
+// +build !libstorage_storage_driver libstorage_storage_driver_ebs
 
 package utils
 

--- a/drivers/storage/ebs/utils/utils_test.go
+++ b/drivers/storage/ebs/utils/utils_test.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_ebs
+
 package utils
 
 import (

--- a/drivers/storage/ebs/utils/utils_unix.go
+++ b/drivers/storage/ebs/utils/utils_unix.go
@@ -1,4 +1,5 @@
 // +build !windows
+// +build !libstorage_storage_driver libstorage_storage_driver_ebs
 
 package utils
 

--- a/drivers/storage/efs/efs.go
+++ b/drivers/storage/efs/efs.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_efs
+
 package efs
 
 import (

--- a/drivers/storage/efs/executor/efs_executor.go
+++ b/drivers/storage/efs/executor/efs_executor.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_executor libstorage_storage_executor_efs
+
 package executor
 
 import (

--- a/drivers/storage/efs/storage/efs_storage.go
+++ b/drivers/storage/efs/storage/efs_storage.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_efs
+
 package storage
 
 import (

--- a/drivers/storage/efs/tests/efs_test.go
+++ b/drivers/storage/efs/tests/efs_test.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_efs
+
 package efs
 
 import (

--- a/drivers/storage/efs/utils/utils.go
+++ b/drivers/storage/efs/utils/utils.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_efs
+
 package utils
 
 import (

--- a/drivers/storage/efs/utils/utils_go17.go
+++ b/drivers/storage/efs/utils/utils_go17.go
@@ -1,4 +1,5 @@
 // +build go1.7
+// +build !libstorage_storage_driver libstorage_storage_driver_efs
 
 package utils
 

--- a/drivers/storage/efs/utils/utils_pre_go17.go
+++ b/drivers/storage/efs/utils/utils_pre_go17.go
@@ -1,4 +1,5 @@
 // +build !go1.7
+// +build !libstorage_storage_driver libstorage_storage_driver_efs
 
 package utils
 

--- a/drivers/storage/efs/utils/utils_test.go
+++ b/drivers/storage/efs/utils/utils_test.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_efs
+
 package utils
 
 import (

--- a/drivers/storage/isilon/executor/isilon_executor.go
+++ b/drivers/storage/isilon/executor/isilon_executor.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_executor libstorage_storage_executor_isilon
+
 package executor
 
 import (

--- a/drivers/storage/isilon/isilon.go
+++ b/drivers/storage/isilon/isilon.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_isilon
+
 package isilon
 
 import (

--- a/drivers/storage/isilon/storage/isilon_storage.go
+++ b/drivers/storage/isilon/storage/isilon_storage.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_isilon
+
 package storage
 
 import (

--- a/drivers/storage/isilon/tests/isilon_test.go
+++ b/drivers/storage/isilon/tests/isilon_test.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_isilon
+
 package isilon
 
 import (

--- a/drivers/storage/rackspace/executor/rackspace_executor.go
+++ b/drivers/storage/rackspace/executor/rackspace_executor.go
@@ -1,3 +1,5 @@
+// +build none
+
 package executor
 
 import (

--- a/drivers/storage/rackspace/rackspace.go
+++ b/drivers/storage/rackspace/rackspace.go
@@ -1,3 +1,5 @@
+// +build none
+
 package rackspace
 
 import (

--- a/drivers/storage/rackspace/storage/rackspace_storage.go
+++ b/drivers/storage/rackspace/storage/rackspace_storage.go
@@ -1,3 +1,5 @@
+// +build none
+
 package storage
 
 import (

--- a/drivers/storage/rackspace/tests/rackspace_test.go
+++ b/drivers/storage/rackspace/tests/rackspace_test.go
@@ -1,3 +1,5 @@
+// +build none
+
 package rackspace
 
 import (

--- a/drivers/storage/scaleio/executor/scaleio_executor.go
+++ b/drivers/storage/scaleio/executor/scaleio_executor.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_executor libstorage_storage_executor_scaleio
+
 package executor
 
 import (

--- a/drivers/storage/scaleio/scaleio.go
+++ b/drivers/storage/scaleio/scaleio.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_scaleio
+
 package scaleio
 
 import (

--- a/drivers/storage/scaleio/storage/scaleio_storage.go
+++ b/drivers/storage/scaleio/storage/scaleio_storage.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_scaleio
+
 package storage
 
 import (

--- a/drivers/storage/scaleio/tests/scaleio_test.go
+++ b/drivers/storage/scaleio/tests/scaleio_test.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_scaleio
+
 package scaleio
 
 import (

--- a/drivers/storage/vbox/client/vbox_client.go
+++ b/drivers/storage/vbox/client/vbox_client.go
@@ -1,3 +1,5 @@
+// +build none
+
 package client
 
 import (

--- a/drivers/storage/vbox/client/vbox_client_test.go
+++ b/drivers/storage/vbox/client/vbox_client_test.go
@@ -1,3 +1,5 @@
+// +build none
+
 package client
 
 import (

--- a/drivers/storage/vbox/client/vbox_machine.go
+++ b/drivers/storage/vbox/client/vbox_machine.go
@@ -1,3 +1,5 @@
+// +build none
+
 package client
 
 // Machine represents an installed virtual machine in vbox.

--- a/drivers/storage/vbox/client/vbox_soap.go
+++ b/drivers/storage/vbox/client/vbox_soap.go
@@ -1,3 +1,5 @@
+// +build none
+
 package client
 
 import "encoding/xml"

--- a/drivers/storage/vbox/executor/vbox_executor.go
+++ b/drivers/storage/vbox/executor/vbox_executor.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_executor libstorage_storage_executor_vbox
+
 package executor
 
 import (

--- a/drivers/storage/vbox/storage/vbox_storage.go
+++ b/drivers/storage/vbox/storage/vbox_storage.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_vbox
+
 package storage
 
 import (

--- a/drivers/storage/vbox/tests/vbox_test.go
+++ b/drivers/storage/vbox/tests/vbox_test.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_vbox
+
 package vbox
 
 import (

--- a/drivers/storage/vbox/vbox.go
+++ b/drivers/storage/vbox/vbox.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_vbox
+
 package vbox
 
 import (

--- a/drivers/storage/vfs/client/vfs_client.go
+++ b/drivers/storage/vfs/client/vfs_client.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_vfs
+
 package client
 
 import (

--- a/drivers/storage/vfs/executor/vfs_executor.go
+++ b/drivers/storage/vfs/executor/vfs_executor.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_executor libstorage_storage_executor_vfs
+
 package executor
 
 import (

--- a/drivers/storage/vfs/storage/vfs_storage.go
+++ b/drivers/storage/vfs/storage/vfs_storage.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_vfs
+
 package storage
 
 import (

--- a/drivers/storage/vfs/storage/vfs_storage_snap.go
+++ b/drivers/storage/vfs/storage/vfs_storage_snap.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_vfs
+
 package storage
 
 import (

--- a/drivers/storage/vfs/storage/vfs_storage_vol.go
+++ b/drivers/storage/vfs/storage/vfs_storage_vol.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_vfs
+
 package storage
 
 import (

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_vfs
+
 package vfs
 
 import (

--- a/drivers/storage/vfs/vfs.go
+++ b/drivers/storage/vfs/vfs.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_vfs
+
 package vfs
 
 import (

--- a/imports/executors/imports_executor.go
+++ b/imports/executors/imports_executor.go
@@ -1,15 +1,13 @@
+// +build !libstorage_storage_executor
+
 package executors
 
 import (
 	// load the storage executors
 	_ "github.com/codedellemc/libstorage/drivers/storage/ebs/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/efs/executor"
-	//_ "github.com/codedellemc/libstorage/drivers/storage/gce/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/isilon/executor"
-	//_ "github.com/codedellemc/libstorage/drivers/storage/openstack/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/scaleio/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/vbox/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/vfs/executor"
-	//_ "github.com/codedellemc/libstorage/drivers/storage/vmax/executor"
-	//_ "github.com/codedellemc/libstorage/drivers/storage/xtremio/executor"
 )

--- a/imports/executors/imports_executor_ebs.go
+++ b/imports/executors/imports_executor_ebs.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_executor,libstorage_storage_executor_ebs
+
+package executors
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/ebs/executor"
+)

--- a/imports/executors/imports_executor_efs.go
+++ b/imports/executors/imports_executor_efs.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_executor,libstorage_storage_executor_efs
+
+package executors
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/efs/executor"
+)

--- a/imports/executors/imports_executor_isilon.go
+++ b/imports/executors/imports_executor_isilon.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_executor,libstorage_storage_executor_isilon
+
+package executors
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/isilon/executor"
+)

--- a/imports/executors/imports_executor_scaleio.go
+++ b/imports/executors/imports_executor_scaleio.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_executor,libstorage_storage_executor_scaleio
+
+package executors
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/scaleio/executor"
+)

--- a/imports/executors/imports_executor_vbox.go
+++ b/imports/executors/imports_executor_vbox.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_executor,libstorage_storage_executor_vbox
+
+package executors
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/vbox/executor"
+)

--- a/imports/executors/imports_executor_vfs.go
+++ b/imports/executors/imports_executor_vfs.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_executor,libstorage_storage_executor_vfs
+
+package executors
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/vfs/executor"
+)

--- a/imports/remote/imports_remote.go
+++ b/imports/remote/imports_remote.go
@@ -1,3 +1,5 @@
+// +build !libstorage_storage_driver
+
 package remote
 
 import (

--- a/imports/remote/imports_remote_ebs.go
+++ b/imports/remote/imports_remote_ebs.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_driver,libstorage_storage_driver_ebs
+
+package remote
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/ebs/storage"
+)

--- a/imports/remote/imports_remote_efs.go
+++ b/imports/remote/imports_remote_efs.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_driver,libstorage_storage_driver_efs
+
+package remote
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/efs/storage"
+)

--- a/imports/remote/imports_remote_isilon.go
+++ b/imports/remote/imports_remote_isilon.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_driver,libstorage_storage_driver_isilon
+
+package remote
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/isilon/storage"
+)

--- a/imports/remote/imports_remote_scaleio.go
+++ b/imports/remote/imports_remote_scaleio.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_driver,libstorage_storage_driver_scaleio
+
+package remote
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/scaleio/storage"
+)

--- a/imports/remote/imports_remote_vbox.go
+++ b/imports/remote/imports_remote_vbox.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_driver,libstorage_storage_driver_vbox
+
+package remote
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/vbox/storage"
+)

--- a/imports/remote/imports_remote_vfs.go
+++ b/imports/remote/imports_remote_vfs.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_driver,libstorage_storage_driver_vfs
+
+package remote
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/vfs/storage"
+)


### PR DESCRIPTION
This patch enables the specific activation of storage drivers/executors via build tags. The tags `libstorage_storage_driver` and `libstorage_storage_executor`, if absent, will result in all drivers/executors being activated. This is the previous, default behavior. However, if the tags `libstorage_storage_driver` and `libstorage_storage_executor` are present along with `libstorage_storage_driver_NAME` and `libstorage_storage_executor_NAME`, where NAME is the name of a driver, ex. `ebs`, then only that driver and executor are considered for compilation.