### PR TITLE
Fix for Attachment Filtering on Unavailable Vols

### DIFF
--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -167,8 +167,9 @@ func handleVolAttachments(
 		// volume
 		if attachments.Mine() &&
 			attachments.Attached() &&
-			(s == types.VolumeAvailable || s == types.VolumeUnavailable) &&
-			!attachments.Unattached() {
+			((s == types.VolumeAvailable && !attachments.Unattached()) ||
+				s == types.VolumeUnavailable) {
+			//!attachments.Unattached() {
 			ctx.WithFields(lf).Debug("omitting unavailable volume")
 			return false
 		}

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -320,9 +320,46 @@ func TestVolumesWithAttachmentsAttachedAndMineWithNotMyInstanceID(
 			t.Fatal(err)
 		}
 
-		assert.Nil(t, reply["vfs"]["vfs-000"])
-		assert.Nil(t, reply["vfs"]["vfs-001"])
-		assert.Nil(t, reply["vfs"]["vfs-002"])
+		if !assert.Nil(t, reply["vfs"]["vfs-000"]) {
+			t.FailNow()
+		}
+		if !assert.Nil(t, reply["vfs"]["vfs-001"]) {
+			t.FailNow()
+		}
+		if !assert.Nil(t, reply["vfs"]["vfs-002"]) {
+			t.FailNow()
+		}
+	}
+	apitests.RunWithClientType(t, types.ControllerClient, vfs.Name, tc, tf)
+}
+
+func TestVolumesWithAttachmentsAttachedAndMineOrUnattachedWithNotMyInstanceID(
+	t *testing.T) {
+	t.SkipNow()
+	tc, _, _, _ := newTestConfigAll(t)
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+
+		ctx := context.Background()
+		iidm := types.InstanceIDMap{
+			"vfs": &types.InstanceID{ID: "none", Driver: "vfs"},
+		}
+		ctx = ctx.WithValue(context.AllInstanceIDsKey, iidm)
+
+		reply, err := client.API().Volumes(ctx,
+			types.VolAttReqWithDevMapOnlyVolsAttachedToInstanceOrUnattachedVols)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !assert.Nil(t, reply["vfs"]["vfs-000"]) {
+			t.FailNow()
+		}
+		if !assert.Nil(t, reply["vfs"]["vfs-001"]) {
+			t.FailNow()
+		}
+		if !assert.Nil(t, reply["vfs"]["vfs-002"]) {
+			t.FailNow()
+		}
 	}
 	apitests.RunWithClientType(t, types.ControllerClient, vfs.Name, tc, tf)
 }
@@ -973,7 +1010,7 @@ func newTestConfigAll(
 		if x < 2 {
 			vj = []byte(fmt.Sprintf(volJSON, x, hostName))
 		} else {
-			vj = []byte(fmt.Sprintf(volNoAttachJSON, x, hostName))
+			vj = []byte(fmt.Sprintf(volNoAttachJSON, x))
 		}
 		v := &types.Volume{}
 		if err := json.Unmarshal(vj, v); err != nil {


### PR DESCRIPTION
This patch should fix the issue where volumes are not filtered with a mask of 31 if they're unavailable.

This is related to #382.