### PR TITLE
ScaleIO and EBS Automated Testing

### DIFF
--- a/drivers/storage/ebs/tests/config-tmpl.yml
+++ b/drivers/storage/ebs/tests/config-tmpl.yml
@@ -1,0 +1,18 @@
+rexray:
+  logLevel: warn
+  modules:
+    rexray:
+      type: docker
+      libstorage:
+        service: ebs
+      host: unix:///run/docker/plugins/rexray.sock
+libstorage:
+  service: ebs
+  integration:
+    volume:
+      operations:
+        mount:
+          preempt: true
+ebs:
+  accessKey: [ACCESS_KEY]
+  secretKey: [SECRET_KEY]

--- a/drivers/storage/ebs/tests/offline-tests.sh
+++ b/drivers/storage/ebs/tests/offline-tests.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# This script runs tests
+
+AWS_ACCESSKEY=${AWS_ACCESSKEY:-$1}
+AWS_SECRETKEY=${AWS_SECRETKEY:-$2}
+CF_STACK_NAME=${CF_STACK_NAME:-$3}
+LAUNCH_KEY_NAME=${LAUNCH_KEY_NAME:-$4}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$5}
+
+usage() {
+  echo "Usage: ${0} access-key secret-key stack-name launch-key-name"
+  echo ""
+  echo "   access-key: AWS access key"
+  echo "   secret-key: AWS secret key"
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+  echo "   launch-key-name: AWS key that will be used to launch EC2 instance"
+  echo "   git-commit: Git Commit ID. Default: master"
+}
+
+if [ -z "${AWS_ACCESSKEY}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${AWS_SECRETKEY}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${LAUNCH_KEY_NAME}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+
+./test-env-up.sh $AWS_ACCESSKEY $AWS_SECRETKEY $CF_STACK_NAME $LAUNCH_KEY_NAME
+sleep 5
+./test-run-aws.sh $CF_STACK_NAME $GIT_COMMIT_ID
+./test-env-down.sh $CF_STACK_NAME

--- a/drivers/storage/ebs/tests/test-cf-template.json
+++ b/drivers/storage/ebs/tests/test-cf-template.json
@@ -1,0 +1,778 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Metadata": {
+    "AWS::CloudFormation::Designer": {
+      "19117008-4607-4d30-95d7-9e27b231f551": {
+        "size": {
+          "width": 420,
+          "height": 220
+        },
+        "position": {
+          "x": 720,
+          "y": 170
+        },
+        "z": 1,
+        "embeds": [
+          "35c845c6-61b8-422c-be16-f1395a95879f",
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a",
+          "e3f368ef-533b-484c-b3f4-897729901208"
+        ]
+      },
+      "e3f368ef-533b-484c-b3f4-897729901208": {
+        "size": {
+          "width": 290,
+          "height": 100
+        },
+        "position": {
+          "x": 840,
+          "y": 250
+        },
+        "z": 2,
+        "parent": "19117008-4607-4d30-95d7-9e27b231f551",
+        "embeds": [
+          "b2904db7-7420-44e0-9bd7-078c253f58e8",
+          "05dd39d3-73fc-4732-be16-9966f7fa4769",
+          "0b3b1e8b-5559-4a13-bf67-7312d43b361c"
+        ]
+      },
+      "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 960,
+          "y": 100
+        },
+        "z": 0,
+        "parent": "19117008-4607-4d30-95d7-9e27b231f551",
+        "embeds": [],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "c7820c4a-775a-4228-9f22-d7b91120d6c9": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 640,
+          "y": 170
+        },
+        "z": 1,
+        "embeds": []
+      },
+      "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8": {
+        "source": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "target": {
+          "id": "19117008-4607-4d30-95d7-9e27b231f551"
+        },
+        "z": 1
+      },
+      "35c845c6-61b8-422c-be16-f1395a95879f": {
+        "size": {
+          "width": 80,
+          "height": 90
+        },
+        "position": {
+          "x": 750,
+          "y": 180
+        },
+        "z": 2,
+        "parent": "19117008-4607-4d30-95d7-9e27b231f551",
+        "embeds": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ]
+      },
+      "b2904db7-7420-44e0-9bd7-078c253f58e8": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 860,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "fe5557b3-266c-40ef-b6bd-4ad21f7511c5": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 760,
+          "y": 200
+        },
+        "z": 3,
+        "parent": "35c845c6-61b8-422c-be16-f1395a95879f",
+        "embeds": [],
+        "references": [
+          "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        ],
+        "dependson": [
+          "c7820c4a-775a-4228-9f22-d7b91120d6c9",
+          "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8"
+        ]
+      },
+      "da60be23-5de7-4310-8cfc-1cae8042ada7": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "target": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "z": 4
+      },
+      "d3c5f91d-7e10-4ff9-9a86-e4fd05e69747": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "target": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "z": 5
+      },
+      "98f6a038-b5dc-43b9-9901-549f72c5aaf1": {
+        "source": {
+          "id": "b2904db7-7420-44e0-9bd7-078c253f58e8"
+        },
+        "target": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "z": 6
+      },
+      "43aacb25-8175-4890-b26f-066ceac37afe": {
+        "source": {
+          "id": "35c845c6-61b8-422c-be16-f1395a95879f"
+        },
+        "target": {
+          "id": "e3f368ef-533b-484c-b3f4-897729901208"
+        },
+        "z": 2
+      },
+      "05dd39d3-73fc-4732-be16-9966f7fa4769": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 960,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "0b3b1e8b-5559-4a13-bf67-7312d43b361c": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 1050,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "9c4181f8-b640-4266-ab00-e30b2bf26f48": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5",
+          "selector": "g:nth-child(1) g:nth-child(4) g:nth-child(5) circle:nth-child(1)     ",
+          "port": "AWS::DependencyLink-*"
+        },
+        "target": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "z": 5
+      },
+      "ec9732a1-755a-45fd-8f95-00f015fdc006": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "target": {
+          "id": "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8"
+        },
+        "z": 4
+      }
+    }
+  },
+  "Resources": {
+    "ScaleIOSubnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": "10.0.0.0/24"
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "e3f368ef-533b-484c-b3f4-897729901208"
+        }
+      }
+    },
+    "ScaleIOSecGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "GroupDescription": "Allow access from SSH traffic",
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "22",
+            "ToPort": "22",
+            "CidrIp": {
+              "Ref": "SSHLocation"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "ToPort": "443",
+            "CidrIp": {
+              "Ref": "SSHLocation"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
+            "CidrIp": {
+              "Ref": "SSHLocation"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "1",
+            "ToPort": "65535",
+            "CidrIp": "10.0.0.0/24"
+          },
+          {
+            "IpProtocol": "udp",
+            "FromPort": "1",
+            "ToPort": "65535",
+            "CidrIp": "10.0.0.0/24"
+          },
+          {
+            "IpProtocol": "icmp",
+            "FromPort": "-1",
+            "ToPort": "-1",
+            "CidrIp": "10.0.0.0/24"
+          }
+        ]
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        }
+      }
+    },
+    "InternetGateway": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {},
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        }
+      }
+    },
+    "RouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "35c845c6-61b8-422c-be16-f1395a95879f"
+        }
+      }
+    },
+    "PublicRoute": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        },
+        "GatewayId": {
+          "Ref": "InternetGateway"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        }
+      },
+      "DependsOn": [
+        "InternetGateway",
+        "GatewayAttachment"
+      ]
+    },
+    "VPC": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true",
+        "CidrBlock": "10.0.0.0/16"
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "19117008-4607-4d30-95d7-9e27b231f551"
+        }
+      }
+    },
+    "EbsNode3": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-72018712",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "EbsNode3"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.13",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo EbsNode3 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "0b3b1e8b-5559-4a13-bf67-7312d43b361c"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "EbsNode2": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-7a03851a",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "EbsNode2"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.12",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo EbsNode2 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "05dd39d3-73fc-4732-be16-9966f7fa4769"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "EbsNode1": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-2e0d8b4e",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "EbsNode1"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.11",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo EbsNode1 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "b2904db7-7420-44e0-9bd7-078c253f58e8"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "GatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "InternetGatewayId": {
+          "Ref": "InternetGateway"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8"
+        }
+      }
+    },
+    "SubnetAttachment": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        },
+        "SubnetId": {
+          "Ref": "ScaleIOSubnet"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "43aacb25-8175-4890-b26f-066ceac37afe"
+        }
+      }
+    }
+  },
+  "Parameters": {
+    "KeyName": {
+      "Description": "Name of an EC2 KeyPair to enable SSH access to the cluster.",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription": "must be the name of an existing EC2 KeyPair."
+    },
+    "SSHLocation": {
+      "Description": " The IP address range that can be used to access the ScaleIO cluster using SSH.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "0.0.0.0/0",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
+    }
+  },
+  "Mappings": {
+    "AWSInstanceType2Arch": {
+      "t2.medium": {
+        "Arch": "HVM64"
+      }
+    },
+    "AWSRegionArch2AMI": {
+      "us-west-1": {
+        "PV64": "ami-d514f291",
+        "HVM64": "ami-d114f295",
+        "HVMG2": "ami-f31ffeb7"
+      }
+    }
+  },
+  "Outputs": {
+    "URL": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "http://",
+            {
+              "Fn::GetAtt": [
+                "EbsNode1",
+                "PublicIp"
+              ]
+            }
+          ]
+        ]
+      },
+      "Description": "Cluster Management URL"
+    }
+  }
+}

--- a/drivers/storage/ebs/tests/test-env-down.sh
+++ b/drivers/storage/ebs/tests/test-env-down.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# This script cleans up the infrastructure used for tests
+
+#set -e
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y curl
+  else
+    sudo brew install curl
+  fi
+}
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  sudo /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y jq
+  else
+    sudo brew install jq
+  fi
+}
+
+usage() {
+  echo "Usage: ${0} stack-name"
+  echo ""
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+
+# Get stack ID
+CF_STACK_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${CF_STACK_NAME} \
+  --output text \
+  --query 'Stacks[0].StackId')
+
+# Delete cloud formation stack
+aws cloudformation delete-stack \
+  --stack-name ${CF_STACK_NAME}
+
+echo "Waiting for CF stack to get deleted ..."
+
+aws cloudformation wait stack-delete-complete \
+  --stack-name ${CF_STACK_ID}
+
+rm -f ~/.aws/config
+rm -f ~/.aws/credentials
+rm -f ./config.yml*
+rm -f ./keyfile
+rm -f ./output*.txt
+
+echo "Stack has been deleted"

--- a/drivers/storage/ebs/tests/test-env-up.sh
+++ b/drivers/storage/ebs/tests/test-env-up.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# This script launches infrastructure required for testing the ScaleIO storage driver.
+# It spins up VPC and EC2 instance so AWS account owner will get charged for time
+# that resources will be running.
+
+#set -e
+
+AWS_ACCESSKEY=${AWS_ACCESSKEY:-$1}
+AWS_SECRETKEY=${AWS_SECRETKEY:-$2}
+CF_STACK_NAME=${CF_STACK_NAME:-$3}
+LAUNCH_KEY_NAME=${LAUNCH_KEY_NAME:-$4}
+
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y curl
+  else
+    sudo brew install curl
+  fi
+}
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  sudo /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y jq
+  else
+    sudo brew install jq
+  fi
+}
+
+usage() {
+  echo "Usage: ${0} access-key secret-key stack-name launch-key-name"
+  echo ""
+  echo "   access-key: AWS access key"
+  echo "   secret-key: AWS secret key"
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+  echo "   launch-key-name: AWS key that will be used to launch EC2 instance."
+  echo "                    The ssh key must be of the same filename in ~/.ssh"
+}
+
+template_path() {
+  echo "$(dirname $0)/test-cf-template.json"
+}
+
+if [ -z "${AWS_ACCESSKEY}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${AWS_SECRETKEY}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${LAUNCH_KEY_NAME}" ]; then
+  usage
+  exit 1
+fi
+rm -f ./keyfile
+if [ -f ~/.ssh/${LAUNCH_KEY_NAME} ]; then
+  echo ${LAUNCH_KEY_NAME} > ./keyfile
+elif [ -f ~/.ssh/${LAUNCH_KEY_NAME}.pem ]; then
+  echo ${LAUNCH_KEY_NAME}.pem > ./keyfile
+else
+  usage
+  exit 1
+fi
+
+aws configure set aws_access_key_id ${AWS_ACCESSKEY}
+aws configure set aws_secret_access_key ${AWS_SECRETKEY}
+aws configure set default.region us-west-2
+
+# Launch CF stack
+aws cloudformation create-stack \
+  --stack-name ${CF_STACK_NAME} \
+  --template-body file://$(template_path) \
+  --parameter ParameterKey=KeyName,ParameterValue=${LAUNCH_KEY_NAME} \
+  --capabilities CAPABILITY_IAM 1>/dev/null
+
+ESC_AWS_ACCESSKEY=$(echo $AWS_ACCESSKEY | sed 's/\//\\\//g')
+ESC_AWS_SECRETKEY=$(echo $AWS_SECRETKEY | sed 's/\//\\\//g')
+cp -f ./config-tmpl.yml ./config.yml
+sed -ie "s/\[ACCESS_KEY\]/$ESC_AWS_ACCESSKEY/" config.yml
+sed -ie "s/\[SECRET_KEY\]/$ESC_AWS_SECRETKEY/" config.yml
+
+echo "Environment launch started. It will take couple minutes to create whole environment..."

--- a/drivers/storage/ebs/tests/test-run-aws.sh
+++ b/drivers/storage/ebs/tests/test-run-aws.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+# This script runs tests
+
+# set -e
+
+: ${CF_EC2_USER:="ec2-user"}
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$2}
+
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y curl
+  else
+    sudo brew install curl
+  fi
+}
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  sudo /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y jq
+  else
+    sudo brew install jq
+  fi
+}
+
+usage() {
+  echo "Usage: ${0} stack-name git-commit"
+  echo ""
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+  echo "   git-commit: Git Commit ID. Default: master"
+}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+
+echo "Waiting for CF stack to come up ..."
+
+aws cloudformation wait stack-create-complete \
+  --stack-name ${CF_STACK_NAME}
+
+# Get IP address of EC2 machine where tests can be executed
+EBS_NODE1=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="EbsNode1")' | jq -r .PhysicalResourceId)
+EBS_NODE2=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="EbsNode2")' | jq -r .PhysicalResourceId)
+EBS_NODE3=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="EbsNode3")' | jq -r .PhysicalResourceId)
+#echo ${EBS_NODE1}
+#echo ${EBS_NODE2}
+#echo ${EBS_NODE3}
+
+EBS_NODE1_FQDN=$(aws ec2 describe-instances --instance-ids ${EBS_NODE1} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+EBS_NODE2_FQDN=$(aws ec2 describe-instances --instance-ids ${EBS_NODE2} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+EBS_NODE3_FQDN=$(aws ec2 describe-instances --instance-ids ${EBS_NODE3} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#echo ${EBS_NODE1_FQDN}
+#echo ${EBS_NODE2_FQDN}
+#echo ${EBS_NODE3_FQDN}
+
+ssh-keyscan -H ${EBS_NODE1_FQDN} >> ~/.ssh/known_hosts
+ssh-keyscan -H ${EBS_NODE2_FQDN} >> ~/.ssh/known_hosts
+ssh-keyscan -H ${EBS_NODE3_FQDN} >> ~/.ssh/known_hosts
+
+rm -f $(dirname $0)/output1.txt
+rm -f $(dirname $0)/output2.txt
+rm -f $(dirname $0)/output3.txt
+
+# ssh key to use
+SSH_KEY_FILE=$(cat ./keyfile)
+
+# Copy REX-Ray build to EC2 instance
+scp -i ~/.ssh/${SSH_KEY_FILE} ./config.yml $CF_EC2_USER@$EBS_NODE1_FQDN:/tmp
+scp -i ~/.ssh/${SSH_KEY_FILE} ./tests1.sh $CF_EC2_USER@$EBS_NODE1_FQDN:/tmp
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE1_FQDN "sudo chmod +x /tmp/tests1.sh"
+if [ -f $GIT_COMMIT_ID ]; then
+  scp -i ~/.ssh/${SSH_KEY_FILE} $GIT_COMMIT_ID $CF_EC2_USER@$EBS_NODE1_FQDN:/tmp
+  ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE1_FQDN "sudo chmod +x /tmp/rexray"
+fi
+
+scp -i ~/.ssh/${SSH_KEY_FILE} ./config.yml $CF_EC2_USER@$EBS_NODE2_FQDN:/tmp
+scp -i ~/.ssh/${SSH_KEY_FILE} ./tests2a.sh $CF_EC2_USER@$EBS_NODE2_FQDN:/tmp
+scp -i ~/.ssh/${SSH_KEY_FILE} ./tests2b.sh $CF_EC2_USER@$EBS_NODE2_FQDN:/tmp
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE2_FQDN "sudo chmod +x /tmp/tests2a.sh"
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE2_FQDN "sudo chmod +x /tmp/tests2b.sh"
+if [ -f $GIT_COMMIT_ID ]; then
+  scp -i ~/.ssh/${SSH_KEY_FILE} $GIT_COMMIT_ID $CF_EC2_USER@$EBS_NODE2_FQDN:/tmp
+  ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE2_FQDN "sudo chmod +x /tmp/rexray"
+fi
+
+scp -i ~/.ssh/${SSH_KEY_FILE} ./config.yml $CF_EC2_USER@$EBS_NODE3_FQDN:/tmp
+scp -i ~/.ssh/${SSH_KEY_FILE} ./tests3.sh $CF_EC2_USER@$EBS_NODE3_FQDN:/tmp
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE3_FQDN "sudo chmod +x /tmp/tests3.sh"
+if [ -f $GIT_COMMIT_ID ]; then
+  scp -i ~/.ssh/${SSH_KEY_FILE} $GIT_COMMIT_ID $CF_EC2_USER@$EBS_NODE3_FQDN:/tmp
+  ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE3_FQDN "sudo chmod +x /tmp/rexray"
+fi
+
+if [ -f $GIT_COMMIT_ID ]; then
+  GIT_COMMIT_ID="/tmp/rexray"
+fi
+
+echo "Executing Tests!"
+
+# Run tests... note the use of "bash --login -c". this forces a load of the user's
+# env variables while cause the make command to fail.
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE1_FQDN "bash --login -c '/tmp/tests1.sh $CF_STACK_NAME $GIT_COMMIT_ID' 2>&1" &
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE2_FQDN "bash --login -c '/tmp/tests2a.sh $CF_STACK_NAME $GIT_COMMIT_ID' 2>&1" &
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE3_FQDN "bash --login -c '/tmp/tests3.sh $CF_STACK_NAME $GIT_COMMIT_ID' 2>&1" &
+
+FINISHED1=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE1_FQDN "cat /tmp/finished.txt 2>&1")
+while [ "$FINISHED1" != "finished" ];
+do
+  sleep 1
+  FINISHED1=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE1_FQDN "cat /tmp/finished.txt 2>&1")
+done
+
+# execute the preemption portion of the script... note that node 1 and node 3
+# should finish before node 2. see comment below.
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE2_FQDN "bash --login -c '/tmp/tests2b.sh $CF_STACK_NAME $GIT_COMMIT_ID' 2>&1" &
+
+FINISHED3=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE3_FQDN "cat /tmp/finished.txt 2>&1")
+while [ "$FINISHED3" != "finished" ];
+do
+  sleep 1
+  FINISHED3=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE3_FQDN "cat /tmp/finished.txt 2>&1")
+done
+
+# this node should finish last because of the preemption test. hence this order
+# (Node 1, 3, 2) for checking for finished
+FINISHED2=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE2_FQDN "cat /tmp/finished.txt 2>&1")
+while [ "$FINISHED2" != "finished" ];
+do
+  sleep 1
+  FINISHED2=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE2_FQDN "cat /tmp/finished.txt 2>&1")
+done
+
+# Copy test coverage results
+scp -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE1_FQDN:/tmp/output.txt $(dirname $0)/output1.txt
+scp -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE2_FQDN:/tmp/output.txt $(dirname $0)/output2.txt
+scp -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE3_FQDN:/tmp/output.txt $(dirname $0)/output3.txt
+
+echo "Tests passed and coverge results are available in the output files"
+echo "Node 1 Results"
+cat $(dirname $0)/output1.txt
+echo " "
+echo "Node 2 Results"
+cat $(dirname $0)/output2.txt
+echo " "
+echo "Node 3 Results"
+cat $(dirname $0)/output3.txt

--- a/drivers/storage/ebs/tests/tests1.sh
+++ b/drivers/storage/ebs/tests/tests1.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+
+# This script builds REX-Ray and then runs tests
+
+DEBUG=false
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$2}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  CF_STACK_NAME="default"
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+echo "Building using libstorage commit: $GIT_COMMIT_ID"
+
+FIRST_VOLUME=$CF_STACK_NAME"_1a"
+SECOND_VOLUME=$CF_STACK_NAME"_1b"
+
+# Clean Up the Env
+sudo rm -f /tmp/output.txt
+sudo rm -f /tmp/finished.txt
+sudo mkdir -p /usr/bin
+sudo mkdir -p /etc/rexray
+
+if [ -f $GIT_COMMIT_ID ]; then
+  echo "Using pre-built REX-Ray"
+
+  sudo cp -f $GIT_COMMIT_ID /usr/bin
+else
+  echo "Building REX-Ray"
+  echo "Building using libstorage commit: $GIT_COMMIT_ID"
+
+  # Build REX-Ray
+  rm -rf $HOME/.glide
+  mkdir -p $HOME/go/src/github.com/codedellemc
+  cd $HOME/go/src/github.com/codedellemc
+  git clone https://github.com/codedellemc/libstorage.git
+  git clone https://github.com/codedellemc/rexray.git
+  cd $HOME/go/src/github.com/codedellemc/rexray
+  sed -e "s/.*# libstorage-version/    ref:     $GIT_COMMIT_ID/g" -i glide.yaml
+  sed -e $"s|.*# libstorage-repo|    repo:    file://$HOME/go/src/github.com/codedellemc/libstorage\n    vcs:     git|g" -i glide.yaml
+  rm -f glide.lock
+  make deps
+  make -j build-libstorage
+  make build
+
+  # Install REX-Ray
+  sudo cp -f $HOME/go/bin/rexray /usr/bin
+fi
+
+sudo cp -f /tmp/config.yml /etc/rexray
+sudo /usr/bin/rexray install
+sudo service rexray restart
+
+sleep 5
+
+# Run the tests....
+TEST1=$(sudo rexray volume create $FIRST_VOLUME --size 16 | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST1" == "$FIRST_VOLUME" ]; then
+  printf "1:rexray volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "1:rexray volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST1" >> /tmp/output.txt
+fi
+
+TEST2=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST2" == "$FIRST_VOLUME" ]; then
+  printf "2:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "2:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST2" >> /tmp/output.txt
+fi
+
+TEST3=$(sudo rexray volume ls $FIRST_VOLUME --format=json | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST3" == "$FIRST_VOLUME" ]; then
+  printf "3:rexray volume ls json:PASS\n" >> /tmp/output.txt
+else
+  printf "3:rexray volume ls json:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST3" >> /tmp/output.txt
+fi
+
+TEST4=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST4" == "$FIRST_VOLUME" ]; then
+  printf "4:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "4:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST4" >> /tmp/output.txt
+fi
+
+TEST5=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST5" == "attached" ]; then
+  printf "5:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "5:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST5" >> /tmp/output.txt
+fi
+
+TEST6=$(sudo rexray volume mount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $5}')
+if [ "$TEST6" == "/var/lib/libstorage/volumes/$FIRST_VOLUME/data" ]; then
+  printf "6:rexray volume mount:PASS\n" >> /tmp/output.txt
+else
+  printf "6:rexray volume mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST6" >> /tmp/output.txt
+fi
+
+TEST7=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].attachments[0].instanceID.driver' | sed -e 's|["'\'']||g')
+if [ "$TEST7" == "ebs" ]; then
+  printf "7:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "7:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST7" >> /tmp/output.txt
+fi
+
+TEST8=$(sudo rexray volume unmount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST8" == "$FIRST_VOLUME" ]; then
+  printf "8:rexray volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "8:rexray volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST8" >> /tmp/output.txt
+fi
+
+TEST9=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST9" == "attached" ]; then
+  printf "9:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "9:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST9" >> /tmp/output.txt
+fi
+
+TEST10=$(sudo rexray volume detach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST10" == "available" ]; then
+  printf "10:rexray volume detach:PASS\n" >> /tmp/output.txt
+else
+  printf "10:rexray volume detach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST10" >> /tmp/output.txt
+fi
+
+TEST11=$(sudo rexray volume rm $FIRST_VOLUME)
+if [ "$TEST11" == "$FIRST_VOLUME" ]; then
+  printf "11:rexray volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "11:rexray volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST11" >> /tmp/output.txt
+fi
+
+for i in `seq 1 10`;
+do
+  TEST12=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+  if [ "$TEST12" == "" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ "$TEST12" == "" ]; then
+  printf "12:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "12:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST12" >> /tmp/output.txt
+fi
+
+TEST13=$(sudo docker volume create --driver rexray --name $SECOND_VOLUME --opt size=16)
+if [ "$TEST13" == "$SECOND_VOLUME" ]; then
+  printf "13:docker volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "13:docker volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST13" >> /tmp/output.txt
+fi
+
+TEST14=$(sudo docker run -d --volume-driver=rexray -v $SECOND_VOLUME:/tmp dvonthenen/demo-boot)
+if [ "$TEST14" != "" ]; then
+  printf "14:docker run mount:PASS\n" >> /tmp/output.txt
+else
+  printf "14:docker run mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST14" >> /tmp/output.txt
+fi
+
+TEST15=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST15" == "/var/lib/libstorage/volumes/$SECOND_VOLUME/data" ]; then
+  printf "15:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "15:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST15" >> /tmp/output.txt
+fi
+
+TEST16=$(sudo docker ps | grep 'dvonthenen/demo-boot' | awk '{print $1}' | xargs sudo docker stop)
+if [ "$TEST16" != "" ]; then
+  printf "16:docker volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "16:docker volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST16" >> /tmp/output.txt
+fi
+
+# Stopping here... even though we stopped the container, the volume is still
+# actually attached until the stopped instanced is deleted. Will let node 2
+# test preemption. Note that you CANNOT rerun these tests without deleting and
+# recreating the environment.
+
+echo "finished" > /tmp/finished.txt

--- a/drivers/storage/ebs/tests/tests2a.sh
+++ b/drivers/storage/ebs/tests/tests2a.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+
+# This script builds REX-Ray and then runs tests
+
+DEBUG=false
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$2}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  CF_STACK_NAME="default"
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+
+FIRST_VOLUME=$CF_STACK_NAME"_2a"
+SECOND_VOLUME=$CF_STACK_NAME"_2b"
+
+# Clean Up the Env
+sudo rm -f /tmp/output.txt
+sudo rm -f /tmp/finished.txt
+sudo mkdir -p /usr/bin
+sudo mkdir -p /etc/rexray
+
+if [ -f $GIT_COMMIT_ID ]; then
+  echo "Using pre-built REX-Ray"
+
+  sudo cp -f $GIT_COMMIT_ID /usr/bin
+else
+  echo "Building REX-Ray"
+  echo "Building using libstorage commit: $GIT_COMMIT_ID"
+
+  # Build REX-Ray
+  rm -rf $HOME/.glide
+  mkdir -p $HOME/go/src/github.com/codedellemc
+  cd $HOME/go/src/github.com/codedellemc
+  git clone https://github.com/codedellemc/libstorage.git
+  git clone https://github.com/codedellemc/rexray.git
+  cd $HOME/go/src/github.com/codedellemc/rexray
+  sed -e "s/.*# libstorage-version/    ref:     $GIT_COMMIT_ID/g" -i glide.yaml
+  sed -e $"s|.*# libstorage-repo|    repo:    file://$HOME/go/src/github.com/codedellemc/libstorage\n    vcs:     git|g" -i glide.yaml
+  rm -f glide.lock
+  make deps
+  make -j build-libstorage
+  make build
+
+  # Install REX-Ray
+  sudo cp -f $HOME/go/bin/rexray /usr/bin
+fi
+
+sudo cp -f /tmp/config.yml /etc/rexray
+sudo /usr/bin/rexray install
+sudo service rexray restart
+
+sleep 5
+
+# Run the tests....
+TEST1=$(sudo rexray volume create $FIRST_VOLUME --size 16 | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST1" == "$FIRST_VOLUME" ]; then
+  printf "1:rexray volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "1:rexray volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST1" >> /tmp/output.txt
+fi
+
+TEST2=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST2" == "$FIRST_VOLUME" ]; then
+  printf "2:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "2:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST2" >> /tmp/output.txt
+fi
+
+TEST3=$(sudo rexray volume ls $FIRST_VOLUME --format=json | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST3" == "$FIRST_VOLUME" ]; then
+  printf "3:rexray volume ls json:PASS\n" >> /tmp/output.txt
+else
+  printf "3:rexray volume ls json:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST3" >> /tmp/output.txt
+fi
+
+TEST4=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST4" == "$FIRST_VOLUME" ]; then
+  printf "4:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "4:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST4" >> /tmp/output.txt
+fi
+
+TEST5=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST5" == "attached" ]; then
+  printf "5:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "5:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST5" >> /tmp/output.txt
+fi
+
+TEST6=$(sudo rexray volume mount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $5}')
+if [ "$TEST6" == "/var/lib/libstorage/volumes/$FIRST_VOLUME/data" ]; then
+  printf "6:rexray volume mount:PASS\n" >> /tmp/output.txt
+else
+  printf "6:rexray volume mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST6" >> /tmp/output.txt
+fi
+
+TEST7=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].attachments[0].instanceID.driver' | sed -e 's|["'\'']||g')
+if [ "$TEST7" == "ebs" ]; then
+  printf "7:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "7:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST7" >> /tmp/output.txt
+fi
+
+TEST8=$(sudo rexray volume unmount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST8" == "$FIRST_VOLUME" ]; then
+  printf "8:rexray volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "8:rexray volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST8" >> /tmp/output.txt
+fi
+
+TEST9=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST9" == "attached" ]; then
+  printf "9:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "9:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST9" >> /tmp/output.txt
+fi
+
+TEST10=$(sudo rexray volume detach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST10" == "available" ]; then
+  printf "10:rexray volume detach:PASS\n" >> /tmp/output.txt
+else
+  printf "10:rexray volume detach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST10" >> /tmp/output.txt
+fi
+
+TEST11=$(sudo rexray volume rm $FIRST_VOLUME)
+if [ "$TEST11" == "$FIRST_VOLUME" ]; then
+  printf "11:rexray volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "11:rexray volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST11" >> /tmp/output.txt
+fi
+
+for i in `seq 1 10`;
+do
+  TEST12=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+  if [ "$TEST12" == "" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ "$TEST12" == "" ]; then
+  printf "12:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "12:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST12" >> /tmp/output.txt
+fi
+
+TEST13=$(sudo docker volume create --driver rexray --name $SECOND_VOLUME --opt size=16)
+if [ "$TEST13" == "$SECOND_VOLUME" ]; then
+  printf "13:docker volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "13:docker volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST13" >> /tmp/output.txt
+fi
+
+TEST14=$(sudo docker run -d --volume-driver=rexray -v $SECOND_VOLUME:/tmp dvonthenen/demo-boot)
+if [ "$TEST14" != "" ]; then
+  printf "14:docker run mount:PASS\n" >> /tmp/output.txt
+else
+  printf "14:docker run mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST14" >> /tmp/output.txt
+fi
+
+TEST15=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST15" == "/var/lib/libstorage/volumes/$SECOND_VOLUME/data" ]; then
+  printf "15:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "15:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST15" >> /tmp/output.txt
+fi
+
+TEST16=$(sudo docker ps | grep 'dvonthenen/demo-boot' | awk '{print $1}' | xargs sudo docker stop)
+if [ "$TEST16" != "" ]; then
+  printf "16:docker volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "16:docker volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST16" >> /tmp/output.txt
+fi
+
+TEST17=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST17" == "/" ]; then
+  printf "17:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "17:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST17" >> /tmp/output.txt
+fi
+
+#Remove old docker Instances
+sudo docker rm $(sudo docker ps -a | grep Exited | awk '{print $1}')
+
+TEST18=$(sudo docker volume rm $SECOND_VOLUME)
+if [ "$TEST18" == "$SECOND_VOLUME" ]; then
+  printf "18:docker volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "18:docker volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST18" >> /tmp/output.txt
+fi
+
+for i in `seq 1 10`;
+do
+  TEST19=$(sudo docker volume ls | grep "$SECOND_VOLUME" | awk '{print $2}')
+  if [ "$TEST19" == "" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ "$TEST19" == "" ]; then
+  printf "19:docker volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "19:docker volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST19" >> /tmp/output.txt
+fi
+
+# Do not print finished to the /tmp/finished.txt file because we need
+# to execute a second script on this node to handle preemption.

--- a/drivers/storage/ebs/tests/tests2b.sh
+++ b/drivers/storage/ebs/tests/tests2b.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# This script builds REX-Ray and then runs tests
+
+DEBUG=false
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$2}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  CF_STACK_NAME="default"
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+
+PREEMPT_VOLUME=$CF_STACK_NAME"_1b"
+
+# Run the tests....
+TEST20=$(sudo docker run -d --volume-driver=rexray -v $PREEMPT_VOLUME:/tmp dvonthenen/demo-boot)
+if [ "$TEST20" != "" ]; then
+  printf "20:docker run mount preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "20:docker run mount preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST20" >> /tmp/output.txt
+fi
+
+TEST21=$(sudo docker volume inspect $PREEMPT_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST21" == "/var/lib/libstorage/volumes/$PREEMPT_VOLUME/data" ]; then
+  printf "21:docker volume inspect preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "21:docker volume inspect preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST21" >> /tmp/output.txt
+fi
+
+TEST22=$(sudo docker ps | grep 'dvonthenen/demo-boot' | awk '{print $1}' | xargs sudo docker stop)
+if [ "$TEST22" != "" ]; then
+  printf "22:docker volume unmount preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "22:docker volume unmount preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST22" >> /tmp/output.txt
+fi
+
+TEST23=$(sudo docker volume inspect $PREEMPT_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST23" == "/" ]; then
+  printf "23:docker volume inspect preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "23:docker volume inspect preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST23" >> /tmp/output.txt
+fi
+
+#Remove old docker Instances
+sudo docker rm $(sudo docker ps -a | grep Exited | awk '{print $1}')
+
+TEST24=$(sudo docker volume rm $PREEMPT_VOLUME)
+if [ "$TEST24" == "$PREEMPT_VOLUME" ]; then
+  printf "24:docker volume rm preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "24:docker volume rm preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST24" >> /tmp/output.txt
+fi
+
+for i in `seq 1 10`;
+do
+  TEST25=$(sudo docker volume ls | grep "$PREEMPT_VOLUME" | awk '{print $2}')
+  if [ "$TEST25" == "" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ "$TEST25" == "" ]; then
+  printf "25:docker volume ls preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "25:docker volume ls preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST25" >> /tmp/output.txt
+fi
+
+echo "finished" > /tmp/finished.txt

--- a/drivers/storage/ebs/tests/tests3.sh
+++ b/drivers/storage/ebs/tests/tests3.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+
+# This script builds REX-Ray and then runs tests
+
+DEBUG=false
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$2}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  CF_STACK_NAME="default"
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+
+FIRST_VOLUME=$CF_STACK_NAME"_3a"
+SECOND_VOLUME=$CF_STACK_NAME"_3b"
+
+# Clean Up the Env
+sudo rm -f /tmp/output.txt
+sudo rm -f /tmp/finished.txt
+sudo mkdir -p /usr/bin
+sudo mkdir -p /etc/rexray
+
+if [ -f $GIT_COMMIT_ID ]; then
+  echo "Using pre-built REX-Ray"
+
+  sudo cp -f $GIT_COMMIT_ID /usr/bin
+else
+  echo "Building REX-Ray"
+  echo "Building using libstorage commit: $GIT_COMMIT_ID"
+
+  # Build REX-Ray
+  rm -rf $HOME/.glide
+  mkdir -p $HOME/go/src/github.com/codedellemc
+  cd $HOME/go/src/github.com/codedellemc
+  git clone https://github.com/codedellemc/libstorage.git
+  git clone https://github.com/codedellemc/rexray.git
+  cd $HOME/go/src/github.com/codedellemc/rexray
+  sed -e "s/.*# libstorage-version/    ref:     $GIT_COMMIT_ID/g" -i glide.yaml
+  sed -e $"s|.*# libstorage-repo|    repo:    file://$HOME/go/src/github.com/codedellemc/libstorage\n    vcs:     git|g" -i glide.yaml
+  rm -f glide.lock
+  make deps
+  make -j build-libstorage
+  make build
+
+  # Install REX-Ray
+  sudo cp -f $HOME/go/bin/rexray /usr/bin
+fi
+
+sudo cp -f /tmp/config.yml /etc/rexray
+sudo /usr/bin/rexray install
+sudo service rexray restart
+
+sleep 5
+
+# Run the tests....
+TEST1=$(sudo rexray volume create $FIRST_VOLUME --size 16 | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST1" == "$FIRST_VOLUME" ]; then
+  printf "1:rexray volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "1:rexray volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST1" >> /tmp/output.txt
+fi
+
+TEST2=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST2" == "$FIRST_VOLUME" ]; then
+  printf "2:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "2:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST2" >> /tmp/output.txt
+fi
+
+TEST3=$(sudo rexray volume ls $FIRST_VOLUME --format=json | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST3" == "$FIRST_VOLUME" ]; then
+  printf "3:rexray volume ls json:PASS\n" >> /tmp/output.txt
+else
+  printf "3:rexray volume ls json:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST3" >> /tmp/output.txt
+fi
+
+TEST4=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST4" == "$FIRST_VOLUME" ]; then
+  printf "4:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "4:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST4" >> /tmp/output.txt
+fi
+
+TEST5=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST5" == "attached" ]; then
+  printf "5:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "5:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST5" >> /tmp/output.txt
+fi
+
+TEST6=$(sudo rexray volume mount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $5}')
+if [ "$TEST6" == "/var/lib/libstorage/volumes/$FIRST_VOLUME/data" ]; then
+  printf "6:rexray volume mount:PASS\n" >> /tmp/output.txt
+else
+  printf "6:rexray volume mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST6" >> /tmp/output.txt
+fi
+
+TEST7=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].attachments[0].instanceID.driver' | sed -e 's|["'\'']||g')
+if [ "$TEST7" == "ebs" ]; then
+  printf "7:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "7:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST7" >> /tmp/output.txt
+fi
+
+TEST8=$(sudo rexray volume unmount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST8" == "$FIRST_VOLUME" ]; then
+  printf "8:rexray volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "8:rexray volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST8" >> /tmp/output.txt
+fi
+
+TEST9=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST9" == "attached" ]; then
+  printf "9:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "9:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST9" >> /tmp/output.txt
+fi
+
+TEST10=$(sudo rexray volume detach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST10" == "available" ]; then
+  printf "10:rexray volume detach:PASS\n" >> /tmp/output.txt
+else
+  printf "10:rexray volume detach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST10" >> /tmp/output.txt
+fi
+
+TEST11=$(sudo rexray volume rm $FIRST_VOLUME)
+if [ "$TEST11" == "$FIRST_VOLUME" ]; then
+  printf "11:rexray volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "11:rexray volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST11" >> /tmp/output.txt
+fi
+
+for i in `seq 1 10`;
+do
+  TEST12=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+  if [ "$TEST12" == "" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ "$TEST12" == "" ]; then
+  printf "12:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "12:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST12" >> /tmp/output.txt
+fi
+
+TEST13=$(sudo docker volume create --driver rexray --name $SECOND_VOLUME --opt size=16)
+if [ "$TEST13" == "$SECOND_VOLUME" ]; then
+  printf "13:docker volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "13:docker volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST13" >> /tmp/output.txt
+fi
+
+TEST14=$(sudo docker run -d --volume-driver=rexray -v $SECOND_VOLUME:/tmp dvonthenen/demo-boot)
+if [ "$TEST14" != "" ]; then
+  printf "14:docker run mount:PASS\n" >> /tmp/output.txt
+else
+  printf "14:docker run mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST14" >> /tmp/output.txt
+fi
+
+TEST15=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST15" == "/var/lib/libstorage/volumes/$SECOND_VOLUME/data" ]; then
+  printf "15:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "15:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST15" >> /tmp/output.txt
+fi
+
+TEST16=$(sudo docker ps | grep 'dvonthenen/demo-boot' | awk '{print $1}' | xargs sudo docker stop)
+if [ "$TEST16" != "" ]; then
+  printf "16:docker volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "16:docker volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST16" >> /tmp/output.txt
+fi
+
+TEST17=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST17" == "/" ]; then
+  printf "17:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "17:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST17" >> /tmp/output.txt
+fi
+
+#Remove old docker Instances
+sudo docker rm $(sudo docker ps -a | grep Exited | awk '{print $1}')
+
+TEST18=$(sudo docker volume rm $SECOND_VOLUME)
+if [ "$TEST18" == "$SECOND_VOLUME" ]; then
+  printf "18:docker volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "18:docker volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST18" >> /tmp/output.txt
+fi
+
+for i in `seq 1 10`;
+do
+  TEST19=$(sudo docker volume ls | grep "$SECOND_VOLUME" | awk '{print $2}')
+  if [ "$TEST19" == "" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ "$TEST19" == "" ]; then
+  printf "19:docker volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "19:docker volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST19" >> /tmp/output.txt
+fi
+
+echo "finished" > /tmp/finished.txt

--- a/drivers/storage/scaleio/tests/README.md
+++ b/drivers/storage/scaleio/tests/README.md
@@ -1,0 +1,31 @@
+# ScaleIO driver testing
+
+ScaleIO driver requires valid AWS environment in which tests can run. The
+requirements are:
+
+* **VPC**: Private network where EC2 instance and ScaleIO instance can be launched
+
+* **Subnet**: In VPC it requires at least one valid Subnet for EC2 instance and
+  ScaleIO
+
+* **EC2**: Any EC2 instance that has permission to run ScaleIO plugin. For list of
+  IAM permissions see user documentation.
+
+For automated testing there are couple script available that will spin up
+while AWS environment by using CloudFormation service.
+
+* `./test-env-up.sh [access-key] [secret-key] [stack-name] [key-name]` -
+  should be used to launch whole AWS environment required for ScaleIO storage
+  driver testing.
+  `[access-key]: AWS access key`
+  `[secret-key]: AWS secret key`
+  `[stack-name]: AWS stack name that must be uniquely identifiable`
+  `[key-name]: AWS key that will be used to launch EC2 instance`
+
+* `./test-run.sh [stack-name] [rexray-path]` - to run the tests on EC2 instance.
+  `[stack-name]` is the same name used in the setup process.
+  `[git-commit]` Git Commit ID. Default: master
+
+* `./test-env-down.sh [stack-name]` - to tear down AWS environment infrastructure
+  and clean up all resources.
+  `[stack-name]` is the same name used in the setup and testing process.

--- a/drivers/storage/scaleio/tests/config.yml
+++ b/drivers/storage/scaleio/tests/config.yml
@@ -1,0 +1,24 @@
+rexray:
+  logLevel: warn
+  modules:
+    rexray:
+      type: docker
+      libstorage:
+        service: scaleio
+      host: unix:///run/docker/plugins/rexray.sock
+libstorage:
+  service: scaleio
+  integration:
+    volume:
+      operations:
+        mount:
+          preempt: true
+scaleio:
+  endpoint: https://10.0.0.11/api
+  insecure: true
+  thinOrThick: ThinProvisioned
+  userName: admin
+  password: F00barbaz
+  systemId: 6f831c6866417634
+  protectionDomainName: default
+  storagePoolName: default

--- a/drivers/storage/scaleio/tests/offline-tests.sh
+++ b/drivers/storage/scaleio/tests/offline-tests.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# This script runs tests
+
+AWS_ACCESSKEY=${AWS_ACCESSKEY:-$1}
+AWS_SECRETKEY=${AWS_SECRETKEY:-$2}
+CF_STACK_NAME=${CF_STACK_NAME:-$3}
+LAUNCH_KEY_NAME=${LAUNCH_KEY_NAME:-$4}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$5}
+
+usage() {
+  echo "Usage: ${0} access-key secret-key stack-name launch-key-name"
+  echo ""
+  echo "   access-key: AWS access key"
+  echo "   secret-key: AWS secret key"
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+  echo "   launch-key-name: AWS key that will be used to launch EC2 instance"
+  echo "   git-commit: Git Commit ID. Default: master"
+}
+
+if [ -z "${AWS_ACCESSKEY}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${AWS_SECRETKEY}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${LAUNCH_KEY_NAME}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+
+./test-env-up.sh $AWS_ACCESSKEY $AWS_SECRETKEY $CF_STACK_NAME $LAUNCH_KEY_NAME
+sleep 5
+./test-run-aws.sh $CF_STACK_NAME $GIT_COMMIT_ID
+./test-env-down.sh $CF_STACK_NAME

--- a/drivers/storage/scaleio/tests/test-cf-template.json
+++ b/drivers/storage/scaleio/tests/test-cf-template.json
@@ -1,0 +1,778 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Metadata": {
+    "AWS::CloudFormation::Designer": {
+      "19117008-4607-4d30-95d7-9e27b231f551": {
+        "size": {
+          "width": 420,
+          "height": 220
+        },
+        "position": {
+          "x": 720,
+          "y": 170
+        },
+        "z": 1,
+        "embeds": [
+          "35c845c6-61b8-422c-be16-f1395a95879f",
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a",
+          "e3f368ef-533b-484c-b3f4-897729901208"
+        ]
+      },
+      "e3f368ef-533b-484c-b3f4-897729901208": {
+        "size": {
+          "width": 290,
+          "height": 100
+        },
+        "position": {
+          "x": 840,
+          "y": 250
+        },
+        "z": 2,
+        "parent": "19117008-4607-4d30-95d7-9e27b231f551",
+        "embeds": [
+          "b2904db7-7420-44e0-9bd7-078c253f58e8",
+          "05dd39d3-73fc-4732-be16-9966f7fa4769",
+          "0b3b1e8b-5559-4a13-bf67-7312d43b361c"
+        ]
+      },
+      "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 960,
+          "y": 100
+        },
+        "z": 0,
+        "parent": "19117008-4607-4d30-95d7-9e27b231f551",
+        "embeds": [],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "c7820c4a-775a-4228-9f22-d7b91120d6c9": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 640,
+          "y": 170
+        },
+        "z": 1,
+        "embeds": []
+      },
+      "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8": {
+        "source": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "target": {
+          "id": "19117008-4607-4d30-95d7-9e27b231f551"
+        },
+        "z": 1
+      },
+      "35c845c6-61b8-422c-be16-f1395a95879f": {
+        "size": {
+          "width": 80,
+          "height": 90
+        },
+        "position": {
+          "x": 750,
+          "y": 180
+        },
+        "z": 2,
+        "parent": "19117008-4607-4d30-95d7-9e27b231f551",
+        "embeds": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ]
+      },
+      "b2904db7-7420-44e0-9bd7-078c253f58e8": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 860,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "fe5557b3-266c-40ef-b6bd-4ad21f7511c5": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 760,
+          "y": 200
+        },
+        "z": 3,
+        "parent": "35c845c6-61b8-422c-be16-f1395a95879f",
+        "embeds": [],
+        "references": [
+          "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        ],
+        "dependson": [
+          "c7820c4a-775a-4228-9f22-d7b91120d6c9",
+          "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8"
+        ]
+      },
+      "da60be23-5de7-4310-8cfc-1cae8042ada7": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "target": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "z": 4
+      },
+      "d3c5f91d-7e10-4ff9-9a86-e4fd05e69747": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "target": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "z": 5
+      },
+      "98f6a038-b5dc-43b9-9901-549f72c5aaf1": {
+        "source": {
+          "id": "b2904db7-7420-44e0-9bd7-078c253f58e8"
+        },
+        "target": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "z": 6
+      },
+      "43aacb25-8175-4890-b26f-066ceac37afe": {
+        "source": {
+          "id": "35c845c6-61b8-422c-be16-f1395a95879f"
+        },
+        "target": {
+          "id": "e3f368ef-533b-484c-b3f4-897729901208"
+        },
+        "z": 2
+      },
+      "05dd39d3-73fc-4732-be16-9966f7fa4769": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 960,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "0b3b1e8b-5559-4a13-bf67-7312d43b361c": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 1050,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "9c4181f8-b640-4266-ab00-e30b2bf26f48": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5",
+          "selector": "g:nth-child(1) g:nth-child(4) g:nth-child(5) circle:nth-child(1)     ",
+          "port": "AWS::DependencyLink-*"
+        },
+        "target": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        },
+        "z": 5
+      },
+      "ec9732a1-755a-45fd-8f95-00f015fdc006": {
+        "source": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        },
+        "target": {
+          "id": "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8"
+        },
+        "z": 4
+      }
+    }
+  },
+  "Resources": {
+    "ScaleIOSubnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "CidrBlock": "10.0.0.0/24"
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "e3f368ef-533b-484c-b3f4-897729901208"
+        }
+      }
+    },
+    "ScaleIOSecGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "GroupDescription": "Allow access from SSH traffic",
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "22",
+            "ToPort": "22",
+            "CidrIp": {
+              "Ref": "SSHLocation"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "ToPort": "443",
+            "CidrIp": {
+              "Ref": "SSHLocation"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
+            "CidrIp": {
+              "Ref": "SSHLocation"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "1",
+            "ToPort": "65535",
+            "CidrIp": "10.0.0.0/24"
+          },
+          {
+            "IpProtocol": "udp",
+            "FromPort": "1",
+            "ToPort": "65535",
+            "CidrIp": "10.0.0.0/24"
+          },
+          {
+            "IpProtocol": "icmp",
+            "FromPort": "-1",
+            "ToPort": "-1",
+            "CidrIp": "10.0.0.0/24"
+          }
+        ]
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        }
+      }
+    },
+    "InternetGateway": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {},
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "c7820c4a-775a-4228-9f22-d7b91120d6c9"
+        }
+      }
+    },
+    "RouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "35c845c6-61b8-422c-be16-f1395a95879f"
+        }
+      }
+    },
+    "PublicRoute": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        },
+        "GatewayId": {
+          "Ref": "InternetGateway"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        }
+      },
+      "DependsOn": [
+        "InternetGateway",
+        "GatewayAttachment"
+      ]
+    },
+    "VPC": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "EnableDnsSupport": "true",
+        "EnableDnsHostnames": "true",
+        "CidrBlock": "10.0.0.0/16"
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "19117008-4607-4d30-95d7-9e27b231f551"
+        }
+      }
+    },
+    "ScaleIONode3": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-66068306",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ScaleIONode3"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.13",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo ScaleIONode3 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "0b3b1e8b-5559-4a13-bf67-7312d43b361c"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "ScaleIONode2": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-19008579",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ScaleIONode2"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.12",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo ScaleIONode2 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "05dd39d3-73fc-4732-be16-9966f7fa4769"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "ScaleIONode1": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-f3058093",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ScaleIONode1"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.11",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo ScaleIONode1 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "b2904db7-7420-44e0-9bd7-078c253f58e8"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "GatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "InternetGatewayId": {
+          "Ref": "InternetGateway"
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "1e18cb0d-7ee5-4790-94f0-2b50519dc1a8"
+        }
+      }
+    },
+    "SubnetAttachment": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "RouteTable"
+        },
+        "SubnetId": {
+          "Ref": "ScaleIOSubnet"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "43aacb25-8175-4890-b26f-066ceac37afe"
+        }
+      }
+    }
+  },
+  "Parameters": {
+    "KeyName": {
+      "Description": "Name of an EC2 KeyPair to enable SSH access to the cluster.",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription": "must be the name of an existing EC2 KeyPair."
+    },
+    "SSHLocation": {
+      "Description": " The IP address range that can be used to access the ScaleIO cluster using SSH.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "0.0.0.0/0",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
+    }
+  },
+  "Mappings": {
+    "AWSInstanceType2Arch": {
+      "t2.medium": {
+        "Arch": "HVM64"
+      }
+    },
+    "AWSRegionArch2AMI": {
+      "us-west-1": {
+        "PV64": "ami-d514f291",
+        "HVM64": "ami-d114f295",
+        "HVMG2": "ami-f31ffeb7"
+      }
+    }
+  },
+  "Outputs": {
+    "URL": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "http://",
+            {
+              "Fn::GetAtt": [
+                "ScaleIONode1",
+                "PublicIp"
+              ]
+            }
+          ]
+        ]
+      },
+      "Description": "Cluster Management URL"
+    }
+  }
+}

--- a/drivers/storage/scaleio/tests/test-env-down.sh
+++ b/drivers/storage/scaleio/tests/test-env-down.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# This script cleans up the infrastructure used for tests
+
+#set -e
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y curl
+  else
+    sudo brew install curl
+  fi
+}
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  sudo /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y jq
+  else
+    sudo brew install jq
+  fi
+}
+
+usage() {
+  echo "Usage: ${0} stack-name"
+  echo ""
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+
+# Get stack ID
+CF_STACK_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${CF_STACK_NAME} \
+  --output text \
+  --query 'Stacks[0].StackId')
+
+# Delete cloud formation stack
+aws cloudformation delete-stack \
+  --stack-name ${CF_STACK_NAME}
+
+echo "Waiting for CF stack to get deleted ..."
+
+aws cloudformation wait stack-delete-complete \
+  --stack-name ${CF_STACK_ID}
+
+rm -f ~/.aws/config
+rm -f ~/.aws/credentials
+rm -f ./keyfile
+rm -f ./output*.txt
+
+echo "Stack has been deleted"

--- a/drivers/storage/scaleio/tests/test-env-up.sh
+++ b/drivers/storage/scaleio/tests/test-env-up.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# This script launches infrastructure required for testing the ScaleIO storage driver.
+# It spins up VPC and EC2 instance so AWS account owner will get charged for time
+# that resources will be running.
+
+#set -e
+
+AWS_ACCESSKEY=${AWS_ACCESSKEY:-$1}
+AWS_SECRETKEY=${AWS_SECRETKEY:-$2}
+CF_STACK_NAME=${CF_STACK_NAME:-$3}
+LAUNCH_KEY_NAME=${LAUNCH_KEY_NAME:-$4}
+
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y curl
+  else
+    sudo brew install curl
+  fi
+}
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  sudo /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y jq
+  else
+    sudo brew install jq
+  fi
+}
+
+usage() {
+  echo "Usage: ${0} access-key secret-key stack-name launch-key-name"
+  echo ""
+  echo "   access-key: AWS access key"
+  echo "   secret-key: AWS secret key"
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+  echo "   launch-key-name: AWS key that will be used to launch EC2 instance."
+  echo "                    The ssh key must be of the same filename in ~/.ssh"
+}
+
+template_path() {
+  echo "$(dirname $0)/test-cf-template.json"
+}
+
+if [ -z "${AWS_ACCESSKEY}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${AWS_SECRETKEY}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${LAUNCH_KEY_NAME}" ]; then
+  usage
+  exit 1
+fi
+rm -f ./keyfile
+if [ -f ~/.ssh/${LAUNCH_KEY_NAME} ]; then
+  echo ${LAUNCH_KEY_NAME} > ./keyfile
+elif [ -f ~/.ssh/${LAUNCH_KEY_NAME}.pem ]; then
+  echo ${LAUNCH_KEY_NAME}.pem > ./keyfile
+else
+  usage
+  exit 1
+fi
+
+aws configure set aws_access_key_id ${AWS_ACCESSKEY}
+aws configure set aws_secret_access_key ${AWS_SECRETKEY}
+aws configure set default.region us-west-2
+
+# Launch CF stack
+aws cloudformation create-stack \
+  --stack-name ${CF_STACK_NAME} \
+  --template-body file://$(template_path) \
+  --parameter ParameterKey=KeyName,ParameterValue=${LAUNCH_KEY_NAME} \
+  --capabilities CAPABILITY_IAM 1>/dev/null
+
+echo "Environment launch started. It will take couple minutes to create whole environment..."

--- a/drivers/storage/scaleio/tests/test-run-aws.sh
+++ b/drivers/storage/scaleio/tests/test-run-aws.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+# This script runs tests
+
+# set -e
+
+: ${CF_EC2_USER:="ec2-user"}
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$2}
+
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y curl
+  else
+    sudo brew install curl
+  fi
+}
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  sudo /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y jq
+  else
+    sudo brew install jq
+  fi
+}
+
+usage() {
+  echo "Usage: ${0} stack-name git-commit"
+  echo ""
+  echo "   stack-name: AWS stack name. Must be uniquely identifiable"
+  echo "   git-commit: Git Commit ID. Default: master"
+}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+
+echo "Waiting for CF stack to come up ..."
+
+aws cloudformation wait stack-create-complete \
+  --stack-name ${CF_STACK_NAME}
+
+# Get IP address of EC2 machine where tests can be executed
+SCALEIO_NODE1=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="ScaleIONode1")' | jq -r .PhysicalResourceId)
+SCALEIO_NODE2=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="ScaleIONode2")' | jq -r .PhysicalResourceId)
+SCALEIO_NODE3=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="ScaleIONode3")' | jq -r .PhysicalResourceId)
+#echo ${SCALEIO_NODE1}
+#echo ${SCALEIO_NODE2}
+#echo ${SCALEIO_NODE3}
+
+SCALEIO_NODE1_FQDN=$(aws ec2 describe-instances --instance-ids ${SCALEIO_NODE1} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+SCALEIO_NODE2_FQDN=$(aws ec2 describe-instances --instance-ids ${SCALEIO_NODE2} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+SCALEIO_NODE3_FQDN=$(aws ec2 describe-instances --instance-ids ${SCALEIO_NODE3} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#echo ${SCALEIO_NODE1_FQDN}
+#echo ${SCALEIO_NODE2_FQDN}
+#echo ${SCALEIO_NODE3_FQDN}
+
+ssh-keyscan -H ${SCALEIO_NODE1_FQDN} >> ~/.ssh/known_hosts
+ssh-keyscan -H ${SCALEIO_NODE2_FQDN} >> ~/.ssh/known_hosts
+ssh-keyscan -H ${SCALEIO_NODE3_FQDN} >> ~/.ssh/known_hosts
+
+rm -f $(dirname $0)/output1.txt
+rm -f $(dirname $0)/output2.txt
+rm -f $(dirname $0)/output3.txt
+
+# wait for scaleio-gateway to be running
+READY1=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE1_FQDN "service scaleio-gateway status 2>&1 | grep running")
+while [ "$READY1" != "" ];
+do
+  sleep 1
+  READY1=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE1_FQDN "service scaleio-gateway status 2>&1 | grep running")
+done
+READY2=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE2_FQDN "service scaleio-gateway status 2>&1 | grep running")
+while [ "$READY2" != "" ];
+do
+  sleep 1
+  READY2=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE2_FQDN "service scaleio-gateway status 2>&1 | grep running")
+done
+READY3=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE3_FQDN "service scaleio-gateway status 2>&1 | grep running")
+while [ "$READY3" != "" ];
+do
+  sleep 1
+  READY3=$(ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE3_FQDN "service scaleio-gateway status 2>&1 | grep running")
+done
+
+# ssh key to use
+SSH_KEY_FILE=$(cat ./keyfile)
+
+# Copy REX-Ray build to EC2 instance
+scp -i ~/.ssh/${SSH_KEY_FILE} ./config.yml $CF_EC2_USER@$SCALEIO_NODE1_FQDN:/tmp
+scp -i ~/.ssh/${SSH_KEY_FILE} ./tests1.sh $CF_EC2_USER@$SCALEIO_NODE1_FQDN:/tmp
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE1_FQDN "sudo chmod +x /tmp/tests1.sh"
+if [ -f $GIT_COMMIT_ID ]; then
+  scp -i ~/.ssh/${SSH_KEY_FILE} $GIT_COMMIT_ID $CF_EC2_USER@$SCALEIO_NODE1_FQDN:/tmp
+  ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE1_FQDN "sudo chmod +x /tmp/rexray"
+fi
+
+scp -i ~/.ssh/${SSH_KEY_FILE} ./config.yml $CF_EC2_USER@$SCALEIO_NODE2_FQDN:/tmp
+scp -i ~/.ssh/${SSH_KEY_FILE} ./tests2a.sh $CF_EC2_USER@$SCALEIO_NODE2_FQDN:/tmp
+scp -i ~/.ssh/${SSH_KEY_FILE} ./tests2b.sh $CF_EC2_USER@$SCALEIO_NODE2_FQDN:/tmp
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE2_FQDN "sudo chmod +x /tmp/tests2a.sh"
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE2_FQDN "sudo chmod +x /tmp/tests2b.sh"
+if [ -f $GIT_COMMIT_ID ]; then
+  scp -i ~/.ssh/${SSH_KEY_FILE} $GIT_COMMIT_ID $CF_EC2_USER@$SCALEIO_NODE2_FQDN:/tmp
+  ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE2_FQDN "sudo chmod +x /tmp/rexray"
+fi
+
+scp -i ~/.ssh/${SSH_KEY_FILE} ./config.yml $CF_EC2_USER@$SCALEIO_NODE3_FQDN:/tmp
+scp -i ~/.ssh/${SSH_KEY_FILE} ./tests3.sh $CF_EC2_USER@$SCALEIO_NODE3_FQDN:/tmp
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE3_FQDN "sudo chmod +x /tmp/tests3.sh"
+if [ -f $GIT_COMMIT_ID ]; then
+  scp -i ~/.ssh/${SSH_KEY_FILE} $GIT_COMMIT_ID $CF_EC2_USER@$SCALEIO_NODE3_FQDN:/tmp
+  ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE3_FQDN "sudo chmod +x /tmp/rexray"
+fi
+
+if [ -f $GIT_COMMIT_ID ]; then
+  GIT_COMMIT_ID="/tmp/rexray"
+fi
+
+echo "Executing Tests!"
+
+# Run tests... note the use of "bash --login -c". this forces a load of the user's
+# env variables while cause the make command to fail.
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE1_FQDN "bash --login -c '/tmp/tests1.sh $CF_STACK_NAME $GIT_COMMIT_ID' 2>&1"
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE2_FQDN "bash --login -c '/tmp/tests2a.sh $CF_STACK_NAME $GIT_COMMIT_ID' 2>&1"
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE2_FQDN "bash --login -c '/tmp/tests2b.sh $CF_STACK_NAME $GIT_COMMIT_ID' 2>&1"
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE3_FQDN "bash --login -c '/tmp/tests3.sh $CF_STACK_NAME $GIT_COMMIT_ID' 2>&1"
+
+# Copy test coverage results
+scp -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE1_FQDN:/tmp/output.txt $(dirname $0)/output1.txt
+scp -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE2_FQDN:/tmp/output.txt $(dirname $0)/output2.txt
+scp -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE3_FQDN:/tmp/output.txt $(dirname $0)/output3.txt
+
+echo "Tests passed and coverge results are available in the output files"
+echo "Node 1 Results"
+cat $(dirname $0)/output1.txt
+echo " "
+echo "Node 2 Results"
+cat $(dirname $0)/output2.txt
+echo " "
+echo "Node 3 Results"
+cat $(dirname $0)/output3.txt

--- a/drivers/storage/scaleio/tests/test-run-metal.sh
+++ b/drivers/storage/scaleio/tests/test-run-metal.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+# This script runs tests
+
+# set -e
+# set -x
+
+: ${LINUX_USER:="rexray"}
+
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$1}
+NODE1_FQDN=${NODE1_FQDN:-$2}
+NODE2_FQDN=${NODE2_FQDN:-$3}
+NODE3_FQDN=${NODE3_FQDN:-$4}
+#NODE4_FQDN=${NODE4_FQDN:-$5}
+
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    sudo yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    sudo apt-get install -y jq
+  else
+    sudo brew install jq
+  fi
+}
+
+usage() {
+  echo "Usage: ${0} git-commit node1_fqdn node2_fqdn node3_fqdn, node4_fqdn"
+  echo ""
+  echo "   git-commit: Git Commit ID. Default: master"
+}
+
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+if [ -z "${NODE1_FQDN}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${NODE2_FQDN}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${NODE3_FQDN}" ]; then
+  usage
+  exit 1
+fi
+#if [ -z "${NODE4_FQDN}" ]; then
+#  usage
+#  exit 1
+#fi
+
+ssh-keyscan -H ${NODE1_FQDN} >> ~/.ssh/known_hosts
+ssh-keyscan -H ${NODE2_FQDN} >> ~/.ssh/known_hosts
+ssh-keyscan -H ${NODE3_FQDN} >> ~/.ssh/known_hosts
+#ssh-keyscan -H ${NODE4_FQDN} >> ~/.ssh/known_hosts
+
+rm -f $(dirname $0)/output1.txt
+rm -f $(dirname $0)/output2.txt
+rm -f $(dirname $0)/output3.txt
+#rm -f $(dirname $0)/output4.txt
+
+# Copy REX-Ray build to EC2 instance
+scp ./config.yml $LINUX_USER@$NODE1_FQDN:/tmp
+scp ./tests1.sh $LINUX_USER@$NODE1_FQDN:/tmp
+ssh $LINUX_USER@$NODE1_FQDN "sudo chmod +x /tmp/tests1.sh"
+
+scp ./config.yml $LINUX_USER@$NODE2_FQDN:/tmp
+scp ./tests2a.sh $LINUX_USER@$NODE2_FQDN:/tmp
+scp ./tests2b.sh $LINUX_USER@$NODE2_FQDN:/tmp
+ssh $LINUX_USER@$NODE2_FQDN "sudo chmod +x /tmp/tests2a.sh"
+ssh $LINUX_USER@$NODE2_FQDN "sudo chmod +x /tmp/tests2b.sh"
+
+scp ./config.yml $LINUX_USER@$NODE3_FQDN:/tmp
+scp ./tests3.sh $LINUX_USER@$NODE3_FQDN:/tmp
+ssh $LINUX_USER@$NODE3_FQDN "sudo chmod +x /tmp/tests3.sh"
+
+#scp ./config.yml $LINUX_USER@$NODE4_FQDN:/tmp
+#scp ./tests4.sh $LINUX_USER@$NODE4_FQDN:/tmp
+#ssh $LINUX_USER@$NODE4_FQDN "sudo chmod +x /tmp/tests4.sh"
+
+echo "Executing Tests!"
+
+# Run tests... note the use of "bash --login -c". this forces a load of the user's
+# env variables while cause the make command to fail.
+ssh $LINUX_USER@$NODE1_FQDN "bash --login -c '/tmp/tests1.sh $GIT_COMMIT_ID' 2>&1" &
+ssh $LINUX_USER@$NODE2_FQDN "bash --login -c '/tmp/tests2a.sh $GIT_COMMIT_ID' 2>&1" &
+ssh $LINUX_USER@$NODE3_FQDN "bash --login -c '/tmp/tests3.sh $GIT_COMMIT_ID' 2>&1" &
+#ssh $LINUX_USER@$NODE4_FQDN "bash --login -c '/tmp/tests4.sh $GIT_COMMIT_ID' 2>&1" &
+
+FINISHED1=$(ssh $LINUX_USER@$NODE1_FQDN "cat /tmp/finished.txt 2>&1")
+while [ "$FINISHED1" != "finished" ];
+do
+  sleep 1
+  FINISHED1=$(ssh $LINUX_USER@$NODE1_FQDN "cat /tmp/finished.txt 2>&1")
+done
+
+# execute the preemption portion of the script... note that node 1 and node 3
+# should finish before node 2. see comment below.
+ssh $LINUX_USER@$NODE2_FQDN "bash --login -c '/tmp/tests2b.sh $GIT_COMMIT_ID' 2>&1" &
+
+FINISHED3=$(ssh $LINUX_USER@$NODE3_FQDN "cat /tmp/finished.txt 2>&1")
+while [ "$FINISHED3" != "finished" ];
+do
+  sleep 1
+  FINISHED3=$(ssh $LINUX_USER@$NODE3_FQDN "cat /tmp/finished.txt 2>&1")
+done
+
+#FINISHED4=$(ssh $LINUX_USER@$NODE4_FQDN "cat /tmp/finished.txt 2>&1")
+#while [ "$FINISHED4" != "finished" ];
+#do
+#  sleep 1
+#  FINISHED4=$(ssh $LINUX_USER@$NODE4_FQDN "cat /tmp/finished.txt 2>&1")
+#done
+
+# this node should finish last because of the preemption test. hence this order
+# (Node 1, 3, 2) for checking for finished
+FINISHED2=$(ssh $LINUX_USER@$NODE2_FQDN "cat /tmp/finished.txt 2>&1")
+while [ "$FINISHED2" != "finished" ];
+do
+  sleep 1
+  FINISHED2=$(ssh $LINUX_USER@$NODE2_FQDN "cat /tmp/finished.txt 2>&1")
+done
+
+# Copy test coverage results
+scp $LINUX_USER@$NODE1_FQDN:/tmp/output.txt $(dirname $0)/output1.txt
+scp $LINUX_USER@$NODE2_FQDN:/tmp/output.txt $(dirname $0)/output2.txt
+scp $LINUX_USER@$NODE3_FQDN:/tmp/output.txt $(dirname $0)/output3.txt
+#scp $LINUX_USER@$NODE4_FQDN:/tmp/output.txt $(dirname $0)/output4.txt
+
+echo "Tests passed and coverge results are available in the output files"
+echo "Node 1 Results"
+cat $(dirname $0)/output1.txt
+echo " "
+echo "Node 2 Results"
+cat $(dirname $0)/output2.txt
+echo " "
+echo "Node 3 Results"
+cat $(dirname $0)/output3.txt
+#echo " "
+#echo "Node 4 Results"
+#cat $(dirname $0)/output4.txt

--- a/drivers/storage/scaleio/tests/tests1.sh
+++ b/drivers/storage/scaleio/tests/tests1.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+
+# This script builds REX-Ray and then runs tests
+
+DEBUG=false
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$2}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  CF_STACK_NAME="default"
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+echo "Building using libstorage commit: $GIT_COMMIT_ID"
+
+FIRST_VOLUME=$CF_STACK_NAME"_1a"
+SECOND_VOLUME=$CF_STACK_NAME"_1b"
+
+# Clean Up the Env
+sudo rm -f /tmp/output.txt
+sudo rm -f /tmp/finished.txt
+sudo mkdir -p /usr/bin
+sudo mkdir -p /etc/rexray
+
+if [ -f $GIT_COMMIT_ID ]; then
+  echo "Using pre-built REX-Ray"
+
+  sudo cp -f $GIT_COMMIT_ID /usr/bin
+else
+  echo "Building REX-Ray"
+  echo "Building using libstorage commit: $GIT_COMMIT_ID"
+
+  # Build REX-Ray
+  rm -rf $HOME/.glide
+  mkdir -p $HOME/go/src/github.com/codedellemc
+  cd $HOME/go/src/github.com/codedellemc
+  git clone https://github.com/codedellemc/libstorage.git
+  git clone https://github.com/codedellemc/rexray.git
+  cd $HOME/go/src/github.com/codedellemc/rexray
+  sed -e "s/.*# libstorage-version/    ref:     $GIT_COMMIT_ID/g" -i glide.yaml
+  sed -e $"s|.*# libstorage-repo|    repo:    file://$HOME/go/src/github.com/codedellemc/libstorage\n    vcs:     git|g" -i glide.yaml
+  rm -f glide.lock
+  make deps
+  make -j build-libstorage
+  make build
+
+  # Install REX-Ray
+  sudo cp -f $HOME/go/bin/rexray /usr/bin
+fi
+
+sudo cp -f /tmp/config.yml /etc/rexray
+sudo /usr/bin/rexray install
+sudo service rexray restart
+
+sleep 5
+
+# Run the tests....
+TEST1=$(sudo rexray volume create $FIRST_VOLUME --size 16 | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST1" == "$FIRST_VOLUME" ]; then
+  printf "1:rexray volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "1:rexray volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST1" >> /tmp/output.txt
+fi
+
+TEST2=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST2" == "$FIRST_VOLUME" ]; then
+  printf "2:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "2:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST2" >> /tmp/output.txt
+fi
+
+TEST3=$(sudo rexray volume ls $FIRST_VOLUME --format=json | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST3" == "$FIRST_VOLUME" ]; then
+  printf "3:rexray volume ls json:PASS\n" >> /tmp/output.txt
+else
+  printf "3:rexray volume ls json:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST3" >> /tmp/output.txt
+fi
+
+TEST4=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST4" == "$FIRST_VOLUME" ]; then
+  printf "4:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "4:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST4" >> /tmp/output.txt
+fi
+
+TEST5=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST5" == "attached" ]; then
+  printf "5:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "5:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST5" >> /tmp/output.txt
+fi
+
+TEST6=$(sudo rexray volume mount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $5}')
+if [ "$TEST6" == "/var/lib/libstorage/volumes/$FIRST_VOLUME/data" ]; then
+  printf "6:rexray volume mount:PASS\n" >> /tmp/output.txt
+else
+  printf "6:rexray volume mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST6" >> /tmp/output.txt
+fi
+
+TEST7=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].attachments[0].instanceID.driver' | sed -e 's|["'\'']||g')
+if [ "$TEST7" == "scaleio" ]; then
+  printf "7:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "7:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST7" >> /tmp/output.txt
+fi
+
+TEST8=$(sudo rexray volume unmount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST8" == "$FIRST_VOLUME" ]; then
+  printf "8:rexray volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "8:rexray volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST8" >> /tmp/output.txt
+fi
+
+TEST9=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST9" == "attached" ]; then
+  printf "9:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "9:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST9" >> /tmp/output.txt
+fi
+
+TEST10=$(sudo rexray volume detach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST10" == "available" ]; then
+  printf "10:rexray volume detach:PASS\n" >> /tmp/output.txt
+else
+  printf "10:rexray volume detach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST10" >> /tmp/output.txt
+fi
+
+TEST11=$(sudo rexray volume rm $FIRST_VOLUME)
+if [ "$TEST11" == "$FIRST_VOLUME" ]; then
+  printf "11:rexray volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "11:rexray volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST11" >> /tmp/output.txt
+fi
+
+TEST12=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST12" == "" ]; then
+  printf "12:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "12:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST12" >> /tmp/output.txt
+fi
+
+TEST13=$(sudo docker volume create --driver rexray --name $SECOND_VOLUME --opt size=16)
+if [ "$TEST13" == "$SECOND_VOLUME" ]; then
+  printf "13:docker volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "13:docker volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST13" >> /tmp/output.txt
+fi
+
+TEST14=$(sudo docker run -d --volume-driver=rexray -v $SECOND_VOLUME:/tmp dvonthenen/demo-boot)
+if [ "$TEST14" != "" ]; then
+  printf "14:docker run mount:PASS\n" >> /tmp/output.txt
+else
+  printf "14:docker run mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST14" >> /tmp/output.txt
+fi
+
+TEST15=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST15" == "/var/lib/libstorage/volumes/$SECOND_VOLUME/data" ]; then
+  printf "15:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "15:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST15" >> /tmp/output.txt
+fi
+
+TEST16=$(sudo docker ps | grep 'dvonthenen/demo-boot' | awk '{print $1}' | xargs sudo docker stop)
+if [ "$TEST16" != "" ]; then
+  printf "16:docker volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "16:docker volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST16" >> /tmp/output.txt
+fi
+
+# Stopping here... even though we stopped the container, the volume is still
+# actually attached until the stopped instanced is deleted. Will let node 2
+# test preemption. Note that you CANNOT rerun these tests without deleting and
+# recreating the environment.
+
+echo "finished" > /tmp/finished.txt

--- a/drivers/storage/scaleio/tests/tests2a.sh
+++ b/drivers/storage/scaleio/tests/tests2a.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+
+# This script builds REX-Ray and then runs tests
+
+DEBUG=false
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$2}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  CF_STACK_NAME="default"
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+
+FIRST_VOLUME=$CF_STACK_NAME"_2a"
+SECOND_VOLUME=$CF_STACK_NAME"_2b"
+
+# Clean Up the Env
+sudo rm -f /tmp/output.txt
+sudo rm -f /tmp/finished.txt
+sudo mkdir -p /usr/bin
+sudo mkdir -p /etc/rexray
+
+if [ -f $GIT_COMMIT_ID ]; then
+  echo "Using pre-built REX-Ray"
+
+  sudo cp -f $GIT_COMMIT_ID /usr/bin
+else
+  echo "Building REX-Ray"
+  echo "Building using libstorage commit: $GIT_COMMIT_ID"
+
+  # Build REX-Ray
+  rm -rf $HOME/.glide
+  mkdir -p $HOME/go/src/github.com/codedellemc
+  cd $HOME/go/src/github.com/codedellemc
+  git clone https://github.com/codedellemc/libstorage.git
+  git clone https://github.com/codedellemc/rexray.git
+  cd $HOME/go/src/github.com/codedellemc/rexray
+  sed -e "s/.*# libstorage-version/    ref:     $GIT_COMMIT_ID/g" -i glide.yaml
+  sed -e $"s|.*# libstorage-repo|    repo:    file://$HOME/go/src/github.com/codedellemc/libstorage\n    vcs:     git|g" -i glide.yaml
+  rm -f glide.lock
+  make deps
+  make -j build-libstorage
+  make build
+
+  # Install REX-Ray
+  sudo cp -f $HOME/go/bin/rexray /usr/bin
+fi
+
+sudo cp -f /tmp/config.yml /etc/rexray
+sudo /usr/bin/rexray install
+sudo service rexray restart
+
+sleep 5
+
+# Run the tests....
+TEST1=$(sudo rexray volume create $FIRST_VOLUME --size 16 | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST1" == "$FIRST_VOLUME" ]; then
+  printf "1:rexray volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "1:rexray volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST1" >> /tmp/output.txt
+fi
+
+TEST2=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST2" == "$FIRST_VOLUME" ]; then
+  printf "2:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "2:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST2" >> /tmp/output.txt
+fi
+
+TEST3=$(sudo rexray volume ls $FIRST_VOLUME --format=json | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST3" == "$FIRST_VOLUME" ]; then
+  printf "3:rexray volume ls json:PASS\n" >> /tmp/output.txt
+else
+  printf "3:rexray volume ls json:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST3" >> /tmp/output.txt
+fi
+
+TEST4=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST4" == "$FIRST_VOLUME" ]; then
+  printf "4:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "4:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST4" >> /tmp/output.txt
+fi
+
+TEST5=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST5" == "attached" ]; then
+  printf "5:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "5:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST5" >> /tmp/output.txt
+fi
+
+TEST6=$(sudo rexray volume mount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $5}')
+if [ "$TEST6" == "/var/lib/libstorage/volumes/$FIRST_VOLUME/data" ]; then
+  printf "6:rexray volume mount:PASS\n" >> /tmp/output.txt
+else
+  printf "6:rexray volume mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST6" >> /tmp/output.txt
+fi
+
+TEST7=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].attachments[0].instanceID.driver' | sed -e 's|["'\'']||g')
+if [ "$TEST7" == "scaleio" ]; then
+  printf "7:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "7:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST7" >> /tmp/output.txt
+fi
+
+TEST8=$(sudo rexray volume unmount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST8" == "$FIRST_VOLUME" ]; then
+  printf "8:rexray volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "8:rexray volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST8" >> /tmp/output.txt
+fi
+
+TEST9=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST9" == "attached" ]; then
+  printf "9:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "9:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST9" >> /tmp/output.txt
+fi
+
+TEST10=$(sudo rexray volume detach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST10" == "available" ]; then
+  printf "10:rexray volume detach:PASS\n" >> /tmp/output.txt
+else
+  printf "10:rexray volume detach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST10" >> /tmp/output.txt
+fi
+
+TEST11=$(sudo rexray volume rm $FIRST_VOLUME)
+if [ "$TEST11" == "$FIRST_VOLUME" ]; then
+  printf "11:rexray volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "11:rexray volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST11" >> /tmp/output.txt
+fi
+
+TEST12=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST12" == "" ]; then
+  printf "12:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "12:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST12" >> /tmp/output.txt
+fi
+
+TEST13=$(sudo docker volume create --driver rexray --name $SECOND_VOLUME --opt size=16)
+if [ "$TEST13" == "$SECOND_VOLUME" ]; then
+  printf "13:docker volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "13:docker volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST13" >> /tmp/output.txt
+fi
+
+TEST14=$(sudo docker run -d --volume-driver=rexray -v $SECOND_VOLUME:/tmp dvonthenen/demo-boot)
+if [ "$TEST14" != "" ]; then
+  printf "14:docker run mount:PASS\n" >> /tmp/output.txt
+else
+  printf "14:docker run mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST14" >> /tmp/output.txt
+fi
+
+TEST15=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST15" == "/var/lib/libstorage/volumes/$SECOND_VOLUME/data" ]; then
+  printf "15:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "15:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST15" >> /tmp/output.txt
+fi
+
+TEST16=$(sudo docker ps | grep 'dvonthenen/demo-boot' | awk '{print $1}' | xargs sudo docker stop)
+if [ "$TEST16" != "" ]; then
+  printf "16:docker volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "16:docker volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST16" >> /tmp/output.txt
+fi
+
+TEST17=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST17" == "/" ]; then
+  printf "17:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "17:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST17" >> /tmp/output.txt
+fi
+
+#Remove old docker Instances
+sudo docker rm $(sudo docker ps -a | grep Exited | awk '{print $1}')
+
+TEST18=$(sudo docker volume rm $SECOND_VOLUME)
+if [ "$TEST18" == "$SECOND_VOLUME" ]; then
+  printf "18:docker volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "18:docker volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST18" >> /tmp/output.txt
+fi
+
+TEST19=$(sudo docker volume ls | grep "$SECOND_VOLUME" | awk '{print $2}')
+if [ "$TEST19" == "" ]; then
+  printf "19:docker volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "19:docker volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST19" >> /tmp/output.txt
+fi
+
+# Do not print finished to the /tmp/finished.txt file because we need
+# to execute a second script on this node to handle preemption.

--- a/drivers/storage/scaleio/tests/tests2b.sh
+++ b/drivers/storage/scaleio/tests/tests2b.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# This script builds REX-Ray and then runs tests
+
+DEBUG=false
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$2}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  CF_STACK_NAME="default"
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+
+PREEMPT_VOLUME=$CF_STACK_NAME"_1b"
+
+# Run the tests....
+TEST20=$(sudo docker run -d --volume-driver=rexray -v $PREEMPT_VOLUME:/tmp dvonthenen/demo-boot)
+if [ "$TEST20" != "" ]; then
+  printf "20:docker run mount preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "20:docker run mount preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST20" >> /tmp/output.txt
+fi
+
+TEST21=$(sudo docker volume inspect $PREEMPT_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST21" == "/var/lib/libstorage/volumes/$PREEMPT_VOLUME/data" ]; then
+  printf "21:docker volume inspect preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "21:docker volume inspect preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST21" >> /tmp/output.txt
+fi
+
+TEST22=$(sudo docker ps | grep 'dvonthenen/demo-boot' | awk '{print $1}' | xargs sudo docker stop)
+if [ "$TEST22" != "" ]; then
+  printf "22:docker volume unmount preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "22:docker volume unmount preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST22" >> /tmp/output.txt
+fi
+
+TEST23=$(sudo docker volume inspect $PREEMPT_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST23" == "/" ]; then
+  printf "23:docker volume inspect preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "23:docker volume inspect preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST23" >> /tmp/output.txt
+fi
+
+#Remove old docker Instances
+sudo docker rm $(sudo docker ps -a | grep Exited | awk '{print $1}')
+
+TEST24=$(sudo docker volume rm $PREEMPT_VOLUME)
+if [ "$TEST24" == "$PREEMPT_VOLUME" ]; then
+  printf "24:docker volume rm preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "24:docker volume rm preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST24" >> /tmp/output.txt
+fi
+
+TEST25=$(sudo docker volume ls | grep "$PREEMPT_VOLUME" | awk '{print $2}')
+if [ "$TEST25" == "" ]; then
+  printf "25:docker volume ls preempt:PASS\n" >> /tmp/output.txt
+else
+  printf "25:docker volume ls preempt:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST25" >> /tmp/output.txt
+fi
+
+echo "finished" > /tmp/finished.txt

--- a/drivers/storage/scaleio/tests/tests3.sh
+++ b/drivers/storage/scaleio/tests/tests3.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+
+# This script builds REX-Ray and then runs tests
+
+DEBUG=false
+
+CF_STACK_NAME=${CF_STACK_NAME:-$1}
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$2}
+
+if [ -z "${CF_STACK_NAME}" ]; then
+  CF_STACK_NAME="default"
+fi
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+
+FIRST_VOLUME=$CF_STACK_NAME"_3a"
+SECOND_VOLUME=$CF_STACK_NAME"_3b"
+
+# Clean Up the Env
+sudo rm -f /tmp/output.txt
+sudo rm -f /tmp/finished.txt
+sudo mkdir -p /usr/bin
+sudo mkdir -p /etc/rexray
+
+if [ -f $GIT_COMMIT_ID ]; then
+  echo "Using pre-built REX-Ray"
+
+  sudo cp -f $GIT_COMMIT_ID /usr/bin
+else
+  echo "Building REX-Ray"
+  echo "Building using libstorage commit: $GIT_COMMIT_ID"
+
+  # Build REX-Ray
+  rm -rf $HOME/.glide
+  mkdir -p $HOME/go/src/github.com/codedellemc
+  cd $HOME/go/src/github.com/codedellemc
+  git clone https://github.com/codedellemc/libstorage.git
+  git clone https://github.com/codedellemc/rexray.git
+  cd $HOME/go/src/github.com/codedellemc/rexray
+  sed -e "s/.*# libstorage-version/    ref:     $GIT_COMMIT_ID/g" -i glide.yaml
+  sed -e $"s|.*# libstorage-repo|    repo:    file://$HOME/go/src/github.com/codedellemc/libstorage\n    vcs:     git|g" -i glide.yaml
+  rm -f glide.lock
+  make deps
+  make -j build-libstorage
+  make build
+
+  # Install REX-Ray
+  sudo cp -f $HOME/go/bin/rexray /usr/bin
+fi
+
+sudo cp -f /tmp/config.yml /etc/rexray
+sudo /usr/bin/rexray install
+sudo service rexray restart
+
+sleep 5
+
+# Run the tests....
+TEST1=$(sudo rexray volume create $FIRST_VOLUME --size 16 | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST1" == "$FIRST_VOLUME" ]; then
+  printf "1:rexray volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "1:rexray volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST1" >> /tmp/output.txt
+fi
+
+TEST2=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST2" == "$FIRST_VOLUME" ]; then
+  printf "2:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "2:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST2" >> /tmp/output.txt
+fi
+
+TEST3=$(sudo rexray volume ls $FIRST_VOLUME --format=json | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST3" == "$FIRST_VOLUME" ]; then
+  printf "3:rexray volume ls json:PASS\n" >> /tmp/output.txt
+else
+  printf "3:rexray volume ls json:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST3" >> /tmp/output.txt
+fi
+
+TEST4=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST4" == "$FIRST_VOLUME" ]; then
+  printf "4:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "4:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST4" >> /tmp/output.txt
+fi
+
+TEST5=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST5" == "attached" ]; then
+  printf "5:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "5:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST5" >> /tmp/output.txt
+fi
+
+TEST6=$(sudo rexray volume mount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $5}')
+if [ "$TEST6" == "/var/lib/libstorage/volumes/$FIRST_VOLUME/data" ]; then
+  printf "6:rexray volume mount:PASS\n" >> /tmp/output.txt
+else
+  printf "6:rexray volume mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST6" >> /tmp/output.txt
+fi
+
+TEST7=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].attachments[0].instanceID.driver' | sed -e 's|["'\'']||g')
+if [ "$TEST7" == "scaleio" ]; then
+  printf "7:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "7:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST7" >> /tmp/output.txt
+fi
+
+TEST8=$(sudo rexray volume unmount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST8" == "$FIRST_VOLUME" ]; then
+  printf "8:rexray volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "8:rexray volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST8" >> /tmp/output.txt
+fi
+
+TEST9=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST9" == "attached" ]; then
+  printf "9:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "9:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST9" >> /tmp/output.txt
+fi
+
+TEST10=$(sudo rexray volume detach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST10" == "available" ]; then
+  printf "10:rexray volume detach:PASS\n" >> /tmp/output.txt
+else
+  printf "10:rexray volume detach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST10" >> /tmp/output.txt
+fi
+
+TEST11=$(sudo rexray volume rm $FIRST_VOLUME)
+if [ "$TEST11" == "$FIRST_VOLUME" ]; then
+  printf "11:rexray volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "11:rexray volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST11" >> /tmp/output.txt
+fi
+
+TEST12=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST12" == "" ]; then
+  printf "12:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "12:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST12" >> /tmp/output.txt
+fi
+
+TEST13=$(sudo docker volume create --driver rexray --name $SECOND_VOLUME --opt size=16)
+if [ "$TEST13" == "$SECOND_VOLUME" ]; then
+  printf "13:docker volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "13:docker volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST13" >> /tmp/output.txt
+fi
+
+TEST14=$(sudo docker run -d --volume-driver=rexray -v $SECOND_VOLUME:/tmp dvonthenen/demo-boot)
+if [ "$TEST14" != "" ]; then
+  printf "14:docker run mount:PASS\n" >> /tmp/output.txt
+else
+  printf "14:docker run mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST14" >> /tmp/output.txt
+fi
+
+TEST15=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST15" == "/var/lib/libstorage/volumes/$SECOND_VOLUME/data" ]; then
+  printf "15:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "15:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST15" >> /tmp/output.txt
+fi
+
+TEST16=$(sudo docker ps | grep 'dvonthenen/demo-boot' | awk '{print $1}' | xargs sudo docker stop)
+if [ "$TEST16" != "" ]; then
+  printf "16:docker volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "16:docker volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST16" >> /tmp/output.txt
+fi
+
+TEST17=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST17" == "/" ]; then
+  printf "17:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "17:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST17" >> /tmp/output.txt
+fi
+
+#Remove old docker Instances
+sudo docker rm $(sudo docker ps -a | grep Exited | awk '{print $1}')
+
+TEST18=$(sudo docker volume rm $SECOND_VOLUME)
+if [ "$TEST18" == "$SECOND_VOLUME" ]; then
+  printf "18:docker volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "18:docker volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST18" >> /tmp/output.txt
+fi
+
+TEST19=$(sudo docker volume ls | grep "$SECOND_VOLUME" | awk '{print $2}')
+if [ "$TEST19" == "" ]; then
+  printf "19:docker volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "19:docker volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST19" >> /tmp/output.txt
+fi
+
+echo "finished" > /tmp/finished.txt

--- a/drivers/storage/scaleio/tests/tests4.sh
+++ b/drivers/storage/scaleio/tests/tests4.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+
+# This script builds REX-Ray and then runs tests
+
+DEBUG=false
+
+GIT_COMMIT_ID=${GIT_COMMIT_ID:-$1}
+
+if [ -z "${GIT_COMMIT_ID}" ]; then
+  GIT_COMMIT_ID="master"
+fi
+echo "Building using libstorage commit: $GIT_COMMIT_ID"
+
+FIRST_VOLUME="myvoltest4a"
+SECOND_VOLUME="myvoltest4b"
+
+# Clean Up the Env
+sudo rm -f /tmp/output.txt
+sudo rm -f /tmp/finished.txt
+sudo mkdir -p /usr/bin
+sudo mkdir -p /etc/rexray
+
+# Build REX-Ray
+rm -rf $HOME/.glide
+mkdir -p $HOME/go/src/github.com/codedellemc
+cd $HOME/go/src/github.com/codedellemc
+git clone https://github.com/codedellemc/libstorage.git
+git clone https://github.com/codedellemc/rexray.git
+cd $HOME/go/src/github.com/codedellemc/rexray
+sed -e "s/.*# libstorage-version/    ref:     $GIT_COMMIT_ID/g" -i glide.yaml
+sed -e $"s|.*# libstorage-repo|    repo:    file://$HOME/go/src/github.com/codedellemc/libstorage\n    vcs:     git|g" -i glide.yaml
+rm -f glide.lock
+make deps
+make -j build-libstorage
+make build
+
+# Install REX-Ray
+sudo cp -f $HOME/go/bin/rexray /usr/bin
+sudo cp -f /tmp/config.yml /etc/rexray
+sudo /usr/bin/rexray install
+sudo service rexray restart
+
+sleep 5
+
+# Run the tests....
+TEST1=$(sudo rexray volume create $FIRST_VOLUME --size 16 | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST1" == "$FIRST_VOLUME" ]; then
+  printf "1:rexray volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "1:rexray volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST1" >> /tmp/output.txt
+fi
+
+TEST2=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST2" == "$FIRST_VOLUME" ]; then
+  printf "2:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "2:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST2" >> /tmp/output.txt
+fi
+
+TEST3=$(sudo rexray volume ls $FIRST_VOLUME --format=json | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST3" == "$FIRST_VOLUME" ]; then
+  printf "3:rexray volume ls json:PASS\n" >> /tmp/output.txt
+else
+  printf "3:rexray volume ls json:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST3" >> /tmp/output.txt
+fi
+
+TEST4=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].name' | sed -e 's|["'\'']||g')
+if [ "$TEST4" == "$FIRST_VOLUME" ]; then
+  printf "4:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "4:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST4" >> /tmp/output.txt
+fi
+
+TEST5=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST5" == "attached" ]; then
+  printf "5:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "5:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST5" >> /tmp/output.txt
+fi
+
+TEST6=$(sudo rexray volume mount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $5}')
+if [ "$TEST6" == "/var/lib/libstorage/volumes/$FIRST_VOLUME/data" ]; then
+  printf "6:rexray volume mount:PASS\n" >> /tmp/output.txt
+else
+  printf "6:rexray volume mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST6" >> /tmp/output.txt
+fi
+
+TEST8=$(sudo rexray volume ls $FIRST_VOLUME --format=jsonp | jq '.[0].attachments[0].instanceID.driver' | sed -e 's|["'\'']||g')
+if [ "$TEST8" == "scaleio" ]; then
+  printf "8:rexray volume ls jsonp:PASS\n" >> /tmp/output.txt
+else
+  printf "8:rexray volume ls jsonp:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST8" >> /tmp/output.txt
+fi
+
+TEST9=$(sudo rexray volume unmount $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST9" == "$FIRST_VOLUME" ]; then
+  printf "9:rexray volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "9:rexray volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST9" >> /tmp/output.txt
+fi
+
+TEST10=$(sudo rexray volume attach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST10" == "attached" ]; then
+  printf "10:rexray volume attach:PASS\n" >> /tmp/output.txt
+else
+  printf "10:rexray volume attach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST10" >> /tmp/output.txt
+fi
+
+TEST11=$(sudo rexray volume detach $FIRST_VOLUME | grep "$FIRST_VOLUME" | awk '{print $3}')
+if [ "$TEST11" == "available" ]; then
+  printf "11:rexray volume detach:PASS\n" >> /tmp/output.txt
+else
+  printf "11:rexray volume detach:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST11" >> /tmp/output.txt
+fi
+
+TEST12=$(sudo rexray volume rm $FIRST_VOLUME)
+if [ "$TEST12" == "$FIRST_VOLUME" ]; then
+  printf "12:rexray volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "12:rexray volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST12" >> /tmp/output.txt
+fi
+
+TEST13=$(sudo rexray volume ls | grep "$FIRST_VOLUME" | awk '{print $2}')
+if [ "$TEST13" == "" ]; then
+  printf "13:rexray volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "13:rexray volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST13" >> /tmp/output.txt
+fi
+
+TEST14=$(sudo docker volume create --driver rexray --name $SECOND_VOLUME --opt size=16)
+if [ "$TEST14" == "$SECOND_VOLUME" ]; then
+  printf "14:docker volume create:PASS\n" >> /tmp/output.txt
+else
+  printf "14:docker volume create:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST14" >> /tmp/output.txt
+fi
+
+TEST15=$(sudo docker run -d --volume-driver=rexray -v $SECOND_VOLUME:/tmp dvonthenen/demo-boot)
+if [ "$TEST15" != "" ]; then
+  printf "15:docker run mount:PASS\n" >> /tmp/output.txt
+else
+  printf "15:docker run mount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST15" >> /tmp/output.txt
+fi
+
+TEST16=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST16" == "/var/lib/libstorage/volumes/$SECOND_VOLUME/data" ]; then
+  printf "16:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "16:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST16" >> /tmp/output.txt
+fi
+
+TEST17=$(sudo docker ps | grep 'dvonthenen/demo-boot' | awk '{print $1}' | xargs sudo docker stop)
+if [ "$TEST17" != "" ]; then
+  printf "17:docker volume unmount:PASS\n" >> /tmp/output.txt
+else
+  printf "17:docker volume unmount:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST17" >> /tmp/output.txt
+fi
+
+TEST18=$(sudo docker volume inspect $SECOND_VOLUME | jq '.[0].Mountpoint' | sed -e 's|["'\'']||g')
+if [ "$TEST18" == "/" ]; then
+  printf "18:docker volume inspect:PASS\n" >> /tmp/output.txt
+else
+  printf "18:docker volume inspect:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST18" >> /tmp/output.txt
+fi
+
+#Remove old docker Instances
+sudo docker rm $(sudo docker ps -a | grep Exited | awk '{print $1}')
+
+TEST19=$(sudo docker volume rm $SECOND_VOLUME)
+if [ "$TEST19" == "$SECOND_VOLUME" ]; then
+  printf "19:docker volume rm:PASS\n" >> /tmp/output.txt
+else
+  printf "19:docker volume rm:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST19" >> /tmp/output.txt
+fi
+
+TEST20=$(sudo docker volume ls | grep "$SECOND_VOLUME" | awk '{print $2}')
+if [ "$TEST20" == "" ]; then
+  printf "20:docker volume ls:PASS\n" >> /tmp/output.txt
+else
+  printf "20:docker volume ls:FAILED\n" >> /tmp/output.txt
+fi
+if [ "$DEBUG" == "true" ]; then
+  printf "#%s\n" "$TEST20" >> /tmp/output.txt
+fi
+
+echo "finished" > /tmp/finished.txt


### PR DESCRIPTION
Verified on 2 environments (Chris' config and AWS). You can run on bare metal or stand up a test environment in AWS using a provided CloudFormation template.

**To run in AWS**
The test-env-up.sh sets up the environment in AWS. AWS was chosen because the entire scaleio environment can be propped up quickly (in under a minute). An AWS key/secret will be required with sufficient permissions. A uniquely identifiable stack-name must be given which allows for the process to stand up multiple environments concurrently.

The test-run.sh pushes over required files, the test script containing multiple tests, and then executes the test script. Once the test cases are completed, an output file containing the test results are copied back to the system.

The test-env-down.sh script is run last and removes all artifacts in Amazon.

**To run on bare metal**
You can use the test-run-metal.sh. It requires 3 nodes running the ScaleIO sdc, go, and jq packages. Will execute the test cases above on those nodes. This is just a "nice to have" and not the focus of the PR.