### PR TITLE
Fix for Premption and Volume Mounting

### DIFF
--- a/drivers/integration/linux/linux.go
+++ b/drivers/integration/linux/linux.go
@@ -170,7 +170,7 @@ func (d *driver) Mount(
 
 	lsAtt := types.VolAttReqWithDevMapOnlyVolsAttachedToInstanceOrUnattachedVols
 	if opts.Preempt {
-		lsAtt = types.VolAttReq
+		lsAtt = types.VolAttReqWithDevMapForInstance
 	}
 
 	vol, err := d.volumeInspectByIDOrName(
@@ -191,7 +191,9 @@ func (d *driver) Mount(
 	}
 
 	client := context.MustClient(ctx)
-	if len(vol.Attachments) == 0 || opts.Preempt {
+	if vol.AttachmentState == types.VolumeAvailable ||
+		(opts.Preempt && vol.AttachmentState != types.VolumeAttached) {
+
 		mp, err := d.getVolumeMountPath(vol.Name)
 		if err != nil {
 			return "", nil, err


### PR DESCRIPTION
This patch updates the Linux integration driver's preemption logic when mounting volumes. If a volume is already attached the branch in the Mount function involving a precautionary unmount is not invoked.