### PR TITLE
Allow dashes in RBD names and pools

### DIFF
--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -662,6 +662,9 @@ volume ID is given as `<pool>.<name>`, a volume named *name* will be created in
 the *pool* storage pool. If no pool is referenced, the `defaultPool` will be
 used.
 
+Both *pool* and *name* may only contain alphanumeric characters, underscores,
+and dashes.
+
 When querying volumes, the driver will return all RBDs present in all pools in
 the cluster, prefixing each volume with the appropriate `<pool>.` value.
 

--- a/drivers/storage/rbd/storage/rbd_storage.go
+++ b/drivers/storage/rbd/storage/rbd_storage.go
@@ -20,6 +20,7 @@ import (
 const (
 	rbdDefaultOrder = 22
 	bytesPerGiB     = 1024 * 1024 * 1024
+	validNameRX     = `[0-9A-Za-z_\-]+`
 )
 
 var (
@@ -431,7 +432,8 @@ func (d *driver) toTypeVolumes(
 func (d *driver) parseVolumeID(name *string) (*string, *string, error) {
 
 	// Look for <pool>.<name>
-	re, _ := regexp.Compile(`^(\w+)\.(\w+)$`)
+	re, _ := regexp.Compile(
+		`^(` + validNameRX + `)\.(` + validNameRX + `)$`)
 	res := re.FindStringSubmatch(*name)
 	if len(res) == 3 {
 		// Name includes pool already
@@ -439,9 +441,10 @@ func (d *driver) parseVolumeID(name *string) (*string, *string, error) {
 	}
 
 	// make sure <name> is valid
-	re, _ = regexp.Compile(`^\w+$`)
+	re, _ = regexp.Compile(`^` + validNameRX + `$`)
 	if !re.MatchString(*name) {
-		return nil, nil, goof.New("Invalid VolumeID")
+		return nil, nil, goof.New(
+			"Invalid character(s) found in volume name")
 	}
 
 	pool := d.defaultPool()

--- a/drivers/storage/rbd/tests/rbd_test.go
+++ b/drivers/storage/rbd/tests/rbd_test.go
@@ -46,7 +46,7 @@ func init() {
 	uuid, _ := types.NewUUID()
 	uuids := strings.Split(uuid.String(), "-")
 	volumeName = uuids[0]
-	volumeName2 = uuids[1]
+	volumeName2 = uuids[1] + "-test"
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Document allowed characters, and return a better error message when
invalid characters are found