### PR TITLE
Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ go_import_path: github.com/codedellemc/libstorage
 
 language: go
 go:
-  - 1.6.3
   - 1.7.5
+  - 1.8
   - tip
 
 os:
@@ -16,7 +16,7 @@ env:
 
 matrix:
   allow_failures:
-    - go:  1.6.3
+    - go:  1.7.5
     - go:  tip
   fast_finish: true
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-GO_VERSION := 1.7.5
+GO_VERSION := 1.8
 
 ifeq (undefined,$(origin BUILD_TAGS))
 BUILD_TAGS :=   gofig \


### PR DESCRIPTION
This patch updates the libStorage build process to use Go 1.8 as the default version of Go for building the project on Travis-CI and via a Docker container.