### PR TITLE
Skeleton for the ScaleIO end-to-end test

### DIFF
--- a/drivers/storage/scaleio/tests/README.md
+++ b/drivers/storage/scaleio/tests/README.md
@@ -1,0 +1,31 @@
+# ScaleIO driver testing
+
+ScaleIO driver requires valid AWS environment in which tests can run. The
+requirements are:
+
+* **VPC**: Private network where EC2 instance and ScaleIO instance can be launched
+
+* **Subnet**: In VPC it requires at least one valid Subnet for EC2 instance and
+  ScaleIO
+
+* **EC2**: Any EC2 instance that has permission to run ScaleIO plugin. For list of
+  IAM permissions see user documentation.
+
+For automated testing there are couple script available that will spin up
+while AWS environment by using CloudFormation service.
+
+* `./test-env-up.sh [access-key] [secret-key] [stack-name] [key-name]` -
+  should be used to launch whole AWS environment required for ScaleIO storage
+  driver testing.
+  `[access-key]: AWS access key`
+  `[secret-key]: AWS secret key`
+  `[stack-name]: AWS stack name that must be uniquely identifiable`
+  `[key-name]: AWS key that will be used to launch EC2 instance`
+
+* `./test-run.sh [stack-name] [rexray-path]` - to run the tests on EC2 instance.
+  `[stack-name]` is the same name used in the setup process.
+  `[rexray-path]` is the fully qualified path to the REX-Ray binary to test.
+
+* `./test-env-down.sh [stack-name]` - to tear down AWS environment infrastructure
+  and clean up all resources.
+  `[stack-name]` is the same name used in the setup and testing process.

--- a/drivers/storage/scaleio/tests/config.yml
+++ b/drivers/storage/scaleio/tests/config.yml
@@ -1,0 +1,40 @@
+rexray:
+  logLevel: debug
+  modules:
+    default-docker:
+      type: docker
+      libstorage:
+        service: scaleio
+      host: unix:///run/docker/plugins/docker.sock
+    mesos:
+      type: docker
+      libstorage:
+        service: scaleio
+      host: unix:///run/docker/plugins/mesos.sock
+      libstorage:
+        integration:
+          volume:
+            operations:
+              unmount:
+                ignoreUsedCount: true
+    rexray:
+      type: docker
+      libstorage:
+        service: scaleio
+      host: unix:///run/docker/plugins/rexray.sock
+libstorage:
+  service: scaleio
+  integration:
+    volume:
+      operations:
+        mount:
+          preempt: true
+scaleio:
+  endpoint: https://10.0.0.11/api
+  insecure: true
+  thinOrThick: ThinProvisioned
+  userName: admin
+  password: F00barbaz
+  systemId: 6f831c6866417634
+  protectionDomainName: default
+  storagePoolName: default

--- a/drivers/storage/scaleio/tests/test-cf-template.json
+++ b/drivers/storage/scaleio/tests/test-cf-template.json
@@ -1,0 +1,778 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Metadata": {
+    "AWS::CloudFormation::Designer": {
+      "19117008-4607-4d30-95d7-9e27b231f551": {
+        "size": {
+          "width": 420,
+          "height": 220
+        },
+        "position": {
+          "x": 720,
+          "y": 170
+        },
+        "z": 1,
+        "embeds": [
+          "35c845c6-61b8-422c-be16-f1395a95879f",
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a",
+          "e3f368ef-533b-484c-b3f4-897729901208"
+        ]
+      },
+      "e3f368ef-533b-484c-b3f4-897729901208": {
+        "size": {
+          "width": 290,
+          "height": 100
+        },
+        "position": {
+          "x": 840,
+          "y": 250
+        },
+        "z": 2,
+        "parent": "19117008-4607-4d30-95d7-9e27b231f551",
+        "embeds": [
+          "b2904db7-7420-44e0-9bd7-078c253f58e8",
+          "05dd39d3-73fc-4732-be16-9966f7fa4769",
+          "0b3b1e8b-5559-4a13-bf67-7312d43b361c"
+        ]
+      },
+      "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 960,
+          "y": 100
+        },
+        "z": 0,
+        "parent": "19117008-4607-4d30-95d7-9e27b231f551",
+        "embeds": [],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "c7820c4a-775a-4228-9f22-d7b91120d6c9": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 640,
+          "y": 170
+        },
+        "z": 1,
+        "embeds": []
+      },
+      "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8": {
+        "source": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "target": {
+          "id": "19117008-4607-4d30-95d7-9e27b231f551"
+        },
+        "z": 1
+      },
+      "35c845c6-61b8-422c-be16-f1395a95879f": {
+        "size": {
+          "width": 80,
+          "height": 90
+        },
+        "position": {
+          "x": 750,
+          "y": 180
+        },
+        "z": 2,
+        "parent": "19117008-4607-4d30-95d7-9e27b231f551",
+        "embeds": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ]
+      },
+      "b2904db7-7420-44e0-9bd7-078c253f58e8": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 860,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "fe5557b3-266c-40ef-b6bd-4ad21f7511c5": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 760,
+          "y": 200
+        },
+        "z": 3,
+        "parent": "35c845c6-61b8-422c-be16-f1395a95879f",
+        "embeds": [],
+        "references": [
+          "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        ],
+        "dependson": [
+          "c7820c4a-775a-4228-9f22-d7b91120d6c9",
+          "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8"
+        ]
+      },
+      "da60be23-5de7-4310-8cfc-1cae8042ada7": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "target": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "z": 4
+      },
+      "d3c5f91d-7e10-4ff9-9a86-e4fd05e69747": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "target": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "z": 5
+      },
+      "98f6a038-b5dc-43b9-9901-549f72c5aaf1": {
+        "source": {
+          "id": "b2904db7-7420-44e0-9bd7-078c253f58e8"
+        },
+        "target": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "z": 6
+      },
+      "43aacb25-8175-4890-b26f-066ceac37afe": {
+        "source": {
+          "id": "35c845c6-61b8-422c-be16-f1395a95879f"
+        },
+        "target": {
+          "id": "e3f368ef-533b-484c-b3f4-897729901208"
+        },
+        "z": 2
+      },
+      "05dd39d3-73fc-4732-be16-9966f7fa4769": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 960,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "0b3b1e8b-5559-4a13-bf67-7312d43b361c": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 1050,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "9c4181f8-b640-4266-ab00-e30b2bf26f48": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5",
+          "selector": "g:nth-child(1) g:nth-child(4) g:nth-child(5) circle:nth-child(1)     ",
+          "port": "AWS::DependencyLink-*"
+        },
+        "target": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "z": 5
+      },
+      "ec9732a1-755a-45fd-8f95-00f015fdc006": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "target": {
+          "id": "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8"
+        },
+        "z": 4
+      }
+    }
+  },
+  "Resources": {
+    "ScaleIOSubnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": "10.0.0.0/24"
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "e3f368ef-533b-484c-b3f4-897729901208"
+        }
+      }
+    },
+    "ScaleIOSecGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "GroupDescription": "Allow access from SSH traffic",
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "22",
+            "ToPort": "22",
+            "CidrIp": {
+              "Ref": "SSHLocation"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "ToPort": "443",
+            "CidrIp": {
+              "Ref": "SSHLocation"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
+            "CidrIp": {
+              "Ref": "SSHLocation"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "1",
+            "ToPort": "65535",
+            "CidrIp": "10.0.0.0/24"
+          },
+          {
+            "IpProtocol": "udp",
+            "FromPort": "1",
+            "ToPort": "65535",
+            "CidrIp": "10.0.0.0/24"
+          },
+          {
+            "IpProtocol": "icmp",
+            "FromPort": "-1",
+            "ToPort": "-1",
+            "CidrIp": "10.0.0.0/24"
+          }
+        ]
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        }
+      }
+    },
+    "InternetGateway": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {},
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        }
+      }
+    },
+    "RouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "35c845c6-61b8-422c-be16-f1395a95879f"
+        }
+      }
+    },
+    "PublicRoute": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        },
+        "GatewayId": {
+          "Ref": "InternetGateway"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        }
+      },
+      "DependsOn": [
+        "InternetGateway",
+        "GatewayAttachment"
+      ]
+    },
+    "VPC": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true",
+        "CidrBlock": "10.0.0.0/16"
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "19117008-4607-4d30-95d7-9e27b231f551"
+        }
+      }
+    },
+    "ScaleIONode3": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-55ee5435",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ScaleIONode3"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.13",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo ScaleIONode3 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "0b3b1e8b-5559-4a13-bf67-7312d43b361c"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "ScaleIONode2": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-bdeb51dd",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ScaleIONode2"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.12",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo ScaleIONode2 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "05dd39d3-73fc-4732-be16-9966f7fa4769"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "ScaleIONode1": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-56ee5436",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ScaleIONode1"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.11",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo ScaleIONode1 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "b2904db7-7420-44e0-9bd7-078c253f58e8"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "GatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "InternetGatewayId": {
+          "Ref": "InternetGateway"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8"
+        }
+      }
+    },
+    "SubnetAttachment": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        },
+        "SubnetId": {
+          "Ref": "ScaleIOSubnet"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "43aacb25-8175-4890-b26f-066ceac37afe"
+        }
+      }
+    }
+  },
+  "Parameters": {
+    "KeyName": {
+      "Description": "Name of an EC2 KeyPair to enable SSH access to the cluster.",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription": "must be the name of an existing EC2 KeyPair."
+    },
+    "SSHLocation": {
+      "Description": " The IP address range that can be used to access the ScaleIO cluster using SSH.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "0.0.0.0/0",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
+    }
+  },
+  "Mappings": {
+    "AWSInstanceType2Arch": {
+      "t2.medium": {
+        "Arch": "HVM64"
+      }
+    },
+    "AWSRegionArch2AMI": {
+      "us-west-1": {
+        "PV64": "ami-d514f291",
+        "HVM64": "ami-d114f295",
+        "HVMG2": "ami-f31ffeb7"
+      }
+    }
+  },
+  "Outputs": {
+    "URL": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "http://",
+            {
+              "Fn::GetAtt": [
+                "ScaleIONode1",
+                "PublicIp"
+              ]
+            }
+          ]
+        ]
+      },
+      "Description": "Cluster Management URL"
+    }
+  }
+}

--- a/drivers/storage/scaleio/tests/test-env-down.sh
+++ b/drivers/storage/scaleio/tests/test-env-down.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# This script cleans up the infrastructure used for tests
+
+set -e
+# set -x
+
+CF_STACK_NAME="$1"
+
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  echo >&2 "Missing AWS command line. Please install aws cli: https://aws.amazon.com/cli/"
+  exit 1
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  echo >&2 "Missing jq command line. Please install the jq utility"
+  exit 1
+}
+
+usage() {
+  echo "Usage: ${0} stack-name"
+  echo ""
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+
+# Get stack ID
+CF_STACK_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${CF_STACK_NAME} \
+  --output text \
+  --query 'Stacks[0].StackId')
+
+# Delete cloud formation stack
+aws cloudformation delete-stack \
+  --stack-name ${CF_STACK_NAME}
+
+echo "Waiting for CF stack to get deleted ..."
+
+aws cloudformation wait stack-delete-complete \
+  --stack-name ${CF_STACK_ID}
+
+rm ~/.aws/config
+rm ~/.aws/credentials
+
+echo "Stack has been deleted"

--- a/drivers/storage/scaleio/tests/test-env-up.sh
+++ b/drivers/storage/scaleio/tests/test-env-up.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# This script launches infrastructure required for testing the ScaleIO storage driver.
+# It spins up VPC and EC2 instance so AWS account owner will get charged for time
+# that resources will be running.
+
+set -e
+# set -x
+
+AWS_ACCESS_KEY="$1"
+AWS_SECRET_KEY="$2"
+CF_STACK_NAME="$3"
+LAUNCH_KEY_NAME="$4"
+
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  echo >&2 "Missing AWS command line. Please install aws cli: https://aws.amazon.com/cli/"
+  exit 1
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  echo >&2 "Missing jq command line. Please install the jq utility"
+  exit 1
+}
+
+usage() {
+  echo "Usage: ${0} access-key secret-key stack-name launch-key-name"
+  echo ""
+  echo "   access-key: AWS access key"
+  echo "   secret-key: AWS secret key"
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+  echo "   launch-key-name: AWS key that will be used to launch EC2 instance"
+}
+
+template_path() {
+  echo "$(dirname $0)/test-cf-template.json"
+}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${LAUNCH_KEY_NAME}" ]; then
+  usage
+  exit 1
+fi
+
+aws configure set aws_access_key_id ${AWS_ACCESS_KEY}
+aws configure set aws_secret_access_key ${AWS_SECRET_KEY}
+aws configure set default.region us-west-2
+
+# Launch CF stack
+aws cloudformation create-stack \
+  --stack-name ${CF_STACK_NAME} \
+  --template-body file://$(template_path) \
+  --parameter ParameterKey=KeyName,ParameterValue=${LAUNCH_KEY_NAME} \
+  --capabilities CAPABILITY_IAM 1>/dev/null
+
+echo "Environment launch started. It will take couple minutes to create whole environment..."

--- a/drivers/storage/scaleio/tests/test-run.sh
+++ b/drivers/storage/scaleio/tests/test-run.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+# This script runs tests
+
+# set -e
+# set -x
+
+: ${CF_EC2_USER:="ec2-user"}
+
+CF_STACK_NAME="$1"
+TEST_BINARY="$2"
+
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  echo >&2 "Missing AWS command line. Please install aws cli: https://aws.amazon.com/cli/"
+  exit 1
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  echo >&2 "Missing jq command line. Please install the jq utility"
+  exit 1
+}
+
+usage() {
+  echo "Usage: ${0} stack-name rexray-path"
+  echo ""
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+  echo "   rexray-path: Path to compiled and runnable golang binary"
+}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${TEST_BINARY}" ]; then
+  usage
+  exit 1
+fi
+
+# Require valid test binary file
+if [ ! -f "${TEST_BINARY}" ]; then
+  echo >&2 "${TEST_BINARY} is not a valid file"
+  exit 1
+fi
+
+echo "Waiting for CF stack to come up ..."
+
+aws cloudformation wait stack-create-complete \
+  --stack-name ${CF_STACK_NAME}
+
+# Get IP address of EC2 machine where tests can be executed
+SCALEIO_NODE1=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="ScaleIONode1")' | jq -r .PhysicalResourceId)
+#SCALEIO_NODE2=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="ScaleIONode2")' | jq -r .PhysicalResourceId)
+#SCALEIO_NODE3=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="ScaleIONode3")' | jq -r .PhysicalResourceId)
+#echo ${SCALEIO_NODE1}
+#echo ${SCALEIO_NODE2}
+#echo ${SCALEIO_NODE3}
+
+SCALEIO_NODE1_FQDN=$(aws ec2 describe-instances --instance-ids ${SCALEIO_NODE1} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#SCALEIO_NODE2_FQDN=$(aws ec2 describe-instances --instance-ids ${SCALEIO_NODE2} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#SCALEIO_NODE3_FQDN=$(aws ec2 describe-instances --instance-ids ${SCALEIO_NODE3} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#echo ${SCALEIO_NODE1_FQDN}
+#echo ${SCALEIO_NODE2_FQDN}
+#echo ${SCALEIO_NODE3_FQDN}
+
+ssh-keyscan -H ${SCALEIO_NODE1_FQDN} >> ~/.ssh/known_hosts
+#ssh-keyscan -H ${SCALEIO_NODE2_FQDN} >> ~/.ssh/known_hosts
+#ssh-keyscan -H ${SCALEIO_NODE3_FQDN} >> ~/.ssh/known_hosts
+
+# Copy REX-Ray build to EC2 instance
+ssh $CF_EC2_USER@$SCALEIO_NODE1_FQDN "sudo mkdir -p /usr/bin"
+ssh $CF_EC2_USER@$SCALEIO_NODE1_FQDN "sudo mkdir -p /etc/rexray"
+scp ${TEST_BINARY} $CF_EC2_USER@$SCALEIO_NODE1_FQDN:/tmp
+scp ./config.yml $CF_EC2_USER@$SCALEIO_NODE1_FQDN:/tmp
+scp ./tests.sh $CF_EC2_USER@$SCALEIO_NODE1_FQDN:/tmp
+ssh $CF_EC2_USER@$SCALEIO_NODE1_FQDN "sudo cp -f /tmp/rexray /usr/bin"
+ssh $CF_EC2_USER@$SCALEIO_NODE1_FQDN "sudo cp -f /tmp/config.yml /etc/rexray"
+ssh $CF_EC2_USER@$SCALEIO_NODE1_FQDN "sudo chmod +x /tmp/tests.sh"
+ssh $CF_EC2_USER@$SCALEIO_NODE1_FQDN "sudo /usr/bin/rexray service restart"
+
+#ssh $CF_EC2_USER@$SCALEIO_NODE2_FQDN "sudo mkdir -p /usr/bin"
+#ssh $CF_EC2_USER@$SCALEIO_NODE2_FQDN "sudo mkdir -p /etc/rexray"
+#scp ${TEST_BINARY} $CF_EC2_USER@$SCALEIO_NODE2_FQDN:/tmp
+#scp ./config.yml $CF_EC2_USER@$SCALEIO_NODE2_FQDN:/tmp
+#scp ./tests.sh $CF_EC2_USER@$SCALEIO_NODE2_FQDN:/tmp
+#ssh $CF_EC2_USER@$SCALEIO_NODE2_FQDN "sudo /tmp/rexray /usr/bin"
+#ssh $CF_EC2_USER@$SCALEIO_NODE2_FQDN "sudo /tmp/config.yml /etc/rexray"
+#ssh $CF_EC2_USER@$SCALEIO_NODE2_FQDN "sudo chmod +x /tmp/tests.sh"
+#ssh $CF_EC2_USER@$SCALEIO_NODE2_FQDN "sudo /usr/bin/rexray service restart"
+
+#ssh $CF_EC2_USER@$SCALEIO_NODE3_FQDN "sudo mkdir -p /usr/bin"
+#ssh $CF_EC2_USER@$SCALEIO_NODE3_FQDN "sudo mkdir -p /etc/rexray"
+#scp ${TEST_BINARY} $CF_EC2_USER@$SCALEIO_NODE3_FQDN:/tmp
+#scp ./config.yml $CF_EC2_USER@$SCALEIO_NODE3_FQDN:/tmp
+#scp ./tests.sh $CF_EC2_USER@$SCALEIO_NODE3_FQDN:/tmp
+#ssh $CF_EC2_USER@$SCALEIO_NODE3_FQDN "sudo /tmp/rexray /usr/bin"
+#ssh $CF_EC2_USER@$SCALEIO_NODE3_FQDN "sudo /tmp/config.yml /etc/rexray"
+#ssh $CF_EC2_USER@$SCALEIO_NODE3_FQDN "sudo chmod +x /tmp/tests.sh"
+#ssh $CF_EC2_USER@$SCALEIO_NODE3_FQDN "sudo /usr/bin/rexray service restart"
+
+# Run tests
+ssh $CF_EC2_USER@$SCALEIO_NODE1_FQDN "sudo /tmp/tests.sh"
+
+# Copy test coverage results
+scp $CF_EC2_USER@$SCALEIO_NODE1_FQDN:/tmp/output.txt $(dirname $0)
+
+echo "Tests passed and coverge results are available at $(dirname $0)/output.txt"

--- a/drivers/storage/scaleio/tests/tests.sh
+++ b/drivers/storage/scaleio/tests/tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# This script runs tests
+
+docker volume create --driver rexray --name myvoltest --opt size=16 >> /tmp/output.txt
+docker volume rm myvoltest >> /tmp/output.txt


### PR DESCRIPTION
This is the initial check in for end-to-end testing for ScaleIO. This makes use of an existing method to outlined by @akutz to add this type of testing. The scripts themselves are based on the EFS implementation. Requires aws cli and jq utilities to be installed.

The `test-env-up.sh` sets up the environment in AWS. AWS was chosen because the entire scaleio environment can be propped up quickly (in under a minute). An AWS key/secret will be required with sufficient permissions. A uniquely identifiable `stack-name` must be given which allows for the process to stand up multiple environments concurrently.

The `test-run.sh` pushes over required files, the test script containing multiple tests, and then executes the test script. Once the test cases are completed, an output file containing the test results are copied back to the system.

The `test-env-down.sh` script is run last and removes all artifacts in Amazon.

The test is fully repeatable (many runs) from creation to deletion in AWS. Currently, it only creates and deletes a single volume using docker CLI. Will create additional test cases as time goes on.