### PR TITLE
Fix for client not sending encryption key

### DIFF
--- a/drivers/storage/libstorage/libstorage_driver_funcs.go
+++ b/drivers/storage/libstorage/libstorage_driver_funcs.go
@@ -117,6 +117,7 @@ func (d *driver) VolumeCreate(
 		Name:             name,
 		AvailabilityZone: opts.AvailabilityZone,
 		Encrypted:        opts.Encrypted,
+		EncryptionKey:    opts.EncryptionKey,
 		IOPS:             opts.IOPS,
 		Size:             opts.Size,
 		Type:             opts.Type,


### PR DESCRIPTION
This patch fixes the client so that is sends the encryption key when creating volumes if such a key is specified.