### PR TITLE
Fix num arg checking for lsx wait

### DIFF
--- a/cli/lsx/lsx.go
+++ b/cli/lsx/lsx.go
@@ -186,7 +186,7 @@ func Run() {
 			result = opResult
 		}
 	} else if strings.EqualFold(cmd, apitypes.LSXCmdWaitForDevice) {
-		if len(args) < 5 {
+		if len(args) < 6 {
 			printUsageAndExit()
 		}
 		op = "wait"


### PR DESCRIPTION
The check to make sure the lsx wait command had the minimum number of
args was one less than it needs to be.

If you accidentally leave off the timeout param, you get panic, index out of range error from line 199:

```
Timeout: utils.DeviceAttachTimeout(args[5]),
```