### PR TITLE
Executor CLI Volume Enhancements

### DIFF
--- a/api/registry/registry_storage.go
+++ b/api/registry/registry_storage.go
@@ -1,6 +1,9 @@
 package registry
 
-import "github.com/codedellemc/libstorage/api/types"
+import (
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/types"
+)
 
 type sdm struct {
 	types.StorageDriver
@@ -77,6 +80,21 @@ func (d *sdm) VolumeCreate(
 	name string,
 	opts *types.VolumeCreateOpts) (*types.Volume, error) {
 
+	// see if we should use the executor?
+	if client, ok := context.Client(ctx); ok {
+		if _, ok := context.ServiceName(ctx); ok {
+			if client.Executor() != nil {
+				lsxSO, err := client.Executor().Supported(ctx, opts.Opts)
+				if err != nil {
+					return nil, err
+				}
+				if lsxSO.VolumeCreate() {
+					return client.Executor().LSXVolumeCreate(ctx, name, opts)
+				}
+			}
+		}
+	}
+
 	return d.StorageDriver.VolumeCreate(ctx.Join(d.Context), name, opts)
 }
 
@@ -115,6 +133,22 @@ func (d *sdm) VolumeRemove(
 	volumeID string,
 	opts *types.VolumeRemoveOpts) error {
 
+	// see if we should use the executor?
+	if client, ok := context.Client(ctx); ok {
+		if _, ok := context.ServiceName(ctx); ok {
+			if client.Executor() != nil {
+				lsxSO, err := client.Executor().Supported(ctx, opts.Opts)
+				if err != nil {
+					return err
+				}
+				if lsxSO.VolumeRemove() {
+					return client.Executor().LSXVolumeRemove(
+						ctx, volumeID, opts)
+				}
+			}
+		}
+	}
+
 	return d.StorageDriver.VolumeRemove(
 		ctx.Join(d.Context), volumeID, opts)
 }
@@ -124,6 +158,22 @@ func (d *sdm) VolumeAttach(
 	volumeID string,
 	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
 
+	// see if we should use the executor?
+	if client, ok := context.Client(ctx); ok {
+		if _, ok := context.ServiceName(ctx); ok {
+			if client.Executor() != nil {
+				lsxSO, err := client.Executor().Supported(ctx, opts.Opts)
+				if err != nil {
+					return nil, "", err
+				}
+				if lsxSO.VolumeAttach() {
+					return client.Executor().LSXVolumeAttach(
+						ctx, volumeID, opts)
+				}
+			}
+		}
+	}
+
 	return d.StorageDriver.VolumeAttach(
 		ctx.Join(d.Context), volumeID, opts)
 }
@@ -132,6 +182,22 @@ func (d *sdm) VolumeDetach(
 	ctx types.Context,
 	volumeID string,
 	opts *types.VolumeDetachOpts) (*types.Volume, error) {
+
+	// see if we should use the executor?
+	if client, ok := context.Client(ctx); ok {
+		if _, ok := context.ServiceName(ctx); ok {
+			if client.Executor() != nil {
+				lsxSO, err := client.Executor().Supported(ctx, opts.Opts)
+				if err != nil {
+					return nil, err
+				}
+				if lsxSO.VolumeDetach() {
+					return client.Executor().LSXVolumeDetach(
+						ctx, volumeID, opts)
+				}
+			}
+		}
+	}
 
 	return d.StorageDriver.VolumeDetach(
 		ctx.Join(d.Context), volumeID, opts)

--- a/cli/lsx/lsx.go
+++ b/cli/lsx/lsx.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,8 +22,27 @@ import (
 	_ "github.com/codedellemc/libstorage/imports/executors"
 )
 
-var cmdRx = regexp.MustCompile(
-	`(?i)^((?:un?)?mounts?|supported|instanceid|nextdevice|localdevices|wait)$`)
+var cmds = map[string]func(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error){
+
+	apitypes.LSXCmdInstanceID:    opInstanceID,
+	apitypes.LSXCmdLocalDevices:  opLocalDevices,
+	apitypes.LSXCmdMount:         opMount,
+	apitypes.LSXCmdMounts:        opMounts,
+	apitypes.LSXCmdNextDevice:    opNextDevice,
+	apitypes.LSXCmdSupported:     opSupported,
+	apitypes.LSXCmdUmount:        opUmount,
+	"unmount":                    opUmount,
+	apitypes.LSXCmdVolumeAttach:  opVolumeAttach,
+	apitypes.LSXCmdVolumeCreate:  opVolumeCreate,
+	apitypes.LSXCmdVolumeDetach:  opVolumeDetach,
+	apitypes.LSXCmdVolumeRemove:  opVolumeRemove,
+	apitypes.LSXCmdWaitForDevice: opWait,
+}
 
 // Run runs the executor CLI.
 func Run() {
@@ -33,13 +52,21 @@ func Run() {
 		printUsageAndExit()
 	}
 
-	d, err := registry.NewStorageExecutor(args[1])
+	var (
+		driverName = args[1]
+		ctx        = context.Background()
+	)
+
+	if parts := strings.Split(driverName, ":"); len(parts) > 1 {
+		driverName = parts[0]
+		ctx = context.WithValue(ctx, context.ServiceKey, parts[1])
+	}
+
+	d, err := registry.NewStorageExecutor(driverName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-
-	driverName := strings.ToLower(d.Name())
 
 	config, err := apiconfig.NewConfig()
 	if err != nil {
@@ -48,221 +75,25 @@ func Run() {
 	}
 
 	apiconfig.UpdateLogLevel(config)
-	ctx := context.Background()
 
 	if err := d.Init(ctx, config); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 
-	cmd := cmdRx.FindString(args[2])
-	if cmd == "" {
+	opName := strings.ToLower(args[2])
+	opFunc, ok := cmds[opName]
+	if !ok {
 		printUsageAndExit()
 	}
-	store := utils.NewStore()
 
 	var (
 		result   interface{}
-		op       string
 		exitCode int
+		store    = utils.NewStore()
 	)
 
-	if strings.EqualFold(cmd, apitypes.LSXCmdSupported) {
-		op = apitypes.LSXCmdSupported
-		if dws, ok := d.(apitypes.StorageExecutorWithSupported); ok {
-			opResult, opErr := dws.Supported(ctx, store)
-			if opErr != nil {
-				err = opErr
-			} else if opResult {
-				rflags := apitypes.LSXOpAllNoMount
-				if _, ok := dws.(apitypes.StorageExecutorWithMount); ok {
-					rflags = rflags | apitypes.LSXSOpMount
-				}
-				if _, ok := dws.(apitypes.StorageExecutorWithUnmount); ok {
-					rflags = rflags | apitypes.LSXSOpUmount
-				}
-				if _, ok := dws.(apitypes.StorageExecutorWithMounts); ok {
-					rflags = rflags | apitypes.LSXSOpMounts
-				}
-				result = rflags
-			} else {
-				result = apitypes.LSXSOpNone
-			}
-		} else {
-			err = apitypes.ErrNotImplemented
-		}
-	} else if strings.EqualFold(cmd, apitypes.LSXCmdMounts) {
-		op = apitypes.LSXCmdMounts
-		dd, ok := d.(apitypes.StorageExecutorWithMounts)
-		if !ok {
-			err = apitypes.ErrNotImplemented
-		} else {
-			mounts, opErr := dd.Mounts(ctx, store)
-			if opErr != nil {
-				err = opErr
-			} else if mounts == nil {
-				result = []*apitypes.MountInfo{}
-			} else {
-				result = mounts
-			}
-		}
-	} else if strings.EqualFold(cmd, apitypes.LSXCmdMount) {
-		op = apitypes.LSXCmdMount
-		dd, ok := d.(apitypes.StorageExecutorWithMount)
-		if !ok {
-			err = apitypes.ErrNotImplemented
-		} else {
-			var (
-				deviceName string
-				mountPath  string
-				mountOpts  = &apitypes.DeviceMountOpts{Opts: store}
-			)
-			mountArgs := args[3:]
-			if len(mountArgs) == 0 {
-				printUsageAndExit()
-			}
-
-			remArgs := []string{}
-			for x := 0; x < len(mountArgs); {
-				a := mountArgs[x]
-				if x < len(mountArgs)-1 {
-					switch a {
-					case "-l":
-						mountOpts.MountLabel = mountArgs[x+1]
-						x = x + 2
-						continue
-					case "-o":
-						mountOpts.MountOptions = mountArgs[x+1]
-						x = x + 2
-						continue
-					}
-				}
-				remArgs = append(remArgs, a)
-				x++
-			}
-
-			if len(remArgs) != 2 {
-				printUsageAndExit()
-			}
-
-			deviceName = remArgs[0]
-			mountPath = remArgs[1]
-
-			opErr := dd.Mount(ctx, deviceName, mountPath, mountOpts)
-			if opErr != nil {
-				err = opErr
-			} else {
-				result = mountPath
-			}
-		}
-	} else if strings.EqualFold(cmd, apitypes.LSXCmdUmount) ||
-		strings.EqualFold(cmd, "unmount") {
-		op = apitypes.LSXCmdUmount
-		dd, ok := d.(apitypes.StorageExecutorWithUnmount)
-		if !ok {
-			err = apitypes.ErrNotImplemented
-		} else {
-			if len(args) < 4 {
-				printUsageAndExit()
-			}
-			mountPath := args[3]
-			opErr := dd.Unmount(ctx, mountPath, store)
-			if opErr != nil {
-				err = opErr
-			} else {
-				result = mountPath
-			}
-		}
-	} else if strings.EqualFold(cmd, apitypes.LSXCmdInstanceID) {
-		op = apitypes.LSXCmdInstanceID
-		opResult, opErr := d.InstanceID(ctx, store)
-		if opErr != nil {
-			err = opErr
-		} else {
-			opResult.Driver = driverName
-			result = opResult
-		}
-	} else if strings.EqualFold(cmd, apitypes.LSXCmdNextDevice) {
-		op = apitypes.LSXCmdNextDevice
-		opResult, opErr := d.NextDevice(ctx, store)
-		if opErr != nil && opErr != apitypes.ErrNotImplemented {
-			err = opErr
-		} else {
-			result = opResult
-		}
-	} else if strings.EqualFold(cmd, apitypes.LSXCmdLocalDevices) {
-		if len(args) < 4 {
-			printUsageAndExit()
-		}
-		op = apitypes.LSXCmdLocalDevices
-		opResult, opErr := d.LocalDevices(ctx, &apitypes.LocalDevicesOpts{
-			ScanType: apitypes.ParseDeviceScanType(args[3]),
-			Opts:     store,
-		})
-		if opErr != nil {
-			err = opErr
-		} else {
-			opResult.Driver = driverName
-			result = opResult
-		}
-	} else if strings.EqualFold(cmd, apitypes.LSXCmdWaitForDevice) {
-		if len(args) < 6 {
-			printUsageAndExit()
-		}
-		op = apitypes.LSXCmdWaitForDevice
-		opts := &apitypes.WaitForDeviceOpts{
-			LocalDevicesOpts: apitypes.LocalDevicesOpts{
-				ScanType: apitypes.ParseDeviceScanType(args[3]),
-				Opts:     store,
-			},
-			Token:   strings.ToLower(args[4]),
-			Timeout: utils.DeviceAttachTimeout(args[5]),
-		}
-
-		ldl := func() (bool, *apitypes.LocalDevices, error) {
-			ldm, err := d.LocalDevices(ctx, &opts.LocalDevicesOpts)
-			if err != nil {
-				return false, nil, err
-			}
-			for k := range ldm.DeviceMap {
-				if strings.ToLower(k) == opts.Token {
-					return true, ldm, nil
-				}
-			}
-			return false, ldm, nil
-		}
-
-		var (
-			found    bool
-			opErr    error
-			opResult *apitypes.LocalDevices
-			timeoutC = time.After(opts.Timeout)
-			tick     = time.Tick(500 * time.Millisecond)
-		)
-
-	TimeoutLoop:
-
-		for {
-			select {
-			case <-timeoutC:
-				exitCode = apitypes.LSXExitCodeTimedOut
-				break TimeoutLoop
-			case <-tick:
-				if found, opResult, opErr = ldl(); found || opErr != nil {
-					break TimeoutLoop
-				}
-			}
-		}
-
-		if opErr != nil {
-			err = opErr
-		} else {
-			opResult.Driver = driverName
-			result = opResult
-		}
-	}
-
-	if err != nil {
+	if result, err = opFunc(ctx, d, store, &exitCode, args...); err != nil {
 		// if the function is not implemented then exit with
 		// apitypes.LSXExitCodeNotImplemented to let callers
 		// know that the function is unsupported on this system
@@ -271,7 +102,7 @@ func Run() {
 			exitCode = apitypes.LSXExitCodeNotImplemented
 		}
 		fmt.Fprintf(os.Stderr,
-			"error: error getting %s: %v\n", op, err)
+			"error: error getting %s: %v\n", opName, err)
 		os.Exit(exitCode)
 	}
 
@@ -283,14 +114,16 @@ func Run() {
 	case encoding.TextMarshaler:
 		buf, err := tr.MarshalText()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: error encoding %s: %v\n", op, err)
+			fmt.Fprintf(
+				os.Stderr, "error: error encoding %s: %v\n", opName, err)
 			os.Exit(1)
 		}
 		os.Stdout.Write(buf)
 	default:
 		buf, err := json.Marshal(result)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: error encoding %s: %v\n", op, err)
+			fmt.Fprintf(
+				os.Stderr, "error: error encoding %s: %v\n", opName, err)
 			os.Exit(1)
 		}
 		if isNullBuf(buf) {
@@ -329,13 +162,501 @@ func executorNames() <-chan string {
 	return c
 }
 
+func opSupported(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	dws, ok := d.(apitypes.StorageExecutorWithSupported)
+	if !ok {
+		return nil, apitypes.ErrNotImplemented
+	}
+
+	ok, err := dws.Supported(ctx, store)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return apitypes.LSXSOpNone, nil
+	}
+
+	rflags := apitypes.LSXSOpInstanceID |
+		apitypes.LSXSOpLocalDevices |
+		apitypes.LSXSOpNextDevice |
+		apitypes.LSXSOpWaitForDevice
+	if _, ok := dws.(apitypes.StorageExecutorWithMount); ok {
+		rflags = rflags | apitypes.LSXSOpMount
+	}
+	if _, ok := dws.(apitypes.StorageExecutorWithUnmount); ok {
+		rflags = rflags | apitypes.LSXSOpUmount
+	}
+	if _, ok := dws.(apitypes.StorageExecutorWithMounts); ok {
+		rflags = rflags | apitypes.LSXSOpMounts
+	}
+	if _, ok := dws.(apitypes.StorageExecutorWithVolumeCreate); ok {
+		rflags = rflags | apitypes.LSXSOpVolumeCreate
+	}
+	if _, ok := dws.(apitypes.StorageExecutorWithVolumeRemove); ok {
+		rflags = rflags | apitypes.LSXSOpVolumeRemove
+	}
+	if _, ok := dws.(apitypes.StorageExecutorWithVolumeAttach); ok {
+		rflags = rflags | apitypes.LSXSOpVolumeAttach
+	}
+	if _, ok := dws.(apitypes.StorageExecutorWithVolumeDetach); ok {
+		rflags = rflags | apitypes.LSXSOpVolumeDetach
+	}
+
+	return rflags, nil
+}
+
+func opMounts(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	dd, ok := d.(apitypes.StorageExecutorWithMounts)
+	if !ok {
+		return nil, apitypes.ErrNotImplemented
+	}
+
+	mounts, err := dd.Mounts(ctx, store)
+	if err != nil {
+		return nil, err
+	}
+
+	if mounts == nil {
+		return []*apitypes.MountInfo{}, nil
+	}
+
+	return mounts, nil
+}
+
+func opMount(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	dd, ok := d.(apitypes.StorageExecutorWithMount)
+	if !ok {
+		return nil, apitypes.ErrNotImplemented
+	}
+
+	var (
+		deviceName string
+		mountPath  string
+		mountOpts  = &apitypes.DeviceMountOpts{Opts: store}
+	)
+	mountArgs := args[3:]
+	if len(mountArgs) == 0 {
+		printUsageAndExit()
+	}
+
+	remArgs := []string{}
+	for x := 0; x < len(mountArgs); {
+		a := mountArgs[x]
+		if x < len(mountArgs)-1 {
+			switch a {
+			case "-l":
+				mountOpts.MountLabel = mountArgs[x+1]
+				x = x + 2
+				continue
+			case "-o":
+				mountOpts.MountOptions = mountArgs[x+1]
+				x = x + 2
+				continue
+			}
+		}
+		remArgs = append(remArgs, a)
+		x++
+	}
+
+	if len(remArgs) != 2 {
+		printUsageAndExit()
+	}
+
+	deviceName = remArgs[0]
+	mountPath = remArgs[1]
+
+	if err := dd.Mount(ctx, deviceName, mountPath, mountOpts); err != nil {
+		return nil, err
+	}
+
+	return mountPath, nil
+}
+
+func opUmount(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	dd, ok := d.(apitypes.StorageExecutorWithUnmount)
+	if !ok {
+		return nil, apitypes.ErrNotImplemented
+	}
+
+	if len(args) < 4 {
+		printUsageAndExit()
+	}
+	mountPath := args[3]
+	if err := dd.Unmount(ctx, mountPath, store); err != nil {
+		return nil, err
+	}
+
+	return mountPath, nil
+}
+
+func opVolumeCreate(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	dd, ok := d.(apitypes.StorageExecutorWithVolumeCreate)
+	if !ok {
+		return nil, apitypes.ErrNotImplemented
+	}
+
+	args = args[3:]
+	if len(args) == 0 {
+		printUsageAndExit()
+	}
+
+	var (
+		opts    = &apitypes.VolumeCreateOpts{Opts: store}
+		remArgs = []string{}
+	)
+
+	for x := 0; x < len(args); {
+		a := args[x]
+		if a == "-e" {
+			encrypted := true
+			opts.Encrypted = &encrypted
+			x = x + 1
+			continue
+		}
+		if x < len(args)-1 {
+			switch a {
+			case "-k":
+				opts.EncryptionKey = &(args[x+1])
+				x = x + 2
+				continue
+			case "-i":
+				i, err := strconv.Atoi(args[x+1])
+				if err != nil {
+					printUsageAndExit()
+				}
+				i64 := int64(i)
+				opts.IOPS = &i64
+				x = x + 2
+				continue
+			case "-s":
+				i, err := strconv.Atoi(args[x+1])
+				if err != nil {
+					printUsageAndExit()
+				}
+				i64 := int64(i)
+				opts.Size = &i64
+				x = x + 2
+				continue
+			case "-t":
+				opts.Type = &(args[x+1])
+				x = x + 2
+				continue
+			case "-z":
+				opts.AvailabilityZone = &(args[x+1])
+				x = x + 2
+				continue
+			}
+		}
+		remArgs = append(remArgs, a)
+		x++
+	}
+
+	if len(remArgs) != 1 {
+		printUsageAndExit()
+	}
+
+	vol, err := dd.VolumeCreate(ctx, remArgs[0], opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return vol, nil
+}
+
+func opVolumeRemove(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	dd, ok := d.(apitypes.StorageExecutorWithVolumeRemove)
+	if !ok {
+		return nil, apitypes.ErrNotImplemented
+	}
+
+	args = args[3:]
+	if len(args) == 0 {
+		printUsageAndExit()
+	}
+
+	var (
+		opts    = &apitypes.VolumeRemoveOpts{Opts: store}
+		remArgs = []string{}
+	)
+
+	for x := 0; x < len(args); {
+		a := args[x]
+		if a == "-f" {
+			opts.Force = true
+			x = x + 1
+			continue
+		}
+		remArgs = append(remArgs, a)
+		x++
+	}
+
+	if len(remArgs) != 1 {
+		printUsageAndExit()
+	}
+
+	if err := dd.VolumeRemove(ctx, remArgs[0], opts); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func opVolumeAttach(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	dd, ok := d.(apitypes.StorageExecutorWithVolumeAttach)
+	if !ok {
+		return nil, apitypes.ErrNotImplemented
+	}
+
+	args = args[3:]
+	if len(args) == 0 {
+		printUsageAndExit()
+	}
+
+	var (
+		opts    = &apitypes.VolumeAttachOpts{Opts: store}
+		remArgs = []string{}
+	)
+
+	for x := 0; x < len(args); {
+		a := args[x]
+		if a == "-f" {
+			opts.Force = true
+			x = x + 1
+			continue
+		}
+		if x < len(args)-1 && a == "-n" {
+			opts.NextDevice = &(args[x+1])
+			x = x + 2
+			continue
+		}
+		remArgs = append(remArgs, a)
+		x++
+	}
+
+	if len(remArgs) != 1 {
+		printUsageAndExit()
+	}
+
+	if opts.NextDevice == nil {
+		nd, err := d.NextDevice(ctx, store)
+		if err != nil && err != apitypes.ErrNotImplemented {
+			return nil, err
+		}
+		opts.NextDevice = &nd
+	}
+
+	vol, tok, err := dd.VolumeAttach(ctx, remArgs[0], opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &apitypes.LSXVolumeAttachResult{Volume: vol, Token: tok}, nil
+}
+
+func opVolumeDetach(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	dd, ok := d.(apitypes.StorageExecutorWithVolumeDetach)
+	if !ok {
+		return nil, apitypes.ErrNotImplemented
+	}
+
+	args = args[3:]
+	if len(args) == 0 {
+		printUsageAndExit()
+	}
+
+	var (
+		opts    = &apitypes.VolumeDetachOpts{Opts: store}
+		remArgs = []string{}
+	)
+
+	for x := 0; x < len(args); {
+		a := args[x]
+		if a == "-f" {
+			opts.Force = true
+			x = x + 1
+			continue
+		}
+		remArgs = append(remArgs, a)
+		x++
+	}
+
+	if len(remArgs) != 1 {
+		printUsageAndExit()
+	}
+
+	vol, err := dd.VolumeDetach(ctx, remArgs[0], opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return vol, nil
+}
+
+func opInstanceID(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	result, err := d.InstanceID(ctx, store)
+	if err != nil {
+		return nil, err
+	}
+	result.Driver = d.Name()
+	return result, nil
+}
+
+func opNextDevice(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	result, err := d.NextDevice(ctx, store)
+	if err != nil {
+		if err != apitypes.ErrNotImplemented {
+			return nil, err
+		}
+		return nil, nil
+	}
+	return result, nil
+}
+
+func opLocalDevices(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	if len(args) < 4 {
+		printUsageAndExit()
+	}
+	result, err := d.LocalDevices(ctx, &apitypes.LocalDevicesOpts{
+		ScanType: apitypes.ParseDeviceScanType(args[3]),
+		Opts:     store,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.Driver = d.Name()
+	return result, nil
+}
+
+func opWait(
+	ctx apitypes.Context,
+	d apitypes.StorageExecutor,
+	store apitypes.Store,
+	exitCode *int,
+	args ...string) (interface{}, error) {
+
+	if len(args) < 6 {
+		printUsageAndExit()
+	}
+
+	opts := &apitypes.WaitForDeviceOpts{
+		LocalDevicesOpts: apitypes.LocalDevicesOpts{
+			ScanType: apitypes.ParseDeviceScanType(args[3]),
+			Opts:     store,
+		},
+		Token:   strings.ToLower(args[4]),
+		Timeout: utils.DeviceAttachTimeout(args[5]),
+	}
+
+	ldl := func() (bool, *apitypes.LocalDevices, error) {
+		ldm, err := d.LocalDevices(ctx, &opts.LocalDevicesOpts)
+		if err != nil {
+			return false, nil, err
+		}
+		for k := range ldm.DeviceMap {
+			if strings.ToLower(k) == opts.Token {
+				return true, ldm, nil
+			}
+		}
+		return false, ldm, nil
+	}
+
+	var (
+		timeoutC = time.After(opts.Timeout)
+		tick     = time.Tick(500 * time.Millisecond)
+	)
+
+	for {
+		select {
+		case <-timeoutC:
+			*exitCode = apitypes.LSXExitCodeTimedOut
+			return nil, nil
+		case <-tick:
+			found, result, err := ldl()
+			if err != nil {
+				return nil, err
+			}
+			if found {
+				result.Driver = d.Name()
+				return result, nil
+			}
+		}
+	}
+}
+
 func printUsage() {
 	buf := &bytes.Buffer{}
 	w := io.MultiWriter(buf, os.Stderr)
 
 	fmt.Fprintf(w, "usage: ")
 	lpad1 := buf.Len()
-	fmt.Fprintf(w, "%s <executor> ", os.Args[0])
+	fmt.Fprintf(w, "%s <executor>[:<service>] ", os.Args[0])
 	lpad2 := buf.Len()
 	fmt.Fprintf(w, "supported\n")
 	printUsageLeftPadded(w, lpad2, "instanceID\n")
@@ -343,8 +664,15 @@ func printUsage() {
 	printUsageLeftPadded(w, lpad2, "localDevices <scanType>\n")
 	printUsageLeftPadded(w, lpad2, "wait <scanType> <attachToken> <timeout>\n")
 	printUsageLeftPadded(w, lpad2, "mounts\n")
-	printUsageLeftPadded(w, lpad2, "mount [-l label] [-o options] device path\n")
-	printUsageLeftPadded(w, lpad2, "umount path\n")
+	printUsageLeftPadded(
+		w, lpad2, "mount [-l label] [-o options] <device> <path>\n")
+	printUsageLeftPadded(w, lpad2, "umount <path>\n")
+	printUsageLeftPadded(
+		w, lpad2, "volumeCreate [-e] [-k encryptionKey] "+
+			"[-i iops] [-s size] [-t type] [-z zone] <name>\n")
+	printUsageLeftPadded(w, lpad2, "volumeRemove [-f] <id>\n")
+	printUsageLeftPadded(w, lpad2, "volumeAttach [-n nextDevice] [-f] <id>\n")
+	printUsageLeftPadded(w, lpad2, "volumeDetach [-f] <id>\n")
 	fmt.Fprintln(w)
 	executorVar := "executor:    "
 	printUsageLeftPadded(w, lpad1, executorVar)


### PR DESCRIPTION
This path adds the following commands to the executor:

* volumeCreate
* volumeRemove
* volumeAttach
* volumeDetach

Now storage platforms can participate in the above workflow logic on the client-side without being part of the libStorage client.