### PR TITLE
Global GO_VERSION in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go_import_path: github.com/codedellemc/libstorage
 language: go
 go:
   - 1.6.3
-  - 1.7.4
+  - 1.7.5
   - tip
 
 os:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+GO_VERSION := 1.7.5
 
 ifeq (undefined,$(origin BUILD_TAGS))
 BUILD_TAGS :=   gofig \
@@ -36,7 +37,7 @@ endif
 ifneq (,$(shell if docker version &> /dev/null; then echo -; fi))
 
 DPKG := github.com/codedellemc/libstorage
-DIMG := golang:1.7.1
+DIMG := golang:$(GO_VERSION)
 DGOHOSTOS := $(shell uname -s | tr A-Z a-z)
 ifeq (undefined,$(origin DGOOS))
 DGOOS := $(DGOHOSTOS)
@@ -201,7 +202,7 @@ else
 GOVERSION := $(shell go version | awk '{print $$3}' | cut -c3-)
 endif
 
-ifeq (1.7.4,$(TRAVIS_GO_VERSION))
+ifeq ($(GO_VERSION),$(TRAVIS_GO_VERSION))
 ifeq (linux,$(TRAVIS_OS_NAME))
 COVERAGE_ENABLED := 1
 endif


### PR DESCRIPTION
This patch introduce a new variable to the Makefile, GO_VERSION, that controls the version expected from Travis as well as the version used by the Docker image when building libStorage.