### PR TITLE
Fix nil deref for lsx localdevices

### DIFF
--- a/cli/lsx/lsx.go
+++ b/cli/lsx/lsx.go
@@ -107,10 +107,10 @@ func Run() {
 			ScanType: apitypes.ParseDeviceScanType(args[3]),
 			Opts:     store,
 		})
-		opResult.Driver = driverName
 		if opErr != nil {
 			err = opErr
 		} else {
+			opResult.Driver = driverName
 			result = opResult
 		}
 	} else if strings.EqualFold(cmd, apitypes.LSXCmdWaitForDevice) {


### PR DESCRIPTION
When the executor CLI was just to get local devices, a nil dereference
could happen if the driver executor return an err and a nil pointer, as
the nil pointer was always dereferenced without checking err first.