### PR TITLE
Fix links between config and storage providers

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -583,13 +583,14 @@ remote storage systems. Currently the following storage drivers are supported:
 
  Driver | Driver Name
 --------|------------
-[Isilon](./storage-providers.md#isilon) | isilon
-[ScaleIO](./storage-providers.md#scaleio) | scaleio
+[Dell EMC Isilon](./storage-providers.md#dell-emc-isilon) | isilon
+[Dell EMC ScaleIO](./storage-providers.md#dell-emc-scaleio) | scaleio
 [VirtualBox](./storage-providers.md#virtualbox) | virtualbox
-[EBS](./storage-providers.md#aws-ebs) | ebs, ec2
-[EFS](./storage-providers.md#aws-efs) | efs
-[RBD](./storage-providers.md#ceph-rbd) | rbd
-[GCEPD](./storage-providers.md#gcepd) | gcepd
+[AWS EBS](./storage-providers.md#aws-ebs) | ebs, ec2
+[AWS EFS](./storage-providers.md#aws-efs) | efs
+[AWS S3FS](./storage-providers.md#aws-s3fs) | s3fs
+[Ceph RBD](./storage-providers.md#ceph-rbd) | rbd
+[GCE PD](./storage-providers.md#gce-persistent-disk) | gcepd
 [Azure UD](./storage-providers.md#azure-ud) | azureud
 
 The `libstorage.server.libstorage.storage.driver` property can be used to
@@ -691,13 +692,14 @@ libstorage:
 
 Driver|Supported
 ------|---------
-Isilon|Not yet
-ScaleIO|Yes
+Dell EMC Isilon|Not yet
+Dell EMC ScaleIO|Yes
 VirtualBox|Yes
-EBS|Yes
-EFS|No
-RBD|No
-GCEPD|Yes
+AWS EBS|Yes
+AWS EFS|No
+AWS S3FS|No
+Ceph RBD|No
+GCE PD|Yes
 Azure UD|Yes
 
 #### Ignore Used Count


### PR DESCRIPTION
The headings for several storage provers had changed, and these headings
change the URL for linking. The tables in the config guide needed to be
updated to reflect that.

At the same time, Add S3FS, and make the Driver titles consistent.