### PR TITLE
Renamed Docker Int Driver to Linux Int Driver

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -610,9 +610,9 @@ integration drivers are supported:
 
  Driver | Driver Name
 --------|------------
-Docker   | docker
+Linux   | linux
 
-The integration driver `docker` provides necessary functionality to enable
+The integration driver `linux` provides necessary functionality to enable
 most consuming platforms to work with storage volumes.
 
 ### Volume Configuration

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 ifeq (undefined,$(origin BUILD_TAGS))
 BUILD_TAGS :=   gofig \
 				pflag \
-				libstorage_integration_driver_docker
+				libstorage_integration_driver_linux
 ifneq (true,$(TRAVIS))
 BUILD_TAGS +=   libstorage_storage_driver \
 				libstorage_storage_driver_vfs \

--- a/drivers/integration/linux/linux.go
+++ b/drivers/integration/linux/linux.go
@@ -1,4 +1,4 @@
-package docker
+package linux
 
 import (
 	"os"
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	providerName            = "docker"
+	providerName            = "linux"
 	defaultVolumeSize int64 = 16
 )
 
@@ -66,7 +66,7 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 		types.ConfigIgVolOpsCreateDefaultFsType: d.fsType(),
 		types.ConfigIgVolOpsMountPath:           d.mountDirPath(),
 		types.ConfigIgVolOpsCreateImplicit:      d.volumeCreateImplicit(),
-	}).Info("docker integration driver successfully initialized")
+	}).Info("linux integration driver successfully initialized")
 
 	return nil
 }

--- a/drivers/integration/linux/linux_gofig.go
+++ b/drivers/integration/linux/linux_gofig.go
@@ -1,6 +1,6 @@
 // +build gofig
 
-package docker
+package linux
 
 import (
 	gofigCore "github.com/akutz/gofig"
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	r := gofigCore.NewRegistration("Docker")
+	r := gofigCore.NewRegistration("Integration")
 	r.Key(gofig.String, "", "ext4", "",
 		types.ConfigIgVolOpsCreateDefaultFsType)
 	r.Key(gofig.String, "", "", "", types.ConfigIgVolOpsCreateDefaultType)

--- a/drivers/integration/linux/linux_utils.go
+++ b/drivers/integration/linux/linux_utils.go
@@ -1,4 +1,4 @@
-package docker
+package linux
 
 import (
 	"fmt"

--- a/imports/config/imports_config_11_int_docker.go
+++ b/imports/config/imports_config_11_int_docker.go
@@ -1,7 +1,0 @@
-// +build libstorage_integration_driver_docker
-
-package config
-
-func init() {
-	defaultIntDriver = "docker"
-}

--- a/imports/config/imports_config_11_int_linux.go
+++ b/imports/config/imports_config_11_int_linux.go
@@ -1,0 +1,7 @@
+// +build libstorage_integration_driver_linux
+
+package config
+
+func init() {
+	defaultIntDriver = "linux"
+}

--- a/imports/local/imports_local_int_docker.go
+++ b/imports/local/imports_local_int_docker.go
@@ -1,8 +1,0 @@
-// +build libstorage_integration_driver_docker
-
-package local
-
-import (
-	// load the packages
-	_ "github.com/codedellemc/libstorage/drivers/integration/docker"
-)

--- a/imports/local/imports_local_int_linux.go
+++ b/imports/local/imports_local_int_linux.go
@@ -1,0 +1,8 @@
+// +build libstorage_integration_driver_linux
+
+package local
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/integration/linux"
+)


### PR DESCRIPTION
The Docker Integration driver has been renamed to the more appropriate Linux Integration driver. All of the functionality is the same except the driver's key is now `linux` instead of `docker` and the package is `github.com/codedellemc/libstorage/drivers/integration/linux`.