### PR TITLE
Fix for Linux Int Driver's Mount/Preempt

### DIFF
--- a/drivers/integration/linux/linux.go
+++ b/drivers/integration/linux/linux.go
@@ -168,12 +168,14 @@ func (d *driver) Mount(
 		"volumeID":   volumeID,
 		"opts":       opts}).Info("mounting volume")
 
+	lsAtt := types.VolAttReqWithDevMapOnlyVolsAttachedToInstanceOrUnattachedVols
+	if opts.Preempt {
+		lsAtt = types.VolAttReq
+	}
+
 	vol, err := d.volumeInspectByIDOrName(
-		ctx, volumeID, volumeName,
-		types.VolAttReqWithDevMapOnlyVolsAttachedToInstanceOrUnattachedVols,
-		opts.Opts)
+		ctx, volumeID, volumeName, lsAtt, opts.Opts)
 	if isErrNotFound(err) && d.volumeCreateImplicit() {
-		var err error
 		if vol, err = d.Create(ctx, volumeName, &types.VolumeCreateOpts{
 			Opts: utils.NewStore(),
 		}); err != nil {


### PR DESCRIPTION
This patch fixes the Linux integration driver's Mount function so that it respects the preempt option as described in issue #389.