### PR TITLE
S3FS Fuse Driver Support

### DIFF
--- a/api/client/client_api_funcs.go
+++ b/api/client/client_api_funcs.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -164,10 +165,15 @@ func (c *client) VolumeCopy(
 
 func (c *client) VolumeRemove(
 	ctx types.Context,
-	service, volumeID string) error {
+	service, volumeID string,
+	force bool) error {
 
-	if _, err := c.httpDelete(ctx,
-		fmt.Sprintf("/volumes/%s/%s", service, volumeID), nil); err != nil {
+	buf := &bytes.Buffer{}
+	fmt.Fprintf(buf, "/volumes/%s/%s", service, volumeID)
+	if force {
+		fmt.Fprintf(buf, "?force")
+	}
+	if _, err := c.httpDelete(ctx, buf.String(), nil); err != nil {
 		return err
 	}
 	return nil

--- a/api/registry/registry_integration.go
+++ b/api/registry/registry_integration.go
@@ -227,7 +227,7 @@ func (d *idm) Create(
 func (d *idm) Remove(
 	ctx types.Context,
 	volumeName string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	fields := log.Fields{
 		"volumeName": volumeName,

--- a/api/registry/registry_os.go
+++ b/api/registry/registry_os.go
@@ -1,7 +1,8 @@
 package registry
 
 import (
-	"strings"
+	"os"
+	"path"
 
 	"github.com/codedellemc/libstorage/api/types"
 )
@@ -58,8 +59,13 @@ func (d *odm) Format(
 
 	ctx = ctx.Join(d.Context)
 
-	if strings.Contains(deviceName, ":") {
+	if !path.IsAbs(deviceName) {
 		return nil
 	}
+
+	if _, err := os.Stat(deviceName); os.IsNotExist(err) {
+		return nil
+	}
+
 	return d.OSDriver.Format(ctx, deviceName, opts)
 }

--- a/api/registry/registry_storage.go
+++ b/api/registry/registry_storage.go
@@ -113,7 +113,7 @@ func (d *sdm) VolumeSnapshot(
 func (d *sdm) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	return d.StorageDriver.VolumeRemove(
 		ctx.Join(d.Context), volumeID, opts)

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -820,7 +820,10 @@ func (r *router) volumeRemove(
 		return nil, svc.Driver().VolumeRemove(
 			ctx,
 			store.GetString("volumeID"),
-			store)
+			&types.VolumeRemoveOpts{
+				Force: store.GetBool("force"),
+				Opts:  store,
+			})
 	}
 
 	return httputils.WriteTask(

--- a/api/types/types_clients.go
+++ b/api/types/types_clients.go
@@ -141,7 +141,8 @@ type APIClient interface {
 	// VolumeRemove removes a single volume.
 	VolumeRemove(
 		ctx Context,
-		service, volumeID string) error
+		service, volumeID string,
+		force bool) error
 
 	// VolumeAttach attaches a single volume.
 	VolumeAttach(

--- a/api/types/types_drivers_integration.go
+++ b/api/types/types_drivers_integration.go
@@ -78,7 +78,7 @@ type IntegrationDriver interface {
 	Remove(
 		ctx Context,
 		volumeName string,
-		opts Store) error
+		opts *VolumeRemoveOpts) error
 
 	// Attach will attach a volume based on volumeName to the instance of
 	// instanceID.

--- a/api/types/types_drivers_storage.go
+++ b/api/types/types_drivers_storage.go
@@ -245,6 +245,12 @@ type VolumeDetachOpts struct {
 	Opts  Store
 }
 
+// VolumeRemoveOpts are options for removing a volume.
+type VolumeRemoveOpts struct {
+	Force bool
+	Opts  Store
+}
+
 // StorageDriverManager is the management wrapper for a StorageDriver.
 type StorageDriverManager interface {
 	StorageDriver
@@ -319,7 +325,7 @@ type StorageDriver interface {
 	VolumeRemove(
 		ctx Context,
 		volumeID string,
-		opts Store) error
+		opts *VolumeRemoveOpts) error
 
 	// VolumeAttach attaches a volume and provides a token clients can use
 	// to validate that device has appeared locally.

--- a/api/types/types_model.go
+++ b/api/types/types_model.go
@@ -57,43 +57,43 @@ type Instance struct {
 // struct is populated from the content in the /proc/<pid>/mountinfo file.
 type MountInfo struct {
 	// ID is a unique identifier of the mount (may be reused after umount).
-	ID int `json:"id" yaml:"id"`
+	ID int `json:"id,omitempty" yaml:"id,omitempty"`
 
 	// Parent indicates the ID of the mount parent (or of self for the top of
 	// the mount tree).
-	Parent int `json:"parent"`
+	Parent int `json:"parent,omitempty" yaml:"parent,omitempty"`
 
 	// Major indicates one half of the device ID which identifies the device
 	// class.
-	Major int `json:"major"`
+	Major int `json:"major,omitempty" yaml:"major,omitempty"`
 
 	// Minor indicates one half of the device ID which identifies a specific
 	// instance of device.
-	Minor int `json:"minor"`
+	Minor int `json:"minor,omitempty" yaml:"minor,omitempty"`
 
 	// Root of the mount within the filesystem.
-	Root string `json:"root"`
+	Root string `json:"root,omitempty" yaml:"root,omitempty"`
 
 	// MountPoint indicates the mount point relative to the process's root.
-	MountPoint string `json:"mountPoint" yaml:"mountPoint"`
+	MountPoint string `json:"mountPoint,omitempty" yaml:"mountPoint,omitempty"`
 
 	// Opts represents mount-specific options.
-	Opts string `json:"opts"`
+	Opts string `json:"opts,omitempty" yaml:"opts,omitempty"`
 
 	// Optional represents optional fields.
-	Optional string `json:"optional"`
+	Optional string `json:"optional,omitempty" yaml:"optional,omitempty"`
 
 	// FSType indicates the type of filesystem, such as EXT3.
-	FSType string `json:"fsType" yaml:"fsType"`
+	FSType string `json:"fsType,omitempty" yaml:"fsType,omitempty"`
 
 	// Source indicates filesystem specific information or "none".
-	Source string `json:"source"`
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
 
 	// VFSOpts represents per super block options.
-	VFSOpts string `json:"vfsOpts" yaml:"vfsOpts"`
+	VFSOpts string `json:"vfsOpts,omitempty" yaml:"vfsOpts,omitempty"`
 
 	// Fields are additional properties that can be defined for this type.
-	Fields map[string]string `json:"fields,omitempty" yaml:",omitempty"`
+	Fields map[string]string `json:"fields,omitempty" yaml:"fields,omitempty"`
 }
 
 // Snapshot provides information about a storage-layer snapshot.

--- a/drivers/integration/linux/linux.go
+++ b/drivers/integration/linux/linux.go
@@ -272,7 +272,6 @@ func (d *driver) Mount(
 	if opts.NewFSType == "" {
 		opts.NewFSType = d.fsType()
 	}
-
 	if err := client.OS().Format(
 		ctx,
 		ma.DeviceName,
@@ -504,14 +503,14 @@ func (d *driver) Create(
 func (d *driver) Remove(
 	ctx types.Context,
 	volumeName string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	if volumeName == "" {
 		return goof.New("missing volume name or ID")
 	}
 
 	vol, err := d.volumeInspectByIDOrName(
-		ctx, "", volumeName, 0, opts)
+		ctx, "", volumeName, 0, opts.Opts)
 	if err != nil {
 		return err
 	}

--- a/drivers/storage/ebs/storage/ebs_storage.go
+++ b/drivers/storage/ebs/storage/ebs_storage.go
@@ -530,7 +530,7 @@ func (d *driver) VolumeSnapshot(
 func (d *driver) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 	// Initialize for logging
 	fields := map[string]interface{}{
 		"provider": d.Name(),

--- a/drivers/storage/efs/storage/efs_storage.go
+++ b/drivers/storage/efs/storage/efs_storage.go
@@ -90,7 +90,7 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 	d.maxRetries = &maxRetries
 	fields["maxRetries"] = maxRetries
 
-	log.WithFields(fields).Info("storage driver initialized")
+	ctx.WithFields(fields).Info("storage driver initialized")
 	return nil
 }
 
@@ -161,7 +161,7 @@ func (d *driver) Login(ctx types.Context) (interface{}, error) {
 		fields[efs.Endpoint] = *endpoint
 	}
 
-	ctx.WithFields(fields).Debug("efs service connetion attempt")
+	ctx.WithFields(fields).Debug("efs service connection attempt")
 	sess := session.New()
 
 	var (
@@ -471,7 +471,7 @@ func (d *driver) VolumeCreate(
 func (d *driver) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	svc := mustSession(ctx)
 

--- a/drivers/storage/isilon/storage/isilon_storage.go
+++ b/drivers/storage/isilon/storage/isilon_storage.go
@@ -304,7 +304,7 @@ func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
 func (d *driver) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	if d.quotas() {
 		ctx.WithField("volume", volumeID).Debug("clearing volume quotas")

--- a/drivers/storage/libstorage/libstorage_client_api.go
+++ b/drivers/storage/libstorage/libstorage_client_api.go
@@ -210,7 +210,8 @@ func (c *client) VolumeCopy(
 
 func (c *client) VolumeRemove(
 	ctx types.Context,
-	service, volumeID string) error {
+	service, volumeID string,
+	force bool) error {
 
 	ctx = c.withInstanceID(c.requireCtx(ctx), service)
 
@@ -226,7 +227,7 @@ func (c *client) VolumeRemove(
 		}
 	}
 
-	err := c.APIClient.VolumeRemove(ctx, service, volumeID)
+	err := c.APIClient.VolumeRemove(ctx, service, volumeID, force)
 	if err != nil {
 		return err
 	}

--- a/drivers/storage/libstorage/libstorage_driver_funcs.go
+++ b/drivers/storage/libstorage/libstorage_driver_funcs.go
@@ -191,7 +191,7 @@ func (d *driver) VolumeSnapshot(
 func (d *driver) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	ctx = d.requireCtx(ctx)
 	serviceName, ok := context.ServiceName(ctx)
@@ -199,7 +199,7 @@ func (d *driver) VolumeRemove(
 		return goof.New("missing service name")
 	}
 
-	return d.client.VolumeRemove(ctx, serviceName, volumeID)
+	return d.client.VolumeRemove(ctx, serviceName, volumeID, opts.Force)
 }
 
 func (d *driver) VolumeAttach(

--- a/drivers/storage/mock/mock_driver.go
+++ b/drivers/storage/mock/mock_driver.go
@@ -329,7 +329,7 @@ func (d *driver) VolumeSnapshot(
 func (d *driver) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	ctx.WithFields(log.Fields{
 		"volumeID": volumeID,

--- a/drivers/storage/rackspace/storage/rackspace_storage.go
+++ b/drivers/storage/rackspace/storage/rackspace_storage.go
@@ -231,7 +231,7 @@ func (d *driver) VolumeSnapshot(
 func (d *driver) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 	fields := eff(map[string]interface{}{
 		"volumeId": volumeID,
 	})

--- a/drivers/storage/rbd/storage/rbd_storage.go
+++ b/drivers/storage/rbd/storage/rbd_storage.go
@@ -212,7 +212,7 @@ func (d *driver) VolumeSnapshot(
 func (d *driver) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	fields := map[string]interface{}{
 		"driverName": d.Name(),

--- a/drivers/storage/s3fs/executor/s3fs_executor.go
+++ b/drivers/storage/s3fs/executor/s3fs_executor.go
@@ -1,0 +1,209 @@
+// +build !libstorage_storage_executor libstorage_storage_executor_s3fs
+
+package executor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+
+	log "github.com/Sirupsen/logrus"
+	gofig "github.com/akutz/gofig/types"
+	"github.com/akutz/goof"
+	"github.com/akutz/gotil"
+
+	"github.com/codedellemc/libstorage/api/registry"
+	"github.com/codedellemc/libstorage/api/types"
+
+	"github.com/codedellemc/libstorage/drivers/storage/s3fs"
+	"github.com/codedellemc/libstorage/drivers/storage/s3fs/utils"
+)
+
+// driver is the storage executor for the s3fs storage driver.
+type driver struct {
+	config gofig.Config
+	cmd    string
+	opts   []string
+	szOpts string
+}
+
+func init() {
+	registry.RegisterStorageExecutor(s3fs.Name, newDriver)
+}
+
+func newDriver() types.StorageExecutor {
+	return &driver{}
+}
+
+func (d *driver) Init(ctx types.Context, config gofig.Config) error {
+	d.config = config
+
+	fields := log.Fields{"driver": s3fs.Name}
+	d.cmd = d.config.GetString(s3fs.ConfigS3FSCmd)
+	fields["cmd"] = d.cmd
+
+	if v := d.config.GetStringSlice(s3fs.ConfigS3FSOptions); len(v) > 0 {
+		d.opts = v
+		fields["opts"] = d.opts
+	} else {
+		d.szOpts = d.config.GetString(s3fs.ConfigS3FSOptions)
+		fields["opts"] = d.szOpts
+	}
+
+	ctx.WithFields(fields).Debug("storage executor initialized")
+	return nil
+}
+
+func (d *driver) Name() string {
+	return s3fs.Name
+}
+
+// Supported returns a flag indicating whether or not the platform
+// implementing the executor is valid for the host on which the executor
+// resides.
+func (d *driver) Supported(
+	ctx types.Context,
+	opts types.Store) (bool, error) {
+
+	return gotil.FileExistsInPath(d.cmd), nil
+}
+
+// InstanceID
+func (d *driver) InstanceID(
+	ctx types.Context,
+	opts types.Store) (*types.InstanceID, error) {
+	return utils.InstanceID(ctx, d.config)
+}
+
+// NextDevice returns the next available device.
+func (d *driver) NextDevice(
+	ctx types.Context,
+	opts types.Store) (string, error) {
+	return "", types.ErrNotImplemented
+}
+
+// Return list of local devices
+func (d *driver) LocalDevices(
+	ctx types.Context,
+	opts *types.LocalDevicesOpts) (*types.LocalDevices, error) {
+
+	buckets, err := d.getMountedBuckets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &types.LocalDevices{Driver: s3fs.Name, DeviceMap: buckets}, nil
+}
+
+func (d *driver) Mount(
+	ctx types.Context,
+	deviceName, mountPoint string,
+	opts *types.DeviceMountOpts) error {
+
+	if mp, ok := d.findMountPoint(ctx, deviceName); ok {
+		ctx.WithFields(log.Fields{
+			"bucket":     deviceName,
+			"mountPoint": mp,
+		}).Debug("bucket is already mounted")
+		if mp == mountPoint {
+			// bucket is mounted to the required target => ok
+			return nil
+		}
+		// bucket is mounted to another target => error
+		return goof.WithFields(goof.Fields{
+			"bucket":      deviceName,
+			"mountPointt": mp,
+		}, "bucket is already mounted")
+	}
+	return d.s3fsMount(ctx, deviceName, mountPoint, opts)
+}
+
+// Mounts get a list of mount points.
+func (d *driver) Mounts(
+	ctx types.Context,
+	opts types.Store) ([]*types.MountInfo, error) {
+
+	ld, err := d.LocalDevices(ctx, &types.LocalDevicesOpts{Opts: opts})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ld.DeviceMap) == 0 {
+		return nil, nil
+	}
+
+	mounts := []*types.MountInfo{}
+	for k, v := range ld.DeviceMap {
+		mounts = append(mounts, &types.MountInfo{Source: k, MountPoint: v})
+	}
+
+	return mounts, nil
+}
+
+func (d *driver) s3fsMount(
+	ctx types.Context,
+	bucket, mountPoint string,
+	opts *types.DeviceMountOpts) error {
+
+	args := []string{bucket, mountPoint}
+	if len(d.opts) > 0 {
+		for _, o := range d.opts {
+			args = append(args, fmt.Sprintf("-o%s", o))
+		}
+	} else if d.szOpts != "" {
+		args = append(args, d.szOpts)
+	}
+
+	fields := map[string]interface{}{
+		"bucket":           bucket,
+		"mountPoint":       mountPoint,
+		"cmd":              d.cmd,
+		"args":             args,
+		"isAWSAuthEnvVars": false,
+	}
+
+	cmd := exec.Command(d.cmd, args...)
+	if ak := d.getAccessKey(); ak != "" {
+		if sk := d.getSecretKey(); sk != "" {
+			cmd.Env = os.Environ()
+			cmd.Env = append(cmd.Env, fmt.Sprintf("AWSACCESSKEYID=%s", ak))
+			cmd.Env = append(cmd.Env, fmt.Sprintf("AWSSECRETACCESSKEY=%s", sk))
+			fields["isAWSAuthEnvVars"] = true
+		}
+	}
+
+	ctx.WithFields(fields).Debug("attempting s3fs mount")
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fields["output"] = string(out)
+		return goof.WithFieldsE(fields, "error mounting s3fs bucket", err)
+	}
+
+	return nil
+}
+
+func (d *driver) findMountPoint(
+	ctx types.Context,
+	bucket string) (string, bool) {
+
+	if buckets, err := d.getMountedBuckets(ctx); err == nil {
+		b, ok := buckets[bucket]
+		return b, ok
+	}
+	return "", false
+}
+
+func (d *driver) getMountedBuckets(
+	ctx types.Context) (map[string]string, error) {
+
+	return getMountedBuckets(ctx, path.Base(d.cmd))
+}
+
+func (d *driver) getAccessKey() string {
+	return d.config.GetString(s3fs.ConfigS3FSAccessKey)
+}
+
+func (d *driver) getSecretKey() string {
+	return d.config.GetString(s3fs.ConfigS3FSSecretKey)
+}

--- a/drivers/storage/s3fs/executor/s3fs_executor_linux.go
+++ b/drivers/storage/s3fs/executor/s3fs_executor_linux.go
@@ -1,0 +1,128 @@
+// +build linux
+
+package executor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+func getMountedBuckets(
+	ctx types.Context,
+	s3fsBinName string) (map[string]string, error) {
+
+	s3fsBinRX := regexp.MustCompile(fmt.Sprintf(`^.*%s$`, s3fsBinName))
+
+	infc, errc, err := walkProc(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		wg            sync.WaitGroup
+		argc          = make(chan []string)
+		numInspectors = runtime.NumCPU() + 1
+	)
+	wg.Add(numInspectors)
+	for i := 0; i < numInspectors; i++ {
+		go func() {
+			inspect(ctx, infc, argc)
+			wg.Done()
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(argc)
+	}()
+
+	m := map[string]string{}
+	for args := range argc {
+		if len(args) < 3 {
+			continue
+		}
+		if !s3fsBinRX.MatchString(args[0]) {
+			continue
+		}
+		m[args[1]] = args[2]
+	}
+	if err := <-errc; err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func walkProc(ctx types.Context) (<-chan os.FileInfo, <-chan error, error) {
+
+	proc, err := os.Open("/proc")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer proc.Close()
+	infos, err := proc.Readdir(-1)
+	if err != nil {
+		return nil, nil, err
+	}
+	var (
+		infc = make(chan os.FileInfo)
+		errc = make(chan error, 1)
+	)
+	go func() {
+		defer close(infc)
+		errc <- func() error {
+			for _, i := range infos {
+				select {
+				case infc <- i:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			return nil
+		}()
+	}()
+	return infc, errc, nil
+}
+
+var pidDirRX = regexp.MustCompile(`^\d+$`)
+
+func inspect(
+	ctx types.Context,
+	infc <-chan os.FileInfo,
+	c chan<- []string) {
+
+	for i := range infc {
+		if !i.IsDir() {
+			continue
+		}
+		if !pidDirRX.MatchString(i.Name()) {
+			continue
+		}
+		func() {
+			cmdLineFile, err := os.Open(path.Join("/proc", i.Name(), "cmdline"))
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return
+			}
+			defer cmdLineFile.Close()
+			buf, err := ioutil.ReadAll(cmdLineFile)
+			if err != nil {
+				return
+			}
+			if len(buf) == 0 {
+				return
+			}
+			select {
+			case c <- strings.Split(string(buf), "\x00"):
+			case <-ctx.Done():
+				return
+			}
+		}()
+	}
+}

--- a/drivers/storage/s3fs/executor/s3fs_executor_other.go
+++ b/drivers/storage/s3fs/executor/s3fs_executor_other.go
@@ -1,0 +1,12 @@
+// +build !linux
+
+package executor
+
+import "github.com/codedellemc/libstorage/api/types"
+
+func getMountedBuckets(
+	ctx types.Context,
+	s3fsBinName string) (map[string]string, error) {
+
+	return nil, types.ErrNotImplemented
+}

--- a/drivers/storage/s3fs/s3fs.go
+++ b/drivers/storage/s3fs/s3fs.go
@@ -1,0 +1,130 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_s3fs
+
+package s3fs
+
+import (
+	"os"
+
+	gofigCore "github.com/akutz/gofig"
+	gofig "github.com/akutz/gofig/types"
+)
+
+const (
+	defaultRegion   = "us-east-1"
+	defaultEndpoint = "s3.amazonaws.com"
+)
+
+const (
+	// Name is the provider's name.
+	Name = "s3fs"
+
+	// TagDelimiter separates tags from volume or snapshot names
+	TagDelimiter = "/"
+
+	// DefaultMaxRetries is the max number of times to retry failed operations
+	DefaultMaxRetries = 10
+
+	// Cmd is a key constant.
+	Cmd = "cmd"
+
+	// Options is a key constant.
+	Options = "options"
+
+	// HostName is a key constant.
+	HostName = "hostName"
+
+	// AccessKey is a key constant.
+	AccessKey = "accessKey"
+
+	// SecretKey is a key constant.
+	SecretKey = "secretKey"
+
+	// Region is a key constant.
+	Region = "region"
+
+	// MaxRetries is a key constant.
+	MaxRetries = "maxRetries"
+
+	// DisablePathStyle sets the S3 AWS config property S3ForcePathStyle
+	// to false. Please see https://github.com/aws/aws-sdk-go/issues/168
+	// for more information.
+	DisablePathStyle = "disablePathStyle"
+
+	// Tag is a key constant.
+	Tag = "tag"
+)
+
+const (
+	// ConfigS3FS is a config key
+	ConfigS3FS = Name
+
+	// ConfigS3FSAccessKey is a config key.
+	ConfigS3FSAccessKey = ConfigS3FS + "." + AccessKey
+
+	// ConfigS3FSSecretKey is a config key.
+	ConfigS3FSSecretKey = ConfigS3FS + "." + SecretKey
+
+	// ConfigS3FSMaxRetries is a config key.
+	ConfigS3FSMaxRetries = ConfigS3FS + "." + MaxRetries
+
+	// ConfigS3FSRegion is a config key.
+	ConfigS3FSRegion = ConfigS3FS + "." + Region
+
+	// ConfigS3FSCmd is a config key.
+	ConfigS3FSCmd = ConfigS3FS + "." + Cmd
+
+	// ConfigS3FSOptions is a config key
+	ConfigS3FSOptions = ConfigS3FS + "." + Options
+
+	// ConfigS3FSHostName is a config key
+	ConfigS3FSHostName = ConfigS3FS + "." + HostName
+
+	// ConfigS3FSTag is a config key.
+	ConfigS3FSTag = ConfigS3FS + "." + Tag
+
+	// ConfigS3FSDisablePathStyle is a config key.
+	ConfigS3FSDisablePathStyle = ConfigS3FS + "." + DisablePathStyle
+)
+
+func init() {
+	hostName, _ := os.Hostname()
+	r := gofigCore.NewRegistration("S3FS")
+	r.Key(gofig.String, "", "", "AWS access key", ConfigS3FSAccessKey)
+	r.Key(gofig.String, "", "", "AWS secret key", ConfigS3FSSecretKey)
+	r.Key(gofig.String,
+		"",
+		defaultRegion,
+		"AWS region",
+		ConfigS3FSRegion)
+	r.Key(gofig.String,
+		"",
+		"s3fs",
+		`The absolute path to the "s3fs" binary.`,
+		ConfigS3FSCmd)
+	r.Key(gofig.String,
+		"",
+		"",
+		`The options to use with the "s3fs" command.`,
+		ConfigS3FSOptions)
+	r.Key(gofig.String,
+		"",
+		hostName,
+		"The host name used as part of the instance ID.",
+		ConfigS3FSHostName)
+	r.Key(gofig.String,
+		"",
+		"",
+		"Tag prefix for S3 naming",
+		ConfigS3FSTag)
+	r.Key(gofig.Int,
+		"",
+		DefaultMaxRetries,
+		"Max number of times to retry failed operations",
+		ConfigS3FSMaxRetries)
+	r.Key(gofig.Bool,
+		"",
+		false,
+		"A flag that disables the use of S3's path style for bucket endpoints",
+		ConfigS3FSDisablePathStyle)
+	gofigCore.Register(r)
+}

--- a/drivers/storage/s3fs/storage/s3fs_storage.go
+++ b/drivers/storage/s3fs/storage/s3fs_storage.go
@@ -1,0 +1,617 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_s3fs
+
+package storage
+
+import (
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+	gofig "github.com/akutz/gofig/types"
+	"github.com/akutz/goof"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	awss3 "github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/registry"
+	"github.com/codedellemc/libstorage/api/types"
+	"github.com/codedellemc/libstorage/api/utils"
+
+	"github.com/codedellemc/libstorage/drivers/storage/s3fs"
+	s3fsUtils "github.com/codedellemc/libstorage/drivers/storage/s3fs/utils"
+)
+
+type driver struct {
+	config           gofig.Config
+	tag              string
+	region           string
+	accessKey        string
+	secretKey        string
+	maxRetries       int
+	disablePathStyle bool
+	svcs             map[string]*awss3.S3
+	svcsRWL          *sync.RWMutex
+}
+
+func init() {
+	registry.RegisterStorageDriver(s3fs.Name, newDriver)
+}
+
+func newDriver() types.StorageDriver {
+	return &driver{}
+}
+
+func (d *driver) Name() string {
+	return s3fs.Name
+}
+
+// Init initializes the driver.
+func (d *driver) Init(ctx types.Context, config gofig.Config) error {
+	d.config = config
+	d.svcs = map[string]*awss3.S3{}
+	d.svcsRWL = &sync.RWMutex{}
+
+	fields := log.Fields{}
+
+	d.tag = d.config.GetString(s3fs.ConfigS3FSTag)
+	fields[s3fs.Tag] = d.tag
+
+	d.accessKey = d.config.GetString(s3fs.ConfigS3FSAccessKey)
+	fields[s3fs.AccessKey] = d.accessKey
+
+	d.secretKey = d.config.GetString(s3fs.ConfigS3FSSecretKey)
+	if d.secretKey != "" {
+		fields[s3fs.SecretKey] = "******"
+	}
+
+	d.region = d.config.GetString(s3fs.ConfigS3FSRegion)
+	fields[s3fs.Region] = d.region
+
+	d.maxRetries = d.config.GetInt(s3fs.ConfigS3FSMaxRetries)
+	fields[s3fs.MaxRetries] = d.maxRetries
+
+	d.disablePathStyle = d.config.GetBool(s3fs.ConfigS3FSDisablePathStyle)
+	fields[s3fs.DisablePathStyle] = d.disablePathStyle
+
+	if _, err := d.getService(ctx, d.region); err != nil {
+		return err
+	}
+
+	ctx.WithFields(fields).Info("storage driver initialized")
+	return nil
+}
+
+func (d *driver) getService(
+	ctx types.Context,
+	region string) (*awss3.S3, error) {
+
+	if region == "" {
+		region = d.region
+	}
+
+	ctx.WithField("region", region).Debug("getting s3 service connection")
+
+	svc := d.serviceExists(region)
+	if svc != nil {
+		ctx.WithField("region", region).Debug(
+			"got existing s3 service connection")
+		return svc, nil
+	}
+
+	ctx.WithField("region", region).Debug("creating new s3 service connection")
+
+	d.svcsRWL.Lock()
+	defer d.svcsRWL.Unlock()
+
+	sess := session.New()
+
+	var (
+		awsLogger   = &awsLogger{ctx: ctx}
+		awsLogLevel = aws.LogOff
+	)
+	if ll, ok := context.GetLogLevel(ctx); ok {
+		switch ll {
+		case log.DebugLevel:
+			awsLogger.lvl = log.DebugLevel
+			awsLogLevel = aws.LogDebugWithHTTPBody
+		case log.InfoLevel:
+			awsLogger.lvl = log.InfoLevel
+			awsLogLevel = aws.LogDebug
+		}
+	}
+
+	config := &aws.Config{
+		Region:           &region,
+		MaxRetries:       &d.maxRetries,
+		S3ForcePathStyle: aws.Bool(!d.disablePathStyle),
+		Credentials: credentials.NewChainCredentials(
+			[]credentials.Provider{
+				&credentials.StaticProvider{
+					Value: credentials.Value{
+						AccessKeyID:     d.accessKey,
+						SecretAccessKey: d.secretKey,
+					},
+				},
+				&credentials.EnvProvider{},
+				&credentials.SharedCredentialsProvider{},
+				&ec2rolecreds.EC2RoleProvider{
+					Client: ec2metadata.New(sess),
+				},
+			},
+		),
+		Logger:   awsLogger,
+		LogLevel: aws.LogLevel(awsLogLevel),
+	}
+
+	svc = awss3.New(sess, config)
+	ctx.WithField("region", region).Debug("s3 connection created")
+
+	if _, err := svc.ListBuckets(&awss3.ListBucketsInput{}); err != nil {
+		ctx.WithField("region", region).WithError(err).Error(
+			"s3 connection failed")
+		return nil, err
+	}
+
+	d.svcs[region] = svc
+	ctx.WithField("region", region).Debug("s3 connection successful")
+
+	return svc, nil
+}
+
+func (d *driver) serviceExists(region string) *awss3.S3 {
+	d.svcsRWL.RLock()
+	defer d.svcsRWL.RUnlock()
+	if svc, ok := d.svcs[region]; ok {
+		return svc
+	}
+	return nil
+}
+
+type awsLogger struct {
+	lvl log.Level
+	ctx types.Context
+}
+
+func (a *awsLogger) Log(args ...interface{}) {
+	switch a.lvl {
+	case log.DebugLevel:
+		a.ctx.Debugln(args...)
+	case log.InfoLevel:
+		a.ctx.Infoln(args...)
+	}
+}
+
+func mustInstanceIDID(ctx types.Context) *string {
+	return &context.MustInstanceID(ctx).ID
+}
+
+// NextDeviceInfo returns the information about the driver's next available
+func (d *driver) NextDeviceInfo(
+	ctx types.Context) (*types.NextDeviceInfo, error) {
+	return s3fsUtils.NextDeviceInfo, nil
+}
+
+// Type returns the type of storage the driver provides.
+func (d *driver) Type(ctx types.Context) (types.StorageType, error) {
+	return types.Object, nil
+}
+
+// InstanceInspect returns an instance.
+func (d *driver) InstanceInspect(
+	ctx types.Context,
+	opts types.Store) (*types.Instance, error) {
+
+	iid := context.MustInstanceID(ctx)
+	return &types.Instance{
+		Name:         iid.ID,
+		InstanceID:   iid,
+		ProviderName: iid.Driver,
+	}, nil
+}
+
+// Volumes returns all volumes or a filtered list of volumes.
+func (d *driver) Volumes(
+	ctx types.Context,
+	opts *types.VolumesOpts) ([]*types.Volume, error) {
+
+	vols, err := d.toTypeVolumes(ctx, opts.Attachments)
+	if err != nil {
+		return nil, goof.WithError("error getting s3fs volumes", err)
+	}
+	return vols, nil
+}
+
+// VolumeInspect inspects a single volume.
+func (d *driver) VolumeInspect(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeInspectOpts) (*types.Volume, error) {
+
+	return d.getVolume(ctx, volumeID, opts.Attachments)
+}
+
+// VolumeCreate creates a new volume.
+func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+
+	if opts.Encrypted != nil && *opts.Encrypted {
+		return nil, types.ErrNotImplemented
+	}
+
+	var cbc *awss3.CreateBucketConfiguration
+	if d.region != "us-east-1" {
+		cbc = &awss3.CreateBucketConfiguration{LocationConstraint: &d.region}
+	}
+
+	svc, _ := d.getService(ctx, "")
+
+	_, err := svc.CreateBucket(
+		&awss3.CreateBucketInput{
+			Bucket: &volumeName,
+			CreateBucketConfiguration: cbc,
+		})
+	if err != nil {
+		ctx.WithField(
+			"volumeName", volumeName).WithError(err).Error(
+			"error creating s3 bucket")
+		return nil, goof.WithFieldE(
+			"volumeName", volumeName, "error creating s3 bucket", err)
+	}
+
+	return d.toTypeVolume(ctx, volumeName, types.VolAttNone), nil
+}
+
+// VolumeCreateFromSnapshot creates a new volume from an existing snapshot.
+func (d *driver) VolumeCreateFromSnapshot(
+	ctx types.Context,
+	snapshotID, volumeName string,
+	opts *types.VolumeCreateOpts) (*types.Volume, error) {
+	// TODO Snapshots are not implemented yet
+	return nil, types.ErrNotImplemented
+}
+
+// VolumeCopy copies an existing volume.
+func (d *driver) VolumeCopy(
+	ctx types.Context,
+	volumeID, volumeName string,
+	opts types.Store) (*types.Volume, error) {
+	// TODO Snapshots are not implemented yet
+	return nil, types.ErrNotImplemented
+}
+
+// VolumeSnapshot snapshots a volume.
+func (d *driver) VolumeSnapshot(
+	ctx types.Context,
+	volumeID, snapshotName string,
+	opts types.Store) (*types.Snapshot, error) {
+	// TODO Snapshots are not implemented yet
+	return nil, types.ErrNotImplemented
+}
+
+// VolumeRemove removes a volume.
+func (d *driver) VolumeRemove(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeRemoveOpts) error {
+
+	var svc *awss3.S3
+
+	{
+		var err error
+		if svc, err = d.getServiceForBucket(ctx, volumeID); err != nil {
+			return err
+		}
+	}
+
+	if opts.Force {
+
+		{
+			// delete objects
+			res, err := svc.ListObjects(
+				&awss3.ListObjectsInput{Bucket: &volumeID})
+			if err != nil {
+				ctx.WithField(
+					"volumeID", volumeID).WithError(err).Error(
+					"error listing objects")
+				return goof.WithFieldE(
+					"volumeID", volumeID,
+					"error listing objects", err)
+			}
+			if res.Contents != nil {
+				for {
+					var key *string
+					for _, obj := range res.Contents {
+						if obj.Key == nil {
+							continue
+						}
+						key = obj.Key
+						_, err := svc.DeleteObject(&awss3.DeleteObjectInput{
+							Bucket: &volumeID,
+							Key:    key,
+						})
+						if err != nil {
+							ctx.WithFields(map[string]interface{}{
+								"volumeID": volumeID,
+								"key":      key,
+							}).WithError(err).Error("error deleting object")
+							return goof.WithFieldsE(map[string]interface{}{
+								"volumeID": volumeID,
+								"key":      key,
+							}, "error deleting object", err)
+						}
+					}
+
+					if res.IsTruncated == nil || !*res.IsTruncated {
+						break
+					}
+
+					var err error
+					keyMarker := res.NextMarker
+					if keyMarker == nil {
+						keyMarker = key
+					}
+					res, err = svc.ListObjects(
+						&awss3.ListObjectsInput{
+							Bucket: &volumeID,
+							Marker: keyMarker,
+						})
+					if err != nil {
+						ctx.WithFields(map[string]interface{}{
+							"volumeID":  volumeID,
+							"keyMarker": keyMarker,
+						}).WithError(err).Error("error listing next objects")
+						return goof.WithFieldsE(map[string]interface{}{
+							"volumeID":  volumeID,
+							"keyMarker": keyMarker,
+						}, "error listing next objects", err)
+					}
+				}
+			}
+		}
+
+		{
+			// delete versions
+			res, err := svc.ListObjectVersions(
+				&awss3.ListObjectVersionsInput{Bucket: &volumeID})
+			if err != nil {
+				ctx.WithField(
+					"volumeID", volumeID).WithError(err).Error(
+					"error listing object versions")
+				return goof.WithFieldE(
+					"volumeID", volumeID,
+					"error listing object versions", err)
+			}
+			if res.Versions != nil {
+				for {
+					var key *string
+					var ver *string
+					for _, obj := range res.Versions {
+						if obj.Key == nil {
+							continue
+						}
+						if obj.VersionId == nil {
+							continue
+						}
+						key = obj.Key
+						ver = obj.VersionId
+						_, err := svc.DeleteObject(&awss3.DeleteObjectInput{
+							Bucket:    &volumeID,
+							Key:       key,
+							VersionId: ver,
+						})
+						if err != nil {
+							ctx.WithFields(map[string]interface{}{
+								"volumeID":  volumeID,
+								"key":       key,
+								"versionID": ver,
+							}).WithError(err).Error("error deleting object ver")
+							return goof.WithFieldsE(map[string]interface{}{
+								"volumeID":  volumeID,
+								"key":       key,
+								"versionID": ver,
+							}, "error deleting object ver", err)
+						}
+					}
+
+					if res.IsTruncated == nil || !*res.IsTruncated {
+						break
+					}
+
+					var err error
+					keyMarker := res.NextKeyMarker
+					verMarker := res.NextVersionIdMarker
+					if keyMarker == nil {
+						keyMarker = key
+					}
+					if verMarker == nil {
+						verMarker = ver
+					}
+					res, err = svc.ListObjectVersions(
+						&awss3.ListObjectVersionsInput{
+							Bucket:          &volumeID,
+							KeyMarker:       keyMarker,
+							VersionIdMarker: verMarker,
+						})
+					if err != nil {
+						ctx.WithFields(map[string]interface{}{
+							"volumeID":  volumeID,
+							"keyMarker": keyMarker,
+							"verMarkre": verMarker,
+						}).WithError(err).Error("error listing next objects")
+						return goof.WithFieldsE(map[string]interface{}{
+							"volumeID":  volumeID,
+							"keyMarker": keyMarker,
+							"verMarkre": verMarker,
+						}, "error listing next objects", err)
+					}
+				}
+			}
+		}
+	}
+
+	_, err := svc.DeleteBucket(&awss3.DeleteBucketInput{Bucket: &volumeID})
+	if err != nil {
+		ctx.WithField(
+			"volumeID", volumeID).WithError(err).Error(
+			"error deleting s3 bucket")
+		return goof.WithFieldE(
+			"volumeID", volumeID, "error deleting s3 bucket", err)
+	}
+
+	return nil
+}
+
+// VolumeAttach attaches a volume and provides a token clients can use
+// to validate that device has appeared locally.
+func (d *driver) VolumeAttach(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
+
+	vol, err := d.getVolume(ctx, volumeID, types.VolAttReq)
+	if err != nil {
+		return nil, "", goof.WithFieldE(
+			"volumeID", volumeID,
+			"volume is not in bucket list", err)
+	}
+	return vol, "", nil
+}
+
+// VolumeDetach detaches a volume.
+func (d *driver) VolumeDetach(
+	ctx types.Context,
+	volumeID string,
+	opts *types.VolumeDetachOpts) (*types.Volume, error) {
+
+	vol, err := d.getVolume(ctx, volumeID, types.VolAttReq)
+	if err != nil {
+		return nil, goof.WithFieldE(
+			"volumeID", volumeID,
+			"volume is not in bucket list", err)
+	}
+	return vol, nil
+}
+
+// Snapshots returns all volumes or a filtered list of snapshots.
+func (d *driver) Snapshots(
+	ctx types.Context,
+	opts types.Store) ([]*types.Snapshot, error) {
+	// TODO Snapshots are not implemented yet
+	return nil, types.ErrNotImplemented
+}
+
+// SnapshotInspect inspects a single snapshot.
+func (d *driver) SnapshotInspect(
+	ctx types.Context,
+	snapshotID string,
+	opts types.Store) (*types.Snapshot, error) {
+	// TODO Snapshots are not implemented yet
+	return nil, types.ErrNotImplemented
+}
+
+// SnapshotCopy copies an existing snapshot.
+func (d *driver) SnapshotCopy(
+	ctx types.Context,
+	snapshotID, snapshotName, destinationID string,
+	opts types.Store) (*types.Snapshot, error) {
+	// TODO Snapshots are not implemented yet
+	return nil, types.ErrNotImplemented
+}
+
+// SnapshotRemove removes a snapshot.
+func (d *driver) SnapshotRemove(
+	ctx types.Context,
+	snapshotID string,
+	opts types.Store) error {
+	// TODO Snapshots are not implemented yet
+	return types.ErrNotImplemented
+}
+
+var errGetLocDevs = goof.New("error getting local devices from context")
+
+func (d *driver) toTypeVolumes(
+	ctx types.Context,
+	attachments types.VolumeAttachmentsTypes) ([]*types.Volume, error) {
+
+	svc, _ := d.getService(ctx, "")
+
+	res, err := svc.ListBuckets(&awss3.ListBucketsInput{})
+	if err != nil {
+		ctx.WithError(err).Error("error listing s3 buckets")
+		return nil, goof.WithError("error listing s3 buckets", err)
+	}
+
+	var vols []*types.Volume
+	for _, b := range res.Buckets {
+
+		vols = append(vols, d.toTypeVolume(ctx, *b.Name, attachments))
+	}
+	return vols, nil
+}
+
+func (d *driver) toTypeVolume(
+	ctx types.Context,
+	bucket string,
+	attachments types.VolumeAttachmentsTypes) *types.Volume {
+
+	vol := &types.Volume{
+		Name: bucket,
+		ID:   bucket,
+	}
+
+	iid, iidOK := context.InstanceID(ctx)
+	if iidOK && attachments.Requested() {
+		vatt := &types.VolumeAttachment{
+			VolumeID:   bucket,
+			DeviceName: bucket,
+			InstanceID: iid,
+		}
+		if attachments.Devices() {
+			if ld, ldOK := context.LocalDevices(ctx); ldOK {
+				if mp, mpOK := ld.DeviceMap[bucket]; mpOK {
+					vatt.MountPoint = mp
+				}
+			}
+		}
+		vol.Attachments = []*types.VolumeAttachment{vatt}
+	}
+
+	return vol
+}
+
+func (d *driver) getVolume(
+	ctx types.Context,
+	volumeID string,
+	attachments types.VolumeAttachmentsTypes) (*types.Volume, error) {
+
+	svc, _ := d.getService(ctx, "")
+	req, _ := svc.HeadBucketRequest(&awss3.HeadBucketInput{Bucket: &volumeID})
+	if err := req.Send(); err != nil && req.HTTPResponse.StatusCode != 301 {
+		return nil, utils.NewNotFoundError(volumeID)
+	}
+	return d.toTypeVolume(ctx, volumeID, attachments), nil
+}
+
+func (d *driver) getServiceForBucket(
+	ctx types.Context,
+	bucket string) (*awss3.S3, error) {
+
+	svc, _ := d.getService(ctx, "")
+	res, err := svc.GetBucketLocation(
+		&awss3.GetBucketLocationInput{Bucket: &bucket})
+	if err != nil {
+		return nil, utils.NewNotFoundError(bucket)
+	}
+	var region string
+	if res.LocationConstraint != nil {
+		region = *res.LocationConstraint
+	}
+	if svc, err = d.getService(ctx, region); err != nil {
+		return nil, err
+	}
+	return svc, nil
+}

--- a/drivers/storage/s3fs/tests/coverage.mk
+++ b/drivers/storage/s3fs/tests/coverage.mk
@@ -1,0 +1,2 @@
+S3FS_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/s3fs
+TEST_COVERPKG_./drivers/storage/s3fs/tests := $(S3FS_COVERPKG),$(S3FS_COVERPKG)/executor

--- a/drivers/storage/s3fs/tests/s3fs_test.go
+++ b/drivers/storage/s3fs/tests/s3fs_test.go
@@ -1,0 +1,456 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_s3fs
+
+package s3fs
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	gofig "github.com/akutz/gofig/types"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/registry"
+	"github.com/codedellemc/libstorage/api/server"
+	apitests "github.com/codedellemc/libstorage/api/tests"
+	"github.com/codedellemc/libstorage/api/types"
+	"github.com/codedellemc/libstorage/api/utils"
+	"github.com/codedellemc/libstorage/drivers/storage/s3fs"
+	s3fsUtil "github.com/codedellemc/libstorage/drivers/storage/s3fs/utils"
+)
+
+const (
+	driverName   = s3fs.Name
+	testCredFile = "/home/test/cred_file"
+)
+
+// Put contents of sample config.yml here
+var (
+	configYAML = []byte(`
+        s3fs:
+          buckets: "vol1,vol2"
+          cred_file: "/home/test/cred_file"
+`)
+)
+
+var volumeName string
+var volumeName2 string
+var volumeName3 string
+
+type CleanupIface interface {
+	cleanup(key string)
+}
+
+type CleanupObjectContextT struct {
+	objects map[string]CleanupIface
+}
+
+var cleanupObjectContext CleanupObjectContextT
+
+func (ctx *CleanupObjectContextT) remove(key string) {
+	delete(ctx.objects, key)
+}
+
+func (ctx *CleanupObjectContextT) cleanup() {
+	for key, value := range ctx.objects {
+		value.cleanup(key)
+		delete(ctx.objects, key)
+	}
+}
+
+type CleanupVolume struct {
+	vol    *types.Volume
+	client types.Client
+}
+
+func (ctx *CleanupObjectContextT) add(
+	key string,
+	vol *types.Volume,
+	client types.Client) {
+
+	cobj := &CleanupVolume{vol: vol, client: client}
+	ctx.objects[key] = cobj
+}
+
+func (cvol *CleanupVolume) cleanup(key string) {
+	cvol.client.API().VolumeDetach(nil, driverName, cvol.vol.Name,
+		&types.VolumeDetachRequest{Force: true})
+	cvol.client.API().VolumeRemove(nil, driverName, cvol.vol.Name, true)
+}
+
+// Check environment vars to see whether or not to run this test
+func skipTests() bool {
+	travis, _ := strconv.ParseBool(os.Getenv("TRAVIS"))
+	noTestS3FS, _ := strconv.ParseBool(os.Getenv("TEST_SKIP_S3FS"))
+	return travis || noTestS3FS
+}
+
+// Set volume names to first part of UUID before the -
+func init() {
+	volumeName = "vol1"
+	volumeName2 = "vol2"
+	volumeName3 = "vole3"
+	cleanupObjectContext = CleanupObjectContextT{
+		objects: make(map[string]CleanupIface),
+	}
+}
+
+func TestMain(m *testing.M) {
+	server.CloseOnAbort()
+	ec := m.Run()
+	os.Exit(ec)
+}
+
+///////////////////////////////////////////////////////////////////////
+/////////                    PUBLIC TESTS                     /////////
+///////////////////////////////////////////////////////////////////////
+func TestConfig(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		f := config.GetString("s3fs.cred_file")
+		assert.NotEqual(t, f, "")
+		assert.Equal(t, f, testCredFile)
+	}
+	apitests.Run(t, driverName, configYAML, tf)
+	cleanupObjectContext.cleanup()
+}
+
+// Check if InstanceID is properly returned by executor
+// and InstanceID.ID is filled out by InstanceInspect
+func TestInstanceID(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	// create storage driver
+	sd, err := registry.NewStorageDriver(driverName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// initialize storage driver
+	ctx := context.Background()
+	if err := sd.Init(ctx, registry.NewConfig()); err != nil {
+		t.Fatal(err)
+	}
+	// Get Instance ID from executor
+	iid, err := s3fsUtil.InstanceID(ctx, nil)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fill in Instance ID's ID field with InstanceInspect
+	ctx = ctx.WithValue(context.InstanceIDKey, iid)
+	i, err := sd.InstanceInspect(ctx, utils.NewStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	iid = i.InstanceID
+
+	// test resulting InstanceID
+	apitests.Run(
+		t, driverName, configYAML,
+		(&apitests.InstanceIDTest{
+			Driver:   driverName,
+			Expected: iid,
+		}).Test)
+	cleanupObjectContext.cleanup()
+}
+
+// Test if Services are configured and returned properly from the client
+func TestServices(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		reply, err := client.API().Services(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, len(reply), 1)
+
+		_, ok := reply[driverName]
+		assert.True(t, ok)
+	}
+	apitests.Run(t, driverName, configYAML, tf)
+	cleanupObjectContext.cleanup()
+}
+
+// Test volume functionality from storage driver
+func TestVolumeCreateRemove(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		vol := volumeCreate(t, client, volumeName)
+		volumeRemove(t, client, vol.ID)
+	}
+	apitests.Run(t, driverName, configYAML, tf)
+	cleanupObjectContext.cleanup()
+}
+
+// Test volume functionality from storage driver
+func TestVolumes(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		_ = volumeCreate(t, client, volumeName)
+		_ = volumeCreate(t, client, volumeName2)
+
+		vol1 := volumeByName(t, client, volumeName)
+		vol2 := volumeByName(t, client, volumeName2)
+
+		volumeRemove(t, client, vol1.ID)
+		volumeRemove(t, client, vol2.ID)
+	}
+	apitests.Run(t, driverName, configYAML, tf)
+	cleanupObjectContext.cleanup()
+}
+
+// Test volume functionality from storage driver
+func TestVolumeAttachDetach(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+	var vol *types.Volume
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		vol = volumeCreate(t, client, volumeName)
+		_ = volumeAttach(t, client, vol.ID)
+		_ = volumeInspectAttached(t, client, vol.ID)
+		_ = volumeInspectAttachedToMyInstance(t, client, vol.ID)
+	}
+	tf2 := func(config gofig.Config, client types.Client, t *testing.T) {
+		_ = volumeInspectAttachedToMyInstanceWithForeignInstance(t,
+			client, vol.ID)
+	}
+	tf3 := func(config gofig.Config, client types.Client, t *testing.T) {
+		_ = volumeDetach(t, client, vol.ID)
+		_ = volumeInspectDetached(t, client, vol.ID)
+		volumeRemove(t, client, vol.ID)
+	}
+	apitests.Run(t, driverName, configYAML, tf)
+	apitests.RunWithClientType(t, types.ControllerClient, driverName,
+		configYAML, tf2)
+	apitests.Run(t, driverName, configYAML, tf3)
+	cleanupObjectContext.cleanup()
+}
+
+///////////////////////////////////////////////////////////////////////
+/////////        PRIVATE TESTS FOR VOLUME FUNCTIONALITY       /////////
+///////////////////////////////////////////////////////////////////////
+// Test volume creation specifying size and volume name
+func volumeCreate(
+	t *testing.T, client types.Client, volumeName string) *types.Volume {
+	log.WithField("volumeName", volumeName).Info("creating volume")
+	// Prepare request for storage driver call to create volume
+	// s3fs doesnt provide size
+	//	size := int64(1)
+
+	opts := map[string]interface{}{
+		"priority": 2,
+		"owner":    "root@example.com",
+	}
+	volumeCreateRequest := &types.VolumeCreateRequest{
+		Name: volumeName,
+		//		Size: &size,
+		Opts: opts,
+	}
+	// Send request and retrieve created libStorage types.Volume
+	vol, err := client.API().VolumeCreate(nil, driverName,
+		volumeCreateRequest)
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+		t.Error("failed volumeCreate")
+	}
+	apitests.LogAsJSON(vol, t)
+	// Add obj to automated cleanup in case of errors
+	cleanupObjectContext.add(vol.ID, vol, client)
+	// Check volume options
+	assert.Equal(t, volumeName, vol.Name)
+	//	assert.Equal(t, size, vol.Size)
+	return vol
+}
+
+// Test volume retrieval by volume name using Volumes, which retrieves all volumes
+// from the storage driver without filtering, and filters the volumes externally.
+func volumeByName(
+	t *testing.T, client types.Client, volumeName string) *types.Volume {
+	log.WithField("volumeName", volumeName).Info("get volume by s3fs.Name")
+	// Retrieve all volumes
+	vols, err := client.API().Volumes(nil, 0)
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+	}
+	// Filter volumes to those under the service,
+	// and find a volume matching inputted volume name
+	assert.Contains(t, vols, driverName)
+	for _, vol := range vols[driverName] {
+		if vol.Name == volumeName {
+			return vol
+		}
+	}
+	// No matching volumes found
+	t.FailNow()
+	t.Error("failed volumeByName")
+	return nil
+}
+
+// Test volume removal by volume ID
+func volumeRemove(t *testing.T, client types.Client, volumeID string) {
+	log.WithField("volumeID", volumeID).Info("removing volume")
+	err := client.API().VolumeRemove(
+		nil, driverName, volumeID, true)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeRemove")
+		t.FailNow()
+	}
+	cleanupObjectContext.remove(volumeID)
+}
+
+// Test volume attachment by volume ID
+func volumeAttach(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+	log.WithField("volumeID", volumeID).Info("attaching volume")
+	// Get next device name from executor
+	nextDevice, err := client.Executor().NextDevice(
+		context.Background().WithValue(context.ServiceKey, driverName),
+		utils.NewStore())
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("error getting next device name from executor")
+		t.FailNow()
+	}
+	reply, token, err := client.API().VolumeAttach(
+		nil, driverName, volumeID, &types.VolumeAttachRequest{
+			NextDeviceName: &nextDevice,
+		})
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeAttach")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.Equal(t, token, "")
+	return reply
+}
+
+// Test volume retrieval by volume ID using VolumeInspect, which directly
+// retrieves matching volumes from the storage driver. Contrast with
+// volumeByID, which uses Volumes to retrieve all volumes from the storage
+// driver without filtering, and filters the volumes externally.
+func volumeInspect(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+	log.WithField("volumeID", volumeID).Info("inspecting volume")
+	reply, err := client.API().VolumeInspect(nil, driverName, volumeID, 0)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeInspect")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	return reply
+}
+
+// Test if volume is attached, its Attachments field should be populated
+func volumeInspectAttached(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+	log.WithField("volumeID", volumeID).Info("inspecting volume")
+	reply, err := client.API().VolumeInspect(
+		nil, driverName, volumeID,
+		types.VolAttReq)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeInspectAttached")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.Len(t, reply.Attachments, 1)
+	return reply
+}
+
+// Test if volume is attached to specified instance
+func volumeInspectAttachedToMyInstance(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+	log.WithField("volumeID", volumeID).Info(
+		"inspecting volume attached to my instance")
+	reply, err := client.API().VolumeInspect(nil, driverName, volumeID,
+		types.VolAttReqForInstance)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeInspectAttached")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.Len(t, reply.Attachments, 1)
+	return reply
+}
+
+// Test if volume is attached to my instance with foreign instance in filter
+func volumeInspectAttachedToMyInstanceWithForeignInstance(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+	ctx := context.Background()
+	iidm := types.InstanceIDMap{
+		driverName: &types.InstanceID{ID: "none", Driver: driverName}}
+	ctx = ctx.WithValue(context.AllInstanceIDsKey, iidm)
+	log.WithField("volumeID", volumeID).Info(
+		"inspecting volume attached to my instance with foreign id")
+	reply, err := client.API().VolumeInspect(
+		ctx, driverName, volumeID,
+		types.VolAttReqForInstance)
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeInspectAttached")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	// s3fs doesn't filter by 'Mine' instanceID
+	assert.Len(t, reply.Attachments, 1)
+	return reply
+}
+
+// Test if volume is detached, its Attachments field should not be populated
+func volumeInspectDetached(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+	log.WithField("volumeID", volumeID).Info("inspecting volume")
+	reply, err := client.API().VolumeInspect(
+		nil, driverName, volumeID,
+		types.VolAttNone)
+	assert.NoError(t, err)
+
+	if err != nil {
+		t.Error("failed volumeInspectDetached")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.Len(t, reply.Attachments, 0)
+	apitests.LogAsJSON(reply, t)
+	return reply
+}
+
+// Test detaching volume by volume ID
+func volumeDetach(
+	t *testing.T, client types.Client, volumeID string) *types.Volume {
+	log.WithField("volumeID", volumeID).Info("detaching volume")
+	reply, err := client.API().VolumeDetach(
+		nil, driverName, volumeID, &types.VolumeDetachRequest{})
+	assert.NoError(t, err)
+	if err != nil {
+		t.Error("failed volumeDetach")
+		t.FailNow()
+	}
+	apitests.LogAsJSON(reply, t)
+	assert.Len(t, reply.Attachments, 1)
+	return reply
+}

--- a/drivers/storage/s3fs/utils/utils.go
+++ b/drivers/storage/s3fs/utils/utils.go
@@ -1,0 +1,25 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_s3fs
+
+package utils
+
+import (
+	"os"
+
+	gofig "github.com/akutz/gofig/types"
+
+	"github.com/codedellemc/libstorage/api/types"
+	"github.com/codedellemc/libstorage/drivers/storage/s3fs"
+)
+
+// InstanceID returns the instance ID for the local host.
+func InstanceID(
+	ctx types.Context, config gofig.Config) (*types.InstanceID, error) {
+
+	var hostName string
+	if config == nil {
+		hostName = config.GetString(s3fs.ConfigS3FSHostName)
+	} else {
+		hostName, _ = os.Hostname()
+	}
+	return &types.InstanceID{ID: hostName, Driver: s3fs.Name}, nil
+}

--- a/drivers/storage/s3fs/utils/utils_test.go
+++ b/drivers/storage/s3fs/utils/utils_test.go
@@ -1,0 +1,28 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_s3fs
+
+package utils
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/codedellemc/libstorage/api/context"
+)
+
+func skipTest(t *testing.T) {
+	if ok, _ := strconv.ParseBool(os.Getenv("S3FS_UTILS_TEST")); !ok {
+		t.Skip()
+	}
+}
+
+func TestInstanceID(t *testing.T) {
+	skipTest(t)
+	iid, err := InstanceID(context.Background(), nil)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	t.Logf("instanceID=%s", iid.String())
+}

--- a/drivers/storage/s3fs/utils/utils_unix.go
+++ b/drivers/storage/s3fs/utils/utils_unix.go
@@ -1,0 +1,16 @@
+// +build !windows
+// +build !libstorage_storage_driver libstorage_storage_driver_s3fs
+
+package utils
+
+import (
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+// NextDeviceInfo is the NextDeviceInfo object for S3FS.
+//
+var NextDeviceInfo = &types.NextDeviceInfo{
+	Prefix:  "",
+	Pattern: "",
+	Ignore:  true,
+}

--- a/drivers/storage/scaleio/storage/scaleio_storage.go
+++ b/drivers/storage/scaleio/storage/scaleio_storage.go
@@ -442,7 +442,7 @@ func (d *driver) VolumeSnapshot(
 func (d *driver) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	fields := eff(map[string]interface{}{
 		"volumeId": volumeID,

--- a/drivers/storage/vbox/storage/vbox_storage.go
+++ b/drivers/storage/vbox/storage/vbox_storage.go
@@ -294,7 +294,7 @@ func (d *driver) VolumeSnapshot(
 func (d *driver) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	d.Lock()
 	defer d.Unlock()

--- a/drivers/storage/vfs/storage/vfs_storage.go
+++ b/drivers/storage/vfs/storage/vfs_storage.go
@@ -365,7 +365,7 @@ func (d *driver) VolumeSnapshot(
 func (d *driver) VolumeRemove(
 	ctx types.Context,
 	volumeID string,
-	opts types.Store) error {
+	opts *types.VolumeRemoveOpts) error {
 
 	context.MustSession(ctx)
 

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -541,7 +541,7 @@ func TestVolumeRemove(t *testing.T) {
 
 	tf1 := func(config gofig.Config, client types.Client, t *testing.T) {
 		assertVolDir(t, config, "vfs-002", true)
-		err := client.API().VolumeRemove(nil, vfs.Name, "vfs-002")
+		err := client.API().VolumeRemove(nil, vfs.Name, "vfs-002", false)
 		assert.NoError(t, err)
 		assertVolDir(t, config, "vfs-002", false)
 	}
@@ -549,7 +549,7 @@ func TestVolumeRemove(t *testing.T) {
 	apitests.Run(t, vfs.Name, newTestConfig(t), tf1)
 
 	tf2 := func(config gofig.Config, client types.Client, t *testing.T) {
-		err := client.API().VolumeRemove(nil, vfs.Name, "vfs-002")
+		err := client.API().VolumeRemove(nil, vfs.Name, "vfs-002", false)
 		assert.Error(t, err)
 		httpErr := err.(goof.HTTPError)
 		assert.Equal(t, "resource not found", httpErr.Error())

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: bfed9a1798d05ab23243875113ae9bc97fdb346ac25be707c05d31e2e00c0915
-updated: 2016-11-17T13:57:46.85843333-06:00
+hash: 4cee882016929bc1aa12aa52eedc34f0ebc5b8c0103600441f587b0ac4c48328
+updated: 2017-02-04T22:26:14.762400239-06:00
 imports:
 - name: github.com/akutz/gofig
   version: 862741cad5edced279c57d1981e8e3e9fa54e8d5
@@ -20,7 +20,7 @@ imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/aws/aws-sdk-go
-  version: 6627523f8671f323edb36dfc56cc0b47c810211f
+  version: 3f8f870ec9939e32b3372abf74d24e468bcd285d
   repo: https://github.com/aws/aws-sdk-go
   subpackages:
   - aws
@@ -35,10 +35,10 @@ imports:
   - aws/credentials/stscreds
   - aws/defaults
   - aws/ec2metadata
+  - aws/endpoints
   - aws/request
   - aws/session
   - aws/signer/v4
-  - private/endpoints
   - private/protocol
   - private/protocol/ec2query
   - private/protocol/json/jsonutil
@@ -47,10 +47,12 @@ imports:
   - private/protocol/query/queryutil
   - private/protocol/rest
   - private/protocol/restjson
+  - private/protocol/restxml
   - private/protocol/xml/xmlutil
   - private/waiter
   - service/ec2
   - service/efs
+  - service/s3
   - service/sts
 - name: github.com/cesanta/ucl
   version: 97c016fce90e6af1b14558563ac46852167e6a76

--- a/glide.yaml
+++ b/glide.yaml
@@ -57,9 +57,9 @@ import:
   - package: github.com/codedellemc/goisilon
     version: v1.5.0
 
-### EFS and EBS
+### EFS and EBS and S3FS
   - package: github.com/aws/aws-sdk-go
-    version: v1.5.6
+    version: v1.6.18
     repo:    https://github.com/aws/aws-sdk-go
 
 ### Rackspace

--- a/imports/executors/imports_executor.go
+++ b/imports/executors/imports_executor.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/codedellemc/libstorage/drivers/storage/efs/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/isilon/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/rbd/executor"
+	_ "github.com/codedellemc/libstorage/drivers/storage/s3fs/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/scaleio/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/vbox/executor"
 	_ "github.com/codedellemc/libstorage/drivers/storage/vfs/executor"

--- a/imports/executors/imports_executor_s3fs.go
+++ b/imports/executors/imports_executor_s3fs.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_executor,libstorage_storage_executor_s3fs
+
+package executors
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/s3fs/executor"
+)

--- a/imports/remote/imports_remote.go
+++ b/imports/remote/imports_remote.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/codedellemc/libstorage/drivers/storage/efs/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/isilon/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/rbd/storage"
+	_ "github.com/codedellemc/libstorage/drivers/storage/s3fs/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/scaleio/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/vbox/storage"
 	_ "github.com/codedellemc/libstorage/drivers/storage/vfs/storage"

--- a/imports/remote/imports_remote_s3fs.go
+++ b/imports/remote/imports_remote_s3fs.go
@@ -1,0 +1,8 @@
+// +build libstorage_storage_driver,libstorage_storage_driver_s3fs
+
+package remote
+
+import (
+	// load the packages
+	_ "github.com/codedellemc/libstorage/drivers/storage/s3fs/storage"
+)

--- a/libstorage.apib
+++ b/libstorage.apib
@@ -1668,8 +1668,24 @@ Internal server error
 
             { "$ref": "https://raw.githubusercontent.com/codedellemc/libstorage/master/libstorage.json#/definitions/internalServerError" }
 
-## Remove [DELETE]
+## Remove [DELETE /volumes/{service}/{volumeID}?{force}]
 Removes the volume.
+
++ Parameters
+
+    + service: `ebs-00` (string, required)
+
+        The name of the service to which the Volume belongs
+
+    + volumeID: `vol-000` (string, required)
+
+        The volume's unique ID
+
+    + force (optional)
+
+        A flag that indicates whether or not this is a force delete. If true
+        the delete operation should remove the volume regardless of its state
+        or contents.
 
 + Request (application/json)
 


### PR DESCRIPTION
This patch introduces support for mounting S3FS buckets as Linux file systems. This initial version of the S3FS storage driver does not yet support volume (bucket) creation/removal.

This patch also updates the AWS SDK dependency that is shared by the EBS and EFS storage drivers to v1.6.18, released on 2017/01/27.

Finally, this patch also refactors the `VolumeRemove`, and its related signatures, to use the new `VolumeRemoveOpts` struct instead of a bare `Options` type. All drivers affected by this change have been updated as part of this patch. For people compiling REX-Ray against this branch, you will need the following [patch](https://gist.github.com/akutz/b4c4c839fd7ba745662b7cd2de821a11) in order to do so. The linked patch updates REX-Ray's two sources affected by this change to libStorage.

This PR replaces the existing S3FS PR #397. Thank you @Andrey-mp and @alexey-mr for your work on this, we could not have done this without you.