### PR TITLE
Ceph monitor port support (IPv4/IPv6)

### DIFF
--- a/drivers/storage/rbd/executor/rbd_executor.go
+++ b/drivers/storage/rbd/executor/rbd_executor.go
@@ -160,20 +160,9 @@ func getCephMonIPs() ([]net.IP, error) {
 
 	monStrings := strings.Split(strings.TrimSpace(string(out)), ",")
 
-	monIps := []net.IP{}
-
-	for _, mon := range monStrings {
-		host, _, err := net.SplitHostPort(mon)
-		if err != nil {
-			return nil, err
-		}
-		addrs, err := net.LookupIP(host)
-		if err != nil {
-			return nil, err
-		}
-		if len(addrs) > 0 {
-			monIps = append(monIps, addrs...)
-		}
+	monIps, err := utils.ParseMonitorAddresses(monStrings)
+	if err != nil {
+		return nil, err
 	}
 
 	return monIps, nil

--- a/drivers/storage/rbd/tests/rbd_test.go
+++ b/drivers/storage/rbd/tests/rbd_test.go
@@ -21,6 +21,7 @@ import (
 	// load the  driver
 	"github.com/codedellemc/libstorage/drivers/storage/rbd"
 	rbdx "github.com/codedellemc/libstorage/drivers/storage/rbd/executor"
+	rbdu "github.com/codedellemc/libstorage/drivers/storage/rbd/utils"
 )
 
 var (
@@ -104,6 +105,8 @@ var (
 	ipZeroDotTen    = net.ParseIP("192.168.0.10")
 	ipZeroDotTwenty = net.ParseIP("192.168.0.20")
 	ipZeroDotThirty = net.ParseIP("192.168.0.30")
+	ipv6            = net.ParseIP("2001:db8:85a3::8a2e:370:7334")
+	ipv6Local       = net.ParseIP("::1")
 )
 
 var testIPs = []testIPInput{
@@ -151,6 +154,51 @@ func TestInstanceIDSimulatedIPs(t *testing.T) {
 		if test.iid != nil {
 			assert.True(t, test.iid.Equal(net.ParseIP(iid.ID)))
 		}
+	}
+}
+
+type testAddrInput struct {
+	address []string
+	ip      net.IP
+}
+
+var testAddrs = []testAddrInput{
+	{
+		address: []string{"192.168.0.2"},
+		ip:      ipZeroDotTwo,
+	},
+	{
+		address: []string{"192.168.0.2:6789"},
+		ip:      ipZeroDotTwo,
+	},
+	{
+		address: []string{"[2001:db8:85a3::8a2e:370:7334]"},
+		ip:      ipv6,
+	},
+	{
+		address: []string{"[2001:db8:85a3::8a2e:370:7334]:6789"},
+		ip:      ipv6,
+	},
+	{
+		address: []string{"[::1]"},
+		ip:      ipv6Local,
+	},
+}
+
+func TestParseMonitorAddresses(t *testing.T) {
+	if skipTests() {
+		t.SkipNow()
+	}
+
+	for _, test := range testAddrs {
+		ip, err := rbdu.ParseMonitorAddresses(test.address)
+
+		assert.NoError(t, err, "failed with %s", test.address[0])
+		if err != nil {
+			t.Error("failed TestParseMonitorAddresses")
+			t.FailNow()
+		}
+		assert.True(t, test.ip.Equal(ip[0]))
 	}
 }
 
@@ -217,7 +265,7 @@ func volumeCreate(
 func volumeRemove(t *testing.T, client types.Client, volumeID string) {
 	log.WithField("volumeID", volumeID).Info("removing volume")
 	err := client.API().VolumeRemove(
-		nil, rbd.Name, volumeID)
+		nil, rbd.Name, volumeID, false)
 	assert.NoError(t, err)
 	if err != nil {
 		t.Error("failed volumeRemove")


### PR DESCRIPTION
Came across this during early testing for 0.5.0-RC2. Without this fix, any use of the rbd driver on clusters *without* a monitor port defined fails, which is likely the majority. This fixes a regression introduced by 1040f4c.

Previous fix to support Ceph monitors with non standard ports caused a
new issue for monitors *without* ports. The call to net.SplitHostPort()
fails if the string does not contain a ":".

Rework the parsing of monitor addresses to account for the
presence/absence of ports, both for IPv4 and IPv6. As it turns out, The
Ceph config file also requires that IPv6 addresses (but not ports!) be
enclosed by brackets, which is the same requirement for
net.SplitHostPort(), and is something taken advantage of in this patch.

Tests added to cover possible combinations. Tests pass (and in fact, made me rework this solution several times!)