### PR TITLE
Add storage driver template

### DIFF
--- a/drivers/storage/template/executor/DRIVERNAME_executor.go
+++ b/drivers/storage/template/executor/DRIVERNAME_executor.go
@@ -1,0 +1,67 @@
+// +build !libstorage_storage_executor libstorage_storage_executor_DRIVERNAME
+
+package executor
+
+import (
+	gofig "github.com/akutz/gofig/types"
+
+	"github.com/codedellemc/libstorage/api/registry"
+	"github.com/codedellemc/libstorage/api/types"
+	"github.com/codedellemc/libstorage/drivers/storage/template"
+)
+
+// driver is the storage executor for the storage driver.
+type driver struct {
+	config gofig.Config
+}
+
+func init() {
+	registry.RegisterStorageExecutor(template.Name, newDriver)
+}
+
+func newDriver() types.StorageExecutor {
+	return &driver{}
+}
+
+func (d *driver) Init(ctx types.Context, config gofig.Config) error {
+	d.config = config
+	return nil
+}
+
+func (d *driver) Name() string {
+	return template.Name
+}
+
+// Supported returns a flag indicating whether or not the platform
+// implementing the executor is valid for the host on which the executor
+// resides.
+func (d *driver) Supported(
+	ctx types.Context,
+	opts types.Store) (bool, error) {
+
+	return false, types.ErrNotImplemented
+}
+
+// InstanceID returns the instance ID from the current instance from metadata
+func (d *driver) InstanceID(
+	ctx types.Context,
+	opts types.Store) (*types.InstanceID, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// NextDevice returns the next available device.
+func (d *driver) NextDevice(
+	ctx types.Context,
+	opts types.Store) (string, error) {
+
+	return "", types.ErrNotImplemented
+}
+
+// Retrieve device paths currently attached and/or mounted
+func (d *driver) LocalDevices(
+	ctx types.Context,
+	opts *types.LocalDevicesOpts) (*types.LocalDevices, error) {
+
+	return nil, types.ErrNotImplemented
+}

--- a/drivers/storage/template/storage/DRIVERNAME_storage.go
+++ b/drivers/storage/template/storage/DRIVERNAME_storage.go
@@ -1,0 +1,179 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_DRIVERNAME
+
+package storage
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	gofig "github.com/akutz/gofig/types"
+
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/registry"
+	"github.com/codedellemc/libstorage/api/types"
+	"github.com/codedellemc/libstorage/drivers/storage/template"
+)
+
+type driver struct {
+	config gofig.Config
+}
+
+func init() {
+	registry.RegisterStorageDriver(template.Name, newDriver)
+}
+
+func newDriver() types.StorageDriver {
+	return &driver{}
+}
+
+func (d *driver) Name() string {
+	return template.Name
+}
+
+// Init initializes the driver.
+func (d *driver) Init(context types.Context, config gofig.Config) error {
+	d.config = config
+	log.Info("storage driver initialized")
+	return nil
+}
+
+// NextDeviceInfo returns the information about the driver's next available
+// device workflow.
+func (d *driver) NextDeviceInfo(
+	ctx types.Context) (*types.NextDeviceInfo, error) {
+	return nil, types.ErrNotImplemented
+}
+
+// Type returns the type of storage the driver provides.
+func (d *driver) Type(ctx types.Context) (types.StorageType, error) {
+	//Example: Block storage
+	return types.Block, types.ErrNotImplemented
+}
+
+// InstanceInspect returns an instance.
+func (d *driver) InstanceInspect(
+	ctx types.Context,
+	opts types.Store) (*types.Instance, error) {
+
+	iid := context.MustInstanceID(ctx)
+	return &types.Instance{
+		InstanceID: iid,
+	}, nil
+}
+
+// Volumes returns all volumes or a filtered list of volumes.
+func (d *driver) Volumes(
+	ctx types.Context,
+	opts *types.VolumesOpts) ([]*types.Volume, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// VolumeInspect inspects a single volume.
+func (d *driver) VolumeInspect(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeInspectOpts) (*types.Volume, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// VolumeCreate creates a new volume.
+func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// VolumeCreateFromSnapshot creates a new volume from an existing snapshot.
+func (d *driver) VolumeCreateFromSnapshot(
+	ctx types.Context,
+	snapshotID, volumeName string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// VolumeCopy copies an existing volume.
+func (d *driver) VolumeCopy(
+	ctx types.Context,
+	volumeID, volumeName string,
+	opts types.Store) (*types.Volume, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// VolumeSnapshot snapshots a volume.
+func (d *driver) VolumeSnapshot(
+	ctx types.Context,
+	volumeID, snapshotName string,
+	opts types.Store) (*types.Snapshot, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// VolumeRemove removes a volume.
+func (d *driver) VolumeRemove(
+	ctx types.Context,
+	volumeID string,
+	opts types.Store) error {
+
+	return types.ErrNotImplemented
+}
+
+// VolumeAttach attaches a volume and provides a token clients can use
+// to validate that device has appeared locally.
+func (d *driver) VolumeAttach(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
+
+	return nil, "", types.ErrNotImplemented
+}
+
+// VolumeDetach detaches a volume.
+func (d *driver) VolumeDetach(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeDetachOpts) (*types.Volume, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// Snapshots returns all volumes or a filtered list of snapshots.
+func (d *driver) Snapshots(
+	ctx types.Context,
+	opts types.Store) ([]*types.Snapshot, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// SnapshotInspect inspects a single snapshot.
+func (d *driver) SnapshotInspect(
+	ctx types.Context,
+	snapshotID string,
+	opts types.Store) (*types.Snapshot, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// SnapshotCopy copies an existing snapshot.
+func (d *driver) SnapshotCopy(
+	ctx types.Context,
+	snapshotID, snapshotName, destinationID string,
+	opts types.Store) (*types.Snapshot, error) {
+
+	return nil, types.ErrNotImplemented
+}
+
+// SnapshotRemove removes a snapshot.
+func (d *driver) SnapshotRemove(
+	ctx types.Context,
+	snapshotID string,
+	opts types.Store) error {
+
+	return types.ErrNotImplemented
+}
+
+///////////////////////////////////////////////////////////////////////
+/////////        HELPER FUNCTIONS SPECIFIC TO PROVIDER        /////////
+///////////////////////////////////////////////////////////////////////

--- a/drivers/storage/template/template.go
+++ b/drivers/storage/template/template.go
@@ -1,0 +1,16 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_DRIVERNAME
+
+package template
+
+import gofigCore "github.com/akutz/gofig"
+
+const (
+	// Name is the provider's name.
+	Name = "DRIVERNAME"
+)
+
+func init() {
+	r := gofigCore.NewRegistration("DRIVERNAME")
+
+	gofigCore.Register(r)
+}

--- a/drivers/storage/template/tests/DRIVERNAME_test.go
+++ b/drivers/storage/template/tests/DRIVERNAME_test.go
@@ -1,0 +1,44 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_DRIVERNAME
+
+package DRIVERNAME
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/codedellemc/libstorage/api/server"
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+// Put contents of sample config.yml here
+var (
+	configYAML = []byte(``)
+)
+
+var volumeName string
+var volumeName2 string
+
+// Check environment vars to see whether or not to run this test
+func skipTests() bool {
+	travis, _ := strconv.ParseBool(os.Getenv("TRAVIS"))
+	noTest, _ := strconv.ParseBool(os.Getenv("TEST_SKIP_DRIVERNAME"))
+	return travis || noTest
+}
+
+// Set volume names to first part of UUID before the -
+func init() {
+	uuid, _ := types.NewUUID()
+	uuids := strings.Split(uuid.String(), "-")
+	volumeName = uuids[0]
+	uuid, _ = types.NewUUID()
+	uuids = strings.Split(uuid.String(), "-")
+	volumeName2 = uuids[0]
+}
+
+func TestMain(m *testing.M) {
+	server.CloseOnAbort()
+	ec := m.Run()
+	os.Exit(ec)
+}

--- a/drivers/storage/template/tests/coverage.mk
+++ b/drivers/storage/template/tests/coverage.mk
@@ -1,0 +1,2 @@
+DRIVERNAME_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/template
+TEST_COVERPKG_./drivers/storage/template/tests := $(DRIVERNAME_COVERPKG),$(DRIVERNAME_COVERPKG)/executor


### PR DESCRIPTION
Introduce a storage driver template to make it easier for developers to
start adding a new driver from scratch. Includes all required public
methods except for the `Login` method in the storage package.