### PR TITLE
Fix for Import VFS Client w Bad Build Tags

### DIFF
--- a/imports/local/imports_local_gofig.go
+++ b/imports/local/imports_local_gofig.go
@@ -1,4 +1,4 @@
-// +build gofig
+// +build gofig,libstorage_storage_driver_vfs
 
 package local
 


### PR DESCRIPTION
This patch updates an import so that the package is no longer imported when it should not be.