### PR TITLE
Executor Supported Enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -865,6 +865,11 @@ $$(LSX_EMBEDDED_$2): $1
 ifeq (linux,$2)
 EXECUTORS_EMBEDDED += $$(LSX_EMBEDDED_$2)
 endif
+ifeq (darwin,$2)
+ifeq (1,$$(EMBED_EXECUTOR_DARWIN))
+EXECUTORS_EMBEDDED += $$(LSX_EMBEDDED_$2)
+endif
+endif
 endef
 
 $(eval $(call EXECUTOR_RULES,$(EXECUTOR_LINUX),linux))

--- a/drivers/storage/libstorage/libstorage_driver.go
+++ b/drivers/storage/libstorage/libstorage_driver.go
@@ -106,7 +106,7 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 		}
 
 		d.lsxCache = &lss{Store: utils.NewStore()}
-		d.supportedCache = utils.NewStore()
+		d.supportedCache = &lss{Store: utils.NewStore()}
 		d.instanceIDCache = &lss{Store: newIIDCache()}
 	}
 

--- a/drivers/storage/libstorage/libstorage_store.go
+++ b/drivers/storage/libstorage/libstorage_store.go
@@ -23,3 +23,10 @@ func (s *lss) GetExecutorInfo(lsx string) *types.ExecutorInfo {
 func (s *lss) GetInstanceID(driverName string) *types.InstanceID {
 	return s.Store.GetInstanceID(driverName)
 }
+
+func (s *lss) GetLSXSupported(driverName string) types.LSXSupportedOp {
+	if obj, ok := s.Store.Get(driverName).(types.LSXSupportedOp); ok {
+		return obj
+	}
+	return 0
+}

--- a/drivers/storage/vfs/executor/vfs_executor.go
+++ b/drivers/storage/vfs/executor/vfs_executor.go
@@ -70,6 +70,27 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 	return nil
 }
 
+// Mount mounts a device to a specified path.
+func (d *driver) Mount(
+	ctx types.Context,
+	deviceName, mountPoint string,
+	opts *types.DeviceMountOpts) error {
+
+	return os.MkdirAll(mountPoint, 0755)
+}
+
+// Unmount unmounts the underlying device from the specified path.
+func (d *driver) Unmount(
+	ctx types.Context,
+	mountPoint string,
+	opts types.Store) error {
+
+	if !gotil.FileExists(mountPoint) {
+		return os.ErrNotExist
+	}
+	return os.RemoveAll(mountPoint)
+}
+
 // InstanceID returns the local system's InstanceID.
 func (d *driver) InstanceID(
 	ctx types.Context,


### PR DESCRIPTION
This patch enhances the executor CLI to change the behavior of the "supported" function. Internally, storage platforms will still implement the same "Supported" function as previously, but now the executor CLI returns more than simply a flag. The executor CLI will now return a bitmask that corresponds to the functions supported by a storage platform on the executing host. This provides a means to indicate whether an executor supports mounting/unmounting for a given storage platform. The update also centralizes the query for future additions to the executor logic.

This patch also introduces the interface `StorageExecutorWithMount` with two new functions, `Mount` and `Unmount`, but these functions are not yet a part of the storage workflow.

This is a WiP. I will likely squash a future commit onto this PR that allows the new mount functionality in the executor to participate in the standard workflow. I just pushed the PR in order to allow others to review the work so far.