### PR TITLE
Remove use of 'ceph' command in RBD driver

### DIFF
--- a/drivers/storage/rbd/tests/cephconfig.sh
+++ b/drivers/storage/rbd/tests/cephconfig.sh
@@ -44,3 +44,6 @@ for x in $(seq 1 $NUM_NODES); do
 	ceph-deploy osd create --zap-disk libstorage-rbd-test-server$x:/dev/sdb
 done
 ceph-deploy admin localhost libstorage-rbd-test-client
+
+# Create a second Ceph pool for testing purposes
+sudo ceph osd pool create test 64


### PR DESCRIPTION
The RBD driver was using 'ceph' and 'rbd' commands to interact
with a Ceph cluster. 'rbd' is a compiled binary, but 'ceph' is
a Python script. As such, it is way more susceptible to incorrectly
configured environments.

Specifically, when rexray is started under mesosphere dcos, the
systemd unit file loads python 3.5 instead of python 2.7. However,
the 'ceph' command does not work under python 3.5 (missing a module
that is only installed in 2.7). This is a fixable problem with systemd
environmentfiles and environment directives, but there is an easy
way to avoid the whole problem and not be dependent on Python versions.

Swap the 'ceph' command for 'rados', which is also a compiled binary
like 'rbd'. The only thing 'ceph' was being used for was to get a list
of pools on the cluster, so we swap 'ceph osd ls pools' for
'rados lspools'.

Add some unit tests to exercise creating volumes in multiple pools.