### PR TITLE
ScaleIO Executor Typo

### DIFF
--- a/drivers/storage/scaleio/executor/scaleio_executor.go
+++ b/drivers/storage/scaleio/executor/scaleio_executor.go
@@ -134,9 +134,6 @@ func (d *driver) getInstanceID() (*types.InstanceID, error) {
 
 	out, err := exec.Command(d.drvCfg, "--query_guid").CombinedOutput()
 	if err != nil {
-		return nil, err
-	}
-	if err != nil {
 		return nil, goof.WithError("error getting sdc guid", err)
 	}
 


### PR DESCRIPTION
This patch corrects an issue with the ScaleIO executor where an error is checked twice. So you better not watch out, you better not cry, you better not pout, and I'm telling you why. ScaleIO is coming to town!