### PR TITLE
rbd: require attach state to be available to attach

### DIFF
--- a/drivers/storage/rbd/tests/rbd_test.go
+++ b/drivers/storage/rbd/tests/rbd_test.go
@@ -385,6 +385,23 @@ func volumeInspectAvailable(
 	return reply
 }
 
+func volumeAttachFail(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+
+	log.WithField("volumeID", volumeID).Info("attaching volume")
+	reply, _, err := client.API().VolumeAttach(
+		nil, rbd.Name, volumeID, &types.VolumeAttachRequest{})
+
+	assert.Error(t, err)
+	if err == nil {
+		t.Error("volumeAttach succeeded when it should have failed")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+
+	return reply
+}
+
 func TestVolumeAttach(t *testing.T) {
 	if skipTests() {
 		t.SkipNow()
@@ -396,6 +413,7 @@ func TestVolumeAttach(t *testing.T) {
 		_ = volumeInspectAttached(t, client, vol.ID)
 		_ = volumeInspectAttachedDevices(t, client, vol.ID)
 		_ = volumeInspectNoAttachments(t, client, vol.ID)
+		_ = volumeAttachFail(t, client, vol.ID)
 		_ = volumeDetach(t, client, vol.ID)
 		_ = volumeInspectDetached(t, client, vol.ID)
 		_ = volumeInspectAvailable(t, client, vol.ID)


### PR DESCRIPTION
The `VolumeAttach` method was blindly proceeded with the steps to do an actual attach of the volume to the host.  I had incorrectly thought that `rexray` would not allow a call to attach a volume that wasn't available. Even if it did, it is incorrect to rely on `rexray` behavior to handle error cases -- `rexray` is just one of many possible clients, and it is up to the driver to enforce valid behavior.

This patch makes sure the volume is available before proceeding with the attach, and includes a testcase that catches the error. Multiple calls to `rbd map` of the same device on the same host will actually succeed, so we can test this scenario on a single host.

Before the fix:

```
[vagrant@libstorage-rbd-test-admin ~]$ sudo ./rbd.test -test.run VolumeAttach
--- FAIL: TestVolumeAttach (2.25s)
	tests.go:506: {
		  "attachmentState": 3,
		  "name": "6b8d1864",
		  "size": 8,
		  "id": "rbd.6b8d1864",
		  "type": "rbd"
		}
	tests.go:506: {
		  "attachments": [
		    {
		      "deviceName": "",
		      "instanceID": {
		        "id": "172.21.13.10",
		        "driver": "rbd"
		      },
		      "status": "",
		      "volumeID": "rbd.6b8d1864"
		    }
		  ],
		  "attachmentState": 2,
		  "name": "6b8d1864",
		  "size": 8,
		  "id": "rbd.6b8d1864",
		  "type": "rbd"
		}
	tests.go:506: {
		  "attachments": [
		    {
		      "deviceName": "",
		      "instanceID": {
		        "id": "172.21.13.10",
		        "driver": "rbd"
		      },
		      "status": "",
		      "volumeID": "rbd.6b8d1864"
		    }
		  ],
		  "attachmentState": 2,
		  "name": "6b8d1864",
		  "size": 8,
		  "id": "rbd.6b8d1864",
		  "type": "rbd"
		}
	tests.go:506: {
		  "attachments": [
		    {
		      "deviceName": "/dev/rbd0",
		      "instanceID": {
		        "id": "172.21.13.10",
		        "driver": "rbd"
		      },
		      "status": "",
		      "volumeID": "rbd.6b8d1864"
		    }
		  ],
		  "attachmentState": 2,
		  "name": "6b8d1864",
		  "size": 8,
		  "id": "rbd.6b8d1864",
		  "type": "rbd"
		}
	tests.go:506: {
		  "name": "6b8d1864",
		  "size": 8,
		  "id": "rbd.6b8d1864",
		  "type": "rbd"
		}
        Error Trace:    rbd_test.go:395
			rbd_test.go:416
			tests.go:290
			asm_amd64.s:2086
	Error:		An error is expected but got nil.

	rbd_test.go:397: volumeAttach succeeded when it should have failed
FAIL
coverage: 6.5% of statements in github.com/codedellemc/libstorage/drivers/storage/rbd, github.com/codedellemc/libstorage/drivers/storage/rbd/executor
```

After the fix:

```
[vagrant@libstorage-rbd-test-admin ~]$ sudo ./rbd.test -test.run VolumeAttach
PASS
coverage: 6.5% of statements in github.com/codedellemc/libstorage/drivers/storage/rbd, github.com/codedellemc/libstorage/drivers/storage/rbd/executor
```