### PR TITLE
Implement GCE application default credentials

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -697,6 +697,7 @@ VirtualBox|Yes
 EBS|Yes
 EFS|No
 RBD|No
+GCEPD|Yes
 
 #### Ignore Used Count
 By default accounting takes place during operations that are performed

--- a/drivers/storage/gcepd/gcepd.go
+++ b/drivers/storage/gcepd/gcepd.go
@@ -30,9 +30,10 @@ const (
 )
 
 func init() {
-	r := gofigCore.NewRegistration("GCE")
+	r := gofigCore.NewRegistration("GCEPD")
 	r.Key(gofig.String, "", "",
-		"Required: JSON keyfile for service account", "gcepd.keyfile")
+		"If defined, location of JSON keyfile for service account",
+		"gcepd.keyfile")
 	r.Key(gofig.String, "", "",
 		"If defined, limit GCE access to given zone", "gcepd.zone")
 	r.Key(gofig.String, "", DefaultDiskType, "Default GCE disk type",

--- a/drivers/storage/gcepd/tests/README.md
+++ b/drivers/storage/gcepd/tests/README.md
@@ -21,11 +21,14 @@ instance. You will also need to copy the JSON file with your service account
 credentials.
 
 Using an SSH session to connect to the GCE instance, please export the required
-GCE credentials used by the GCE storage driver:
+GCE service account credentials used by the GCE storage driver:
 
 ```bash
-export GCE_KEYFILE=/etc/gcekey.json
+export GCEPD_KEYFILE=/etc/gcekey.json
 ```
+
+If `GCEPD_KEYFILE` is not exported, the default location the test binary looks for
+a credentials file is at `/tmp/gce_key.json`.
 
 The tests may now be executed with the following command:
 


### PR DESCRIPTION
Enhance the GCEPD driver by adding support for application default
credentials. With this patch, A user no longer has to upload or provide
a JSON encoded file with service account credentials, as the GCE client
library will automatically fetch any service account credentials
associated with the GCE instances via the metadata server.

Improve docs to clarify what permissions are required of a service
account, regardless of whether you are providing it via JSON or
metadata lookup.