### PR TITLE
Fix for Executor build change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -854,13 +854,13 @@ endif
 $$(LSX_EMBEDDED_$2): $1
 	@mkdir -p $$(@D) && cp -f $$? $$@
 
+ifeq (linux,$2)
 EXECUTORS_EMBEDDED += $$(LSX_EMBEDDED_$2)
+endif
 endef
 
 $(eval $(call EXECUTOR_RULES,$(EXECUTOR_LINUX),linux))
-ifneq (true,$(TRAVIS))
 $(eval $(call EXECUTOR_RULES,$(EXECUTOR_DARWIN),darwin))
-endif
 #$(eval $(call EXECUTOR_RULES,$(EXECUTOR_WINDOWS),windows))
 
 $(EXECUTORS_GENERATED): $(EXECUTORS_EMBEDDED)


### PR DESCRIPTION
This patch updates the Makefile with the appropriate code for building the executor for Linux only.