### PR TITLE
Fix for Ceph MonIPs with Ports

### DIFF
--- a/drivers/storage/rbd/executor/rbd_executor.go
+++ b/drivers/storage/rbd/executor/rbd_executor.go
@@ -160,17 +160,19 @@ func getCephMonIPs() ([]net.IP, error) {
 
 	monStrings := strings.Split(strings.TrimSpace(string(out)), ",")
 
-	monIps := make([]net.IP, 0, 4)
+	monIps := []net.IP{}
 
 	for _, mon := range monStrings {
-		ip := net.ParseIP(mon)
-		if ip != nil {
-			monIps = append(monIps, ip)
-		} else {
-			ipSlice, err := net.LookupIP(mon)
-			if err == nil {
-				monIps = append(monIps, ipSlice...)
-			}
+		host, _, err := net.SplitHostPort(mon)
+		if err != nil {
+			return nil, err
+		}
+		addrs, err := net.LookupIP(host)
+		if err != nil {
+			return nil, err
+		}
+		if len(addrs) > 0 {
+			monIps = append(monIps, addrs...)
 		}
 	}
 


### PR DESCRIPTION
This patch is a first-attempt at fixing a bug where the RBD executor does not properly parse CephMon addresses with ports.

This patch does not account for IPv6 addresses as those require brackets for parsing, but this should hopefully help a community user move forward sooner than later.