### PR TITLE
Attached-To-Me Query Fix

### DIFF
--- a/drivers/storage/vfs/storage/vfs_storage.go
+++ b/drivers/storage/vfs/storage/vfs_storage.go
@@ -155,6 +155,15 @@ func (d *driver) Volumes(
 		if opts.Attachments > 0 {
 			v.AttachmentState = 0
 		}
+		if opts.Attachments.Mine() {
+			atts := []*types.VolumeAttachment{}
+			for _, a := range v.Attachments {
+				if a.InstanceID != nil && a.InstanceID.ID == iid.ID {
+					atts = append(atts, a)
+				}
+			}
+			v.Attachments = atts
+		}
 		volumes = append(volumes, v)
 	}
 
@@ -174,6 +183,21 @@ func (d *driver) VolumeInspect(
 	}
 	if opts.Attachments > 0 {
 		v.AttachmentState = 0
+	}
+	if opts.Attachments.Mine() {
+		iid, iidOK := context.InstanceID(ctx)
+		if iidOK {
+			if iid.ID == "" {
+				return nil, goof.New("missing instance ID")
+			}
+		}
+		atts := []*types.VolumeAttachment{}
+		for _, a := range v.Attachments {
+			if a.InstanceID != nil && a.InstanceID.ID == iid.ID {
+				atts = append(atts, a)
+			}
+		}
+		v.Attachments = atts
 	}
 	return v, nil
 }

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -253,6 +253,30 @@ func TestVolumesWithAttachmentsAttachedAndUnattached(t *testing.T) {
 	apitests.Run(t, vfs.Name, tc, tf)
 }
 
+func TestVolumesWithAttachmentsAttachedToMeAndAvailable(t *testing.T) {
+	tc, _, vols, _ := newTestConfigAll(t)
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		reply, err := client.API().Volumes(nil,
+			types.VolAttReqOnlyVolsAttachedToInstanceOrUnattachedVols)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.NotNil(t, reply["vfs"]["vfs-000"])
+		assert.NotNil(t, reply["vfs"]["vfs-001"])
+		assert.NotNil(t, reply["vfs"]["vfs-002"])
+		assert.EqualValues(t, vols["vfs-000"], reply["vfs"]["vfs-000"])
+		assert.EqualValues(t, vols["vfs-001"], reply["vfs"]["vfs-001"])
+		assert.Equal(
+			t, types.VolumeAttached, reply["vfs"]["vfs-000"].AttachmentState)
+		assert.Equal(
+			t, types.VolumeAttached, reply["vfs"]["vfs-001"].AttachmentState)
+		assert.Equal(
+			t, types.VolumeAvailable, reply["vfs"]["vfs-002"].AttachmentState)
+	}
+	apitests.Run(t, vfs.Name, tc, tf)
+}
+
 func TestVolumesWithAttachmentsMineWithNotMyInstanceID(
 	t *testing.T) {
 	tc, _, _, _ := newTestConfigAll(t)


### PR DESCRIPTION
This patch fixes an issue where volume data was being incorrectly returned when requested for instances other than the one provided via the instance ID header. Volumes that were unavailable were being returned as available, creating issues for libStorage clients.

The new test, `TestVolumesWithAttachmentsAttachedToMeAndAvailable`, shows this effort:

```shell
[0]akutz@pax:libstorage$ LIBSTORAGE_LOGGING_LEVEL=debug LIBSTORAGE_DEBUG=true go test -tags "gofig pflag libstorage_integration_driver_docker libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs" ./drivers/storage/vfs/tests -run TestVolumesWithAttachmentsAttachedToMeAndAvailable$ -v
INFO[0000] libStorage path                               home=/Users/akutz/.libstorage
INFO[0000] libStorage path                               etc=/Users/akutz/.libstorage/etc/libstorage
INFO[0000] libStorage path                               lib=/Users/akutz/.libstorage/var/lib/libstorage
INFO[0000] libStorage path                               log=/Users/akutz/.libstorage/var/log/libstorage
INFO[0000] libStorage path                               run=/Users/akutz/.libstorage/var/run/libstorage
INFO[0000] libStorage path                               lsx=/Users/akutz/.libstorage/var/lib/libstorage/lsx-darwin
INFO[0000] registered custom context key                 externalID=Libstorage-Tx internalID=1 keyBitmask=2
INFO[0000] registered custom context key                 externalID=Libstorage-Instanceid internalID=2 keyBitmask=2
INFO[0000] registered custom context key                 externalID=Libstorage-Localdevices internalID=3 keyBitmask=2
DEBU[0000] enter join                                    elem=[lsx.lock]
DEBU[0000] exit join                                     elem=[/Users/akutz/.libstorage/var/run/libstorage lsx.lock]
DEBU[0000] enter join                                    elem=[volumes]
DEBU[0000] exit join                                     elem=[/Users/akutz/.libstorage/var/lib/libstorage volumes]
=== RUN   TestVolumesWithAttachmentsAttachedToMeAndAvailable
DEBU[0000] initializing configuration                   
DEBU[0000] created scoped scope                          new=libstorage.server parentScopes=libstorage.tests.tcp,

                  _ _ _     _____ _
                 | (_) |   / ____| |
                 | |_| |__| (___ | |_ ___  _ __ __ _  __ _  ___
                 | | | '_ \\___ \| __/ _ \| '__/ _' |/ _' |/ _ \
                 | | | |_) |___) | || (_) | | | (_| | (_| |  __/
                 |_|_|_.__/_____/ \__\___/|_|  \__,_|\__, |\___|
                                                      __/ |
                                                     |___/

################################################################################
##                                                                            ##
##                  libStorage starting - 2016/12/20 19:49:29.634             ##
##                                                                            ##
##     server:      shade-throat-im                                           ##
##      token:      c9aeec3b-a734-41f3-7e69-9f6901cea952                      ##
##                                                                            ##
##     semver:      0.3.2+10+dirty                                            ##
##     osarch:      Darwin-x86_64                                             ##
##     branch:      feature/opt-in-local-drivers                              ##
##     commit:      6f84db6df3e9f0163b526e17f4b30d58c594bcf8                  ##
##     formed:      Mon, 07 Nov 2016 16:06:33 CST                             ##
##                                                                            ##
##        etc:      /Users/akutz/.libstorage/etc/libstorage                   ##
##        lib:      /Users/akutz/.libstorage/var/lib/libstorage               ##
##        log:      /Users/akutz/.libstorage/var/log/libstorage               ##
##        run:      /Users/akutz/.libstorage/var/run/libstorage               ##
##                                                                            ##
################################################################################

INFO[0000] configured logging                            libstorage.logging.httpRequests=true libstorage.logging.httpResponses=true libstorage.logging.level=debug server=shade-throat-im time=1482263369645
INFO[0000] initializing server                           server=shade-throat-im time=1482263369645
DEBU[0000] endpoint info                                 address=tcp://127.0.0.1:26344 endpoint=libstorage.server.endpoints.localhost server=shade-throat-im time=1482263369646
DEBU[0000] created scoped scope                          new=libstorage.server.endpoints.localhost parentScopes=libstorage.server,libstorage.tests.tcp,
INFO[0000] configured endpoint                           address=tcp://127.0.0.1:26344 endpoint=localhost server=shade-throat-im time=1482263369649
INFO[0000] server created                                server=shade-throat-im time=1482263369649
INFO[0000] initialized endpoints                         server=shade-throat-im time=1482263369649
INFO[0000] initializing server services                  server=shade-throat-im time=1482263369649
DEBU[0000] configured result schema validation           enabled=false server=shade-throat-im time=1482263369650
DEBU[0000] got services map                              count=1 server=shade-throat-im time=1482263369650
DEBU[0000] processing service config                     server=shade-throat-im service=vfs time=1482263369650
DEBU[0000] getting scoped config for service             scope=libstorage.server.services.vfs server=shade-throat-im service=vfs time=1482263369650
DEBU[0000] created scoped scope                          new=libstorage.server.services.vfs parentScopes=libstorage.server,libstorage.tests.tcp,
DEBU[0000] got driver name                               driverName=vfs server=shade-throat-im service=vfs time=1482263369653
INFO[0000] vfs.root                                      server=shade-throat-im service=vfs storageDriver=vfs time=1482263369657 vfs.root.path=/var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605
INFO[0000] created new service                           server=shade-throat-im service=vfs time=1482263369657
INFO[0000] initialized services                          server=shade-throat-im time=1482263369657
INFO[0000] initialized router                            len(routes)=3 router=executor-router
INFO[0000] initialized router                            len(routes)=4 router=help-router
INFO[0000] initialized router                            len(routes)=1 router=root-router
INFO[0000] initialized router                            len(routes)=2 router=service-router
INFO[0000] initialized router                            len(routes)=11 router=volume-router
INFO[0000] initialized router                            len(routes)=6 router=snapshot-router
INFO[0000] initialized router                            len(routes)=2 router=tasks-router
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/executors queries=[] route=executors server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/executors/{executor} queries=[] route=executorInspect server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=HEAD path=/executors/{executor} queries=[] route=executorHead server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/help queries=[] route=version server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/help/config queries=[] route=version server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/help/env queries=[] route=version server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/help/version queries=[] route=version server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/ queries=[] route=root server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/services queries=[] route=services server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/services/{service} queries=[] route=serviceInspect server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/volumes queries=[] route=volumes server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/volumes/{service} queries=[] route=volumesForService server=shade-throat-im time=1482263369658 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/volumes/{service}/{volumeID} queries=[] route=volumeInspect server=shade-throat-im time=1482263369659 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=2 method=POST path=/volumes/{service} queries=[detach ] route=volumesDetachForService server=shade-throat-im time=1482263369659 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=POST path=/volumes/{service} queries=[] route=volumeCreate server=shade-throat-im time=1482263369659 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=2 method=POST path=/volumes/{service}/{volumeID} queries=[copy ] route=volumeCopy server=shade-throat-im time=1482263369659 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=2 method=POST path=/volumes/{service}/{volumeID} queries=[snapshot ] route=volumeSnapshot server=shade-throat-im time=1482263369659 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=2 method=POST path=/volumes/{service}/{volumeID} queries=[attach ] route=volumeAttach server=shade-throat-im time=1482263369659 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=2 method=POST path=/volumes queries=[detach ] route=volumesDetachAll server=shade-throat-im time=1482263369659 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=2 method=POST path=/volumes/{service}/{volumeID} queries=[detach ] route=volumeDetach server=shade-throat-im time=1482263369659 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=DELETE path=/volumes/{service}/{volumeID} queries=[] route=volumeRemove server=shade-throat-im time=1482263369660 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/snapshots queries=[] route=snapshots server=shade-throat-im time=1482263369660 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/snapshots/{service} queries=[] route=snapshotsForService server=shade-throat-im time=1482263369661 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/snapshots/{service}/{snapshotID} queries=[] route=snapshotInspect server=shade-throat-im time=1482263369661 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=2 method=POST path=/snapshots/{service}/{snapshotID} queries=[create ] route=snapshotCreate server=shade-throat-im time=1482263369661 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=2 method=POST path=/snapshots/{service}/{snapshotID} queries=[copy ] route=snapshotCopy server=shade-throat-im time=1482263369661 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=DELETE path=/snapshots/{service}/{snapshotID} queries=[] route=snapshotRemove server=shade-throat-im time=1482263369661 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/tasks queries=[] route=tasks server=shade-throat-im time=1482263369661 tls=false
DEBU[0000] registered route                              host=tcp://127.0.0.1:26344 len(queries)=0 method=GET path=/tasks/{taskID} queries=[] route=taskInspect server=shade-throat-im time=1482263369661 tls=false
INFO[0000] waiting for err or close signal               server=shade-throat-im time=1482263369661
INFO[0000] api listening                                 host=tcp://127.0.0.1:26344 server=shade-throat-im time=1482263369661 tls=false
INFO[0001] server started                                server=shade-throat-im time=1482263370665

################################################################################
##                                                                            ##
##                  libStorage started  - 2016/12/20 19:49:30.665             ##
##                                                                            ##
##     endpoints:   tcp://127.0.0.1:26344                                     ##
##                                                                            ##
##      services:   name=vfs, driver=vfs                                      ##
##                                                                            ##
################################################################################

DEBU[0001] created scoped scope                          new=libstorage.client parentScopes=libstorage.tests.tcp,
INFO[0001] configured logging                            libstorage.logging.httpRequests=true libstorage.logging.httpResponses=true libstorage.logging.level=debug time=1482263370683
DEBU[0001] got configured host address                   host=tcp://127.0.0.1:26344 service= storageDriver=libstorage time=1482263370686
INFO[0001] created libStorage client                     clientType=integration disableKeepAlive=false enableInstanceIDHeaders=true enableLocalDevicesHeaders=true host=127.0.0.1:26344 logRequests=true logResponses=true lsxPath=/Users/akutz/.libstorage/var/lib/libstorage/lsx-darwin service= storageDriver=libstorage time=1482263370690
INFO[0001] lsx lock file path                            path=/Users/akutz/.libstorage/var/run/libstorage/lsx.lock service= storageDriver=libstorage time=1482263370690
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP REQUEST (CLIENT) ------------------------- 
INFO[0001]     GET /services HTTP/1.1                   
INFO[0001]     Host: 127.0.0.1:26344                    
INFO[0001]     Libstorage-Tx: txID=bce5beea-315d-4d9a-42e8-5866a9d99f50, txCR=1482263370 
INFO[0001]                                              
INFO[0001] http request                                  host=tcp://127.0.0.1:26344 route=services server=shade-throat-im time=1482263370691 tls=false
DEBU[0001] added route middleware                        host=tcp://127.0.0.1:26344 middleware=schema-validator route=services server=shade-throat-im time=1482263370691 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=transaction-handler route=services server=shade-throat-im time=1482263370691 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=local-devices-handler route=services server=shade-throat-im time=1482263370691 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=instanceIDs-handler route=services server=shade-throat-im time=1482263370691 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=error-handler route=services server=shade-throat-im time=1482263370691 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=transaction-handler route=services server=shade-throat-im time=1482263370691 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=logging-handler route=services server=shade-throat-im time=1482263370691 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=query-params-handler route=services server=shade-throat-im time=1482263370691 tls=false
DEBU[0001] http header                                   Libstorage-Tx=txID=bce5beea-315d-4d9a-42e8-5866a9d99f50, txCR=1482263370 host=tcp://127.0.0.1:26344 route=services server=shade-throat-im time=1482263370691 tls=false
DEBU[0001] http header                                   Libstorage-Instanceid=[] host=tcp://127.0.0.1:26344 route=services server=shade-throat-im time=1482263370691 tls=false txCR=1482263370 txID=bce5beea-315d-4d9a-42e8-5866a9d99f50
DEBU[0001] http header                                   Libstorage-Localdevices=[] host=tcp://127.0.0.1:26344 route=services server=shade-throat-im time=1482263370692 tls=false txCR=1482263370 txID=bce5beea-315d-4d9a-42e8-5866a9d99f50
INFO[0001] 127.0.0.1 - - [20/Dec/2016:13:49:30 -0600] "GET /services HTTP/1.1" 200 202 
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP REQUEST (SERVER) -------------------------- 
INFO[0001]     GET /services HTTP/1.1                   
INFO[0001]     Host: 127.0.0.1:26344                    
INFO[0001]     Accept-Encoding: gzip                    
INFO[0001]     Libstorage-Tx: txID=bce5beea-315d-4d9a-42e8-5866a9d99f50, txCR=1482263370 
INFO[0001]     User-Agent: Go-http-client/1.1           
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP RESPONSE (SERVER) ------------------------- 
INFO[0001]     Content-Type=application/json            
INFO[0001]                                              
INFO[0001]     {                                        
INFO[0001]       "vfs": {                               
INFO[0001]         "name": "vfs",                       
INFO[0001]         "driver": {                          
INFO[0001]           "name": "vfs",                     
INFO[0001]           "type": "object",                  
INFO[0001]           "nextDevice": {                    
INFO[0001]             "ignore": true,                  
INFO[0001]             "prefix": "",                    
INFO[0001]             "pattern": ""                    
INFO[0001]           }                                  
INFO[0001]         }                                    
INFO[0001]       }                                      
INFO[0001]     }                                        
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP RESPONSE (CLIENT) ------------------------- 
INFO[0001]     HTTP/1.1 200 OK                          
INFO[0001]     Content-Length: 202                      
INFO[0001]     Content-Type: application/json           
INFO[0001]     Date: Tue, 20 Dec 2016 19:49:30 GMT      
INFO[0001]     Libstorage-Servername: shade-throat-im   
INFO[0001]                                              
INFO[0001]     {                                        
INFO[0001]       "vfs": {                               
INFO[0001]         "name": "vfs",                       
INFO[0001]         "driver": {                          
INFO[0001]           "name": "vfs",                     
INFO[0001]           "type": "object",                  
INFO[0001]           "nextDevice": {                    
INFO[0001]             "ignore": true,                  
INFO[0001]             "prefix": "",                    
INFO[0001]             "pattern": ""                    
INFO[0001]           }                                  
INFO[0001]         }                                    
INFO[0001]       }                                      
INFO[0001]     }                                        
INFO[0001] initializing executors cache                  service= storageDriver=libstorage time=1482263370693
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP REQUEST (CLIENT) ------------------------- 
INFO[0001]     GET /executors HTTP/1.1                  
INFO[0001]     Host: 127.0.0.1:26344                    
INFO[0001]     Libstorage-Tx: txID=d783f1a2-de2b-425c-713c-354ef8163437, txCR=1482263370 
INFO[0001]                                              
INFO[0001] http request                                  host=tcp://127.0.0.1:26344 route=executors server=shade-throat-im time=1482263370693 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=transaction-handler route=executors server=shade-throat-im time=1482263370693 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=local-devices-handler route=executors server=shade-throat-im time=1482263370693 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=instanceIDs-handler route=executors server=shade-throat-im time=1482263370693 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=error-handler route=executors server=shade-throat-im time=1482263370693 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=transaction-handler route=executors server=shade-throat-im time=1482263370693 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=logging-handler route=executors server=shade-throat-im time=1482263370693 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=query-params-handler route=executors server=shade-throat-im time=1482263370693 tls=false
DEBU[0001] http header                                   Libstorage-Tx=txID=d783f1a2-de2b-425c-713c-354ef8163437, txCR=1482263370 host=tcp://127.0.0.1:26344 route=executors server=shade-throat-im time=1482263370693 tls=false
DEBU[0001] http header                                   Libstorage-Instanceid=[] host=tcp://127.0.0.1:26344 route=executors server=shade-throat-im time=1482263370693 tls=false txCR=1482263370 txID=d783f1a2-de2b-425c-713c-354ef8163437
DEBU[0001] http header                                   Libstorage-Localdevices=[] host=tcp://127.0.0.1:26344 route=executors server=shade-throat-im time=1482263370693 tls=false txCR=1482263370 txID=d783f1a2-de2b-425c-713c-354ef8163437
INFO[0001] 127.0.0.1 - - [20/Dec/2016:13:49:30 -0600] "GET /executors HTTP/1.1" 200 314 
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP REQUEST (SERVER) -------------------------- 
INFO[0001]     GET /executors HTTP/1.1                  
INFO[0001]     Host: 127.0.0.1:26344                    
INFO[0001]     Accept-Encoding: gzip                    
INFO[0001]     Libstorage-Tx: txID=d783f1a2-de2b-425c-713c-354ef8163437, txCR=1482263370 
INFO[0001]     User-Agent: Go-http-client/1.1           
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP RESPONSE (SERVER) ------------------------- 
INFO[0001]     Content-Type=application/json            
INFO[0001]                                              
INFO[0001]     {                                        
INFO[0001]       "lsx-darwin": {                        
INFO[0001]         "name": "lsx-darwin",                
INFO[0001]         "md5checksum": "7c5bdc95aeb24464589952841891c273", 
INFO[0001]         "size": 10727284,                    
INFO[0001]         "lastModified": 1481131986           
INFO[0001]       },                                     
INFO[0001]       "lsx-linux": {                         
INFO[0001]         "name": "lsx-linux",                 
INFO[0001]                                              
INFO[0001]         "md5checksum": "a8c993d0e8c42e9791b0d23bdbe2b2ff", 
INFO[0001]     -------------------------- HTTP RESPONSE (CLIENT) ------------------------- 
INFO[0001]         "size": 10966259,                    
INFO[0001]         "lastModified": 1482174290           
INFO[0001]       }                                      
INFO[0001]     }                                        
INFO[0001]     HTTP/1.1 200 OK                          
INFO[0001]     Content-Length: 314                      
INFO[0001]     Content-Type: application/json           
INFO[0001]     Date: Tue, 20 Dec 2016 19:49:30 GMT      
INFO[0001]     Libstorage-Servername: shade-throat-im   
INFO[0001]                                              
INFO[0001]     {                                        
INFO[0001]       "lsx-darwin": {                        
INFO[0001]         "name": "lsx-darwin",                
INFO[0001]         "md5checksum": "7c5bdc95aeb24464589952841891c273", 
INFO[0001]         "size": 10727284,                    
INFO[0001]         "lastModified": 1481131986           
INFO[0001]       },                                     
INFO[0001]       "lsx-linux": {                         
INFO[0001]         "name": "lsx-linux",                 
INFO[0001]         "md5checksum": "a8c993d0e8c42e9791b0d23bdbe2b2ff", 
INFO[0001]         "size": 10966259,                    
INFO[0001]         "lastModified": 1482174290           
INFO[0001]       }                                      
INFO[0001]     }                                        
DEBU[0001] updating executor                             service= storageDriver=libstorage time=1482263370694
DEBU[0001] waiting on executor lock                      service= storageDriver=libstorage time=1482263370694
DEBU[0001] executor exists, getting local checksum       service= storageDriver=libstorage time=1482263370694
DEBU[0001] getting executor checksum                     service= storageDriver=libstorage time=1482263370694
DEBU[0001] got local executor checksum                   localChecksum=7c5bdc95aeb24464589952841891c273 service= storageDriver=libstorage time=1482263370723
DEBU[0001] signalling executor lock                      service= storageDriver=libstorage time=1482263370724
INFO[0001] initializing supported cache                  server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370724
DEBU[0001] waiting on executor lock                      server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370724 txCR=1482263370 txID=f9a9e363-055e-4a05-4571-6019769eeadb
DEBU[0001] signalling executor lock                      server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370751 txCR=1482263370 txID=f9a9e363-055e-4a05-4571-6019769eeadb
DEBU[0001] cached supported flag                         server=shade-throat-im service=vfs storageDriver=libstorage supported=true time=1482263370751 txCR=1482263370 txID=f9a9e363-055e-4a05-4571-6019769eeadb
INFO[0001] initializing instance ID cache                server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370751
DEBU[0001] waiting on executor lock                      server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370751 txCR=1482263370 txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17
DEBU[0001] signalling executor lock                      server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370786 txCR=1482263370 txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17
DEBU[0001] sending instanceID in API.InstanceInspect call  instanceID=vfs=,,InBheC5rdXR6Ig== server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370786 txCR=1482263370 txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP REQUEST (CLIENT) ------------------------- 
INFO[0001]     GET /services/vfs?instance HTTP/1.1      
INFO[0001]     Host: 127.0.0.1:26344                    
INFO[0001]     Libstorage-Instanceid: vfs=,,InBheC5rdXR6Ig== 
INFO[0001]     Libstorage-Tx: txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17, txCR=1482263370 
INFO[0001]                                              
INFO[0001] http request                                  host=tcp://127.0.0.1:26344 route=serviceInspect server=shade-throat-im time=1482263370787 tls=false
DEBU[0001] added route middleware                        host=tcp://127.0.0.1:26344 middleware=schema-validator route=serviceInspect server=shade-throat-im time=1482263370787 tls=false
DEBU[0001] added route middleware                        host=tcp://127.0.0.1:26344 middleware=service-validator route=serviceInspect server=shade-throat-im time=1482263370787 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=transaction-handler route=serviceInspect server=shade-throat-im time=1482263370787 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=local-devices-handler route=serviceInspect server=shade-throat-im time=1482263370787 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=instanceIDs-handler route=serviceInspect server=shade-throat-im time=1482263370787 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=error-handler route=serviceInspect server=shade-throat-im time=1482263370787 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=transaction-handler route=serviceInspect server=shade-throat-im time=1482263370787 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=logging-handler route=serviceInspect server=shade-throat-im time=1482263370787 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=query-params-handler route=serviceInspect server=shade-throat-im time=1482263370787 tls=false
DEBU[0001] query param                                   host=tcp://127.0.0.1:26344 key=instance len(value)=1 route=serviceInspect server=shade-throat-im time=1482263370787 tls=false value=[]
DEBU[0001] http header                                   Libstorage-Tx=txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17, txCR=1482263370 host=tcp://127.0.0.1:26344 route=serviceInspect server=shade-throat-im time=1482263370788 tls=false
DEBU[0001] http header                                   Libstorage-Instanceid=[vfs=,,InBheC5rdXR6Ig==] host=tcp://127.0.0.1:26344 route=serviceInspect server=shade-throat-im time=1482263370788 tls=false txCR=1482263370 txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17
DEBU[0001] http header                                   Libstorage-Localdevices=[] host=tcp://127.0.0.1:26344 route=serviceInspect server=shade-throat-im time=1482263370788 tls=false txCR=1482263370 txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17
DEBU[0001] getting storage service                       host=tcp://127.0.0.1:26344 route=serviceInspect server=shade-throat-im service=vfs time=1482263370788 tls=false txCR=1482263370 txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17
DEBU[0001] vfs login=vfs=,,InBheC5rdXR6Ig==              host=tcp://127.0.0.1:26344 instanceID=vfs=,,InBheC5rdXR6Ig== route=serviceInspect server=shade-throat-im service=vfs storageDriver=vfs time=1482263370788 tls=false txCR=1482263370 txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17
INFO[0001] 127.0.0.1 - - [20/Dec/2016:13:49:30 -0600] "GET /services/vfs?instance HTTP/1.1" 200 311 
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP REQUEST (SERVER) -------------------------- 
INFO[0001]     GET /services/vfs?instance HTTP/1.1      
INFO[0001]     Host: 127.0.0.1:26344                    
INFO[0001]     Accept-Encoding: gzip                    
INFO[0001]     Libstorage-Instanceid: vfs=,,InBheC5rdXR6Ig== 
INFO[0001]     Libstorage-Tx: txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17, txCR=1482263370 
INFO[0001]     User-Agent: Go-http-client/1.1           
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP RESPONSE (SERVER) ------------------------- 
INFO[0001]     Content-Type=application/json            
INFO[0001]                                              
INFO[0001]     {                                        
INFO[0001]       "name": "vfs",                         
INFO[0001]       "instance": {                          
INFO[0001]         "instanceID": {                      
INFO[0001]                                              
INFO[0001]           "id": "pax.kutz",                  
INFO[0001]           "driver": "vfs"                    
INFO[0001]         },                                   
INFO[0001]         "name": "vfsInstance",               
INFO[0001]     -------------------------- HTTP RESPONSE (CLIENT) ------------------------- 
INFO[0001]         "providerName": ""                   
INFO[0001]       },                                     
INFO[0001]       "driver": {                            
INFO[0001]         "name": "vfs",                       
INFO[0001]         "type": "object",                    
INFO[0001]         "nextDevice": {                      
INFO[0001]           "ignore": true,                    
INFO[0001]           "prefix": "",                      
INFO[0001]           "pattern": ""                      
INFO[0001]         }                                    
INFO[0001]       }                                      
INFO[0001]     }                                        
INFO[0001]     HTTP/1.1 200 OK                          
INFO[0001]     Content-Length: 311                      
INFO[0001]     Content-Type: application/json           
INFO[0001]     Date: Tue, 20 Dec 2016 19:49:30 GMT      
INFO[0001]     Libstorage-Servername: shade-throat-im   
INFO[0001]                                              
INFO[0001]     {                                        
INFO[0001]       "name": "vfs",                         
INFO[0001]       "instance": {                          
INFO[0001]         "instanceID": {                      
INFO[0001]           "id": "pax.kutz",                  
INFO[0001]           "driver": "vfs"                    
INFO[0001]         },                                   
INFO[0001]         "name": "vfsInstance",               
INFO[0001]         "providerName": ""                   
INFO[0001]       },                                     
INFO[0001]       "driver": {                            
INFO[0001]         "name": "vfs",                       
INFO[0001]         "type": "object",                    
INFO[0001]         "nextDevice": {                      
INFO[0001]           "ignore": true,                    
INFO[0001]           "prefix": "",                      
INFO[0001]           "pattern": ""                      
INFO[0001]         }                                    
INFO[0001]       }                                      
INFO[0001]     }                                        
DEBU[0001] received instanceID from API.InstanceInspect call  instanceID=vfs=,,InBheC5rdXR6Ig== server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370789 txCR=1482263370 txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17
DEBU[0001] cached instanceID                             instanceID=vfs=pax.kutz server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370789 txCR=1482263370 txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17
DEBU[0001] xli instanceID success                        instanceID=vfs=pax.kutz server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370789 txCR=1482263370 txID=8a70bb28-3f92-4370-4f0e-d0bc98a95f17
INFO[0001] successefully dialed libStorage server        server=shade-throat-im service= storageDriver=libstorage time=1482263370789
INFO[0001] storage driver initialized                    service= storageDriver=libstorage time=1482263370789
INFO[0001] os driver initialized                         osDriver=darwin service= storageDriver=libstorage time=1482263370789
INFO[0001] docker integration driver successfully initialized  integrationDriver=docker libstorage.integration.volume.operations.create.default.IOPS= libstorage.integration.volume.operations.create.default.availabilityZone= libstorage.integration.volume.operations.create.default.fsType=ext4 libstorage.integration.volume.operations.create.default.size=16 libstorage.integration.volume.operations.create.default.type= libstorage.integration.volume.operations.create.implicit=true libstorage.integration.volume.operations.mount.path=/Users/akutz/.libstorage/var/lib/libstorage/volumes libstorage.integration.volume.operations.mount.rootPath=/data osDriver=darwin service= storageDriver=libstorage time=1482263370796
INFO[0001] path cache initializion disabled; no service name in ctx  integrationDriver=docker osDriver=darwin service= storageDriver=libstorage time=1482263370797
INFO[0001] libStorage integration driver successfully initialized  integrationDriver=docker libstorage.integration.volume.operations.create.disable=false libstorage.integration.volume.operations.mount.preempt=false libstorage.integration.volume.operations.path.cache.async=true libstorage.integration.volume.operations.path.cache.enabled=true libstorage.integration.volume.operations.remove.disable=false libstorage.integration.volume.operations.unmount.ignoreusedcount=false osDriver=darwin service= storageDriver=libstorage time=1482263370801
INFO[0001] integration driver initialized                integrationDriver=docker osDriver=darwin service= storageDriver=libstorage time=1482263370801
INFO[0001] created libStorage client                     integrationDriver=docker osDriver=darwin service= storageDriver=libstorage time=1482263370801
DEBU[0001] waiting on executor lock                      integrationDriver=docker osDriver=darwin server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370801 txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] signalling executor lock                      integrationDriver=docker osDriver=darwin server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370830 txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
WARN[0001] removing local device w/ invalid volume id    deviceID=/dev/xvde integrationDriver=docker osDriver=darwin server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370830 txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
WARN[0001] removing local device w/ invalid volume id    deviceID=/dev/xvdf integrationDriver=docker osDriver=darwin server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370830 txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
WARN[0001] removing local device w/ invalid volume id    deviceID=/dev/xvdc integrationDriver=docker osDriver=darwin server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370830 txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
WARN[0001] removing local device w/ invalid volume id    deviceID=/dev/xvdd integrationDriver=docker osDriver=darwin server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370830 txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] xli localdevices success                      integrationDriver=docker osDriver=darwin server=shade-throat-im service=vfs storageDriver=libstorage time=1482263370830 txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP REQUEST (CLIENT) ------------------------- 
INFO[0001]     GET /volumes?attachments=27 HTTP/1.1     
INFO[0001]     Host: 127.0.0.1:26344                    
INFO[0001]     Libstorage-Instanceid: vfs=pax.kutz      
INFO[0001]     Libstorage-Localdevices: vfs=/dev/xvda::/var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605/vfs-000,/dev/xvdb::/var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605/vfs-001 
INFO[0001]     Libstorage-Tx: txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2, txCR=1482263370 
INFO[0001]                                              
INFO[0001] http request                                  host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im time=1482263370831 tls=false
DEBU[0001] added route middleware                        host=tcp://127.0.0.1:26344 middleware=schema-validator route=volumes server=shade-throat-im time=1482263370831 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=transaction-handler route=volumes server=shade-throat-im time=1482263370831 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=local-devices-handler route=volumes server=shade-throat-im time=1482263370831 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=instanceIDs-handler route=volumes server=shade-throat-im time=1482263370831 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=error-handler route=volumes server=shade-throat-im time=1482263370831 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=transaction-handler route=volumes server=shade-throat-im time=1482263370831 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=logging-handler route=volumes server=shade-throat-im time=1482263370831 tls=false
DEBU[0001] added global middleware                       host=tcp://127.0.0.1:26344 middleware=query-params-handler route=volumes server=shade-throat-im time=1482263370831 tls=false
DEBU[0001] query param                                   host=tcp://127.0.0.1:26344 key=attachments len(value)=1 route=volumes server=shade-throat-im time=1482263370831 tls=false value=[27]
DEBU[0001] http header                                   Libstorage-Tx=txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2, txCR=1482263370 host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im time=1482263370831 tls=false
DEBU[0001] http header                                   Libstorage-Instanceid=[vfs=pax.kutz] host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im time=1482263370831 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] http header                                   Libstorage-Localdevices=[vfs=/dev/xvda::/var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605/vfs-000,/dev/xvdb::/var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605/vfs-001] host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im time=1482263370831 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] getting task service                          host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im time=1482263370831 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] getting task service                          host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im time=1482263370831 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] getting task service                          host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im time=1482263370831 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
INFO[0001] executing task                                host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im task=0 time=1482263370831 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
INFO[0001] executing task                                host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im task=1 time=1482263370831 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] vfs login=vfs=pax.kutz                        host=tcp://127.0.0.1:26344 instanceID=vfs=pax.kutz route=volumes server=shade-throat-im service=vfs storageDriver=vfs task=0 time=1482263370831 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] getting task service                          host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im task=1 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] querying volumes                              attachments=27 host=tcp://127.0.0.1:26344 instanceID=vfs=pax.kutz route=volumes server=shade-throat-im service=vfs storageDriver=vfs task=0 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] manually calculating attachment state         attachments=27 host=tcp://127.0.0.1:26344 instanceID=vfs=pax.kutz route=volumes server=shade-throat-im service=vfs storageDriver=vfs task=0 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2 volumeID=vfs-000 volumeName=Volume 000
DEBU[0001] including volume                              attachmentState=attached attachments=27 host=tcp://127.0.0.1:26344 instanceID=vfs=pax.kutz route=volumes server=shade-throat-im service=vfs storageDriver=vfs task=0 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2 volumeID=vfs-000 volumeName=Volume 000
DEBU[0001] manually calculating attachment state         attachments=27 host=tcp://127.0.0.1:26344 instanceID=vfs=pax.kutz route=volumes server=shade-throat-im service=vfs storageDriver=vfs task=0 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2 volumeID=vfs-001 volumeName=Volume 001
DEBU[0001] including volume                              attachmentState=attached attachments=27 host=tcp://127.0.0.1:26344 instanceID=vfs=pax.kutz route=volumes server=shade-throat-im service=vfs storageDriver=vfs task=0 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2 volumeID=vfs-001 volumeName=Volume 001
DEBU[0001] getting task service                          host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] manually calculating attachment state         attachments=27 host=tcp://127.0.0.1:26344 instanceID=vfs=pax.kutz route=volumes server=shade-throat-im service=vfs storageDriver=vfs task=0 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2 volumeID=vfs-002 volumeName=Volume 002
DEBU[0001] including volume                              attachmentState=available attachments=27 host=tcp://127.0.0.1:26344 instanceID=vfs=pax.kutz route=volumes server=shade-throat-im service=vfs storageDriver=vfs task=0 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2 volumeID=vfs-002 volumeName=Volume 002
DEBU[0001] skipping response schema validation; disabled  host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im task=0 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] task completed                                host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im task=0 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] skipping response schema validation; disabled  host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im task=1 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
DEBU[0001] task completed                                host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im task=1 time=1482263370832 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
INFO[0001] 127.0.0.1 - - [20/Dec/2016:13:49:30 -0600] "GET /volumes?attachments=27 HTTP/1.1" 200 1346 
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP REQUEST (SERVER) -------------------------- 
INFO[0001]     GET /volumes?attachments=27 HTTP/1.1     
INFO[0001]     Host: 127.0.0.1:26344                    
INFO[0001]     Accept-Encoding: gzip                    
INFO[0001]     Libstorage-Instanceid: vfs=pax.kutz      
INFO[0001]     Libstorage-Localdevices: vfs=/dev/xvda::/var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605/vfs-000,/dev/xvdb::/var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605/vfs-001 
INFO[0001]     Libstorage-Tx: txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2, txCR=1482263370 
INFO[0001]     User-Agent: Go-http-client/1.1           
INFO[0001]                                              
INFO[0001]     -------------------------- HTTP RESPONSE (SERVER) ------------------------- 
INFO[0001]     Content-Type=application/json            
INFO[0001]                                              
INFO[0001]     {                                        
INFO[0001]       "vfs": {                               
INFO[0001]         "vfs-000": {                         
INFO[0001]           "attachments": [                   
INFO[0001]             {                                
INFO[0001]                                              
INFO[0001]               "deviceName": "",              
INFO[0001]               "instanceID": {                
INFO[0001]                 "id": "pax.kutz",            
INFO[0001]                 "driver": ""                 
INFO[0001]               },                             
INFO[0001]               "status": "attached",          
INFO[0001]     -------------------------- HTTP RESPONSE (CLIENT) ------------------------- 
INFO[0001]               "volumeID": "000"              
INFO[0001]             }                                
INFO[0001]           ],                                 
INFO[0001]           "attachmentState": 2,              
INFO[0001]           "availabilityZone": "US",          
INFO[0001]           "iops": 1000,                      
INFO[0001]           "name": "Volume 000",              
INFO[0001]           "size": 10240,                     
INFO[0001]           "id": "vfs-000",                   
INFO[0001]           "type": "myType",                  
INFO[0001]           "fields": {                        
INFO[0001]             "owner": "root@example.com",     
INFO[0001]             "priority": "2"                  
INFO[0001]           }                                  
INFO[0001]         },                                   
INFO[0001]         "vfs-001": {                         
INFO[0001]           "attachments": [                   
INFO[0001]             {                                
INFO[0001]               "deviceName": "",              
INFO[0001]               "instanceID": {                
INFO[0001]                 "id": "pax.kutz",            
INFO[0001]                 "driver": ""                 
INFO[0001]               },                             
INFO[0001]               "status": "attached",          
INFO[0001]               "volumeID": "001"              
INFO[0001]             }                                
INFO[0001]           ],                                 
INFO[0001]           "attachmentState": 2,              
INFO[0001]           "availabilityZone": "US",          
INFO[0001]           "iops": 1000,                      
INFO[0001]           "name": "Volume 001",              
INFO[0001]           "size": 10240,                     
INFO[0001]           "id": "vfs-001",                   
INFO[0001]           "type": "myType",                  
INFO[0001]           "fields": {                        
INFO[0001]             "owner": "root@example.com",     
INFO[0001]             "priority": "2"                  
INFO[0001]           }                                  
INFO[0001]         },                                   
INFO[0001]         "vfs-002": {                         
INFO[0001]           "attachmentState": 3,              
INFO[0001]     HTTP/1.1 200 OK                          
INFO[0001]           "availabilityZone": "US",          
INFO[0001]     Content-Length: 1346                     
INFO[0001]           "iops": 1000,                      
INFO[0001]           "name": "Volume 002",              
INFO[0001]           "size": 10240,                     
INFO[0001]           "id": "vfs-002",                   
INFO[0001]           "type": "myType",                  
INFO[0001]     Content-Type: application/json           
INFO[0001]           "fields": {                        
INFO[0001]             "owner": "root@example.com",     
INFO[0001]             "priority": "2"                  
INFO[0001]           }                                  
INFO[0001]     Date: Tue, 20 Dec 2016 19:49:30 GMT      
INFO[0001]         }                                    
INFO[0001]     Libstorage-Servername: shade-throat-im   
INFO[0001]       }                                      
INFO[0001]                                              
INFO[0001]     }                                        
INFO[0001]     {                                        
INFO[0001]       "vfs": {                               
INFO[0001]         "vfs-000": {                         
INFO[0001]           "attachments": [                   
INFO[0001]             {                                
INFO[0001]               "deviceName": "",              
INFO[0001]               "instanceID": {                
DEBU[0001] removing task                                 host=tcp://127.0.0.1:26344 removedAfter=0s route=volumes server=shade-throat-im task=0 tasksLen=2 time=1482263370834 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
INFO[0001]                 "id": "pax.kutz",            
INFO[0001]                 "driver": ""                 
INFO[0001]               },                             
DEBU[0001] removed task                                  host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im task=0 tasksLen=1 time=1482263370834 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
INFO[0001]               "status": "attached",          
INFO[0001]               "volumeID": "000"              
INFO[0001]             }                                
INFO[0001]           ],                                 
INFO[0001]           "attachmentState": 2,              
INFO[0001]           "availabilityZone": "US",          
INFO[0001]           "iops": 1000,                      
INFO[0001]           "name": "Volume 000",              
INFO[0001]           "size": 10240,                     
INFO[0001]           "id": "vfs-000",                   
INFO[0001]           "type": "myType",                  
INFO[0001]           "fields": {                        
INFO[0001]             "owner": "root@example.com",     
INFO[0001]             "priority": "2"                  
INFO[0001]           }                                  
INFO[0001]         },                                   
INFO[0001]         "vfs-001": {                         
INFO[0001]           "attachments": [                   
INFO[0001]             {                                
DEBU[0001] removing task                                 host=tcp://127.0.0.1:26344 removedAfter=0s route=volumes server=shade-throat-im task=1 tasksLen=1 time=1482263370834 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
INFO[0001]               "deviceName": "",              
INFO[0001]               "instanceID": {                
INFO[0001]                 "id": "pax.kutz",            
INFO[0001]                 "driver": ""                 
DEBU[0001] removed task                                  host=tcp://127.0.0.1:26344 route=volumes server=shade-throat-im task=1 tasksLen=0 time=1482263370834 tls=false txCR=1482263370 txID=fcdc315c-bb26-4d67-5a0a-8ae3da2763b2
INFO[0001]               },                             
INFO[0001]               "status": "attached",          
INFO[0001]               "volumeID": "001"              
INFO[0001]             }                                
INFO[0001]           ],                                 
INFO[0001]           "attachmentState": 2,              
INFO[0001]           "availabilityZone": "US",          
INFO[0001]           "iops": 1000,                      
INFO[0001]           "name": "Volume 001",              
INFO[0001]           "size": 10240,                     
INFO[0001]           "id": "vfs-001",                   
INFO[0001]           "type": "myType",                  
INFO[0001]           "fields": {                        
INFO[0001]             "owner": "root@example.com",     
INFO[0001]             "priority": "2"                  
INFO[0001]           }                                  
INFO[0001]         },                                   
INFO[0001]         "vfs-002": {                         
INFO[0001]           "attachmentState": 3,              
INFO[0001]           "availabilityZone": "US",          
INFO[0001]           "iops": 1000,                      
INFO[0001]           "name": "Volume 002",              
INFO[0001]           "size": 10240,                     
INFO[0001]           "id": "vfs-002",                   
INFO[0001]           "type": "myType",                  
INFO[0001]           "fields": {                        
INFO[0001]             "owner": "root@example.com",     
INFO[0001]             "priority": "2"                  
INFO[0001]           }                                  
INFO[0001]         }                                    
INFO[0001]       }                                      
INFO[0001]     }                                        
INFO[0001] shutting down server                          server=shade-throat-im time=1482263370835
INFO[0001] shutting down endpoint                        host=tcp://127.0.0.1:26344 server=shade-throat-im time=1482263370835 tls=false
DEBU[0001] shutdown endpoint complete                    host=tcp://127.0.0.1:26344 server=shade-throat-im time=1482263370835 tls=false
DEBU[0001] shutdown server complete                      server=shade-throat-im time=1482263370835
DEBU[0001] received close signal                         server=shade-throat-im time=1482263370835
INFO[0001] closed server error channel                   server=shade-throat-im time=1482263370835
--- PASS: TestVolumesWithAttachmentsAttachedToMeAndAvailable (1.21s)
	vfs_test.go:935: created temp vfs root dir: /var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605
	vfs_test.go:948: created temp vfs vol dir: /var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605/vol
	vfs_test.go:954: created temp vfs snap dir: /var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605/snap
	vfs_test.go:963: created temp vfs dev file: /var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605/dev
PASS
DEBU[0001] removed test dir                              path=/var/folders/48/52fjq9r10zx3gnm7j57th0500000gn/T/231237605
ok  	github.com/codedellemc/libstorage/drivers/storage/vfs/tests	1.480s
[0]akutz@pax:libstorage$ 
```