### PR TITLE
Enhanced Dev Docs / Build Tag Rebuilds

### DIFF
--- a/.docs/dev-guide/build-reference.md
+++ b/.docs/dev-guide/build-reference.md
@@ -27,7 +27,6 @@ Requirement | Version
 Operating System | Linux, OS X
 [Docker](https://www.docker.com/) | >=1.11
 [GNU Make](https://www.gnu.org/software/make/) | >=3.80
-[Git](https://git-scm.com/) | >= 1.7
 
 OS X ships with a very old version of GNU Make, and a package manager like
 [Homebrew](http://brew.sh/) can be used to install the required version.
@@ -54,6 +53,42 @@ how libStorage is built with Docker:
 | `DGOOS` | This sets the OS target for which to build the libStorage binaries. Valid values are `linux` and `darwin`. If omitted the host OS value returned from `uname -s` is used instead. |
 | `DLOCAL_IMPORTS` | Specify a list of space-delimited import paths that will be copied from the host OS's `GOPATH` into the container build's vendor area, overriding the dependency code that would normally be fetched by Glide.<br/><br/>For example, the project's `glide.yaml` file might specify to build REX-Ray with libStorage v0.2.1. However, the following command will build REX-Ray using the libStorage sources on the host OS at `$GOPATH/src/github.com/codedellemc/libstorage`:<br/><br/><pre lang="bash">$ DLOCAL_IMPORTS=github.com/codedellemc/libstorage make docker-build</pre>Using local sources can sometimes present a problem due to missing dependencies. Please see the next environment variable for instructions on how to overcome this issue. |
 | `DGLIDE_YAML` | Specify a file that will be used for the container build in place of the standard `glide.yaml` file.<br/><br/>This is necessary for occasions when sources injected into the build via the `DLOCAL_IMPORTS` variable import packages that are not imported by the package specified in the project's standard `glide.yaml` file.<br/><br/>For example, if `glide.yaml` specifies that libStorage depends upon AWS SDK v1.2.2, but `DLOCAL_IMPORTS` specifies the value `github.com/aws/aws-sdk-go` and the AWS SDK source code on the host includes a new dependency not present in the v1.2.2 version, Glide will not fetch the new dependency when doing the container build.<br/><br/>So it may be necessary to use `DGLIDE_YAML` to provide a superset of the project's standard `glide.yaml` file which also includes the dependencies necessary to build the packages specified in `DLOCAL_IMPORTS`. |
+
+### Basic Build Notes
+This section outlines particular points of interest about basic builds.
+
+#### Git Is Not Required
+The example at the top of this section uses `git` in order to provide a
+simplified approach, but `git` is not actually a requirement for performing
+basic builds. A libStorage project directory is not even required to be a valid,
+initialized git repository. For example, here is a variation of the basic-build
+one-liner that doesn't use `git` at all:
+
+```bash
+curl -sSLO https://github.com/codedellemc/libstorage/archive/master.zip && \
+    unzip master.zip && \
+    rm -f master.zip && \
+    make -C libstorage-master
+```
+
+The above example is not as concise as the one with `git`, hence why the latter
+was preferred for a first-look at performing basic builds. However, for systems
+that do not have `git` installed, it's still very easy to build libStorage.
+
+In fact, it's possible to build branches from the primary repository or forks
+this way as well. To build the branch `feature/new-driver` or the fork `akutz`,
+the following variation of the above command would be used:
+
+```bash
+curl -sSLO https://github.com/akutz/libstorage/archive/feature/new-driver.zip && \
+    unzip new-driver.zip && \
+    rm -f new-driver.zip && \
+    make -C libstorage-feature-new-driver
+```
+
+Please note in the above command that when a branch contains a `/` character it
+is replaced with a `-` as part of the directory name when the zip file is
+inflated.
 
 ## Advanced Builds
 While building libStorage with Docker is simple, it ultimately relies on the

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.buildtags
 *.*-e
 .*-e
 *-e

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,14 @@ BUILD_TAGS += libstorage_storage_driver libstorage_storage_executor
 BUILD_TAGS += $(foreach d,$(DRIVERS),libstorage_storage_driver_$(d) libstorage_storage_executor_$(d))
 endif
 
-ifneq (,$(BUILD_TAGS))
+ifneq (,$(strip $(BUILD_TAGS)))
 BUILD_TAGS := $(sort $(BUILD_TAGS))
+ifneq (,$(wildcard .buildtags))
+SAVED_BUILD_TAGS := $(shell cat .buildtags)
+endif
+ifneq ($(BUILD_TAGS),$(SAVED_BUILD_TAGS))
+$(file > .buildtags,$(BUILD_TAGS))
+endif
 endif
 
 all:
@@ -49,7 +55,20 @@ ifeq (1,$(DBUILD_ONCE))
 DNAME := $(DNAME)-$(shell date +%s)
 endif
 DPATH := /go/src/$(DPKG)
+ifneq (,$(wildcard .git))
 DSRCS := $(shell git ls-files)
+DGIT_DIR := .git
+else
+DSRCS := $(shell find . -type f)
+DOCKER_GIT_INIT := if [ ! -d $(DPATH)/.git ]; then
+DOCKER_GIT_INIT += git -C $(DPATH) init &> /dev/null &&
+DOCKER_GIT_INIT += git -C $(DPATH) config user.name  "root" &> /dev/null &&
+DOCKER_GIT_INIT += git -C $(DPATH) config user.email "root@localhost" &> /dev/null &&
+DOCKER_GIT_INIT += git -C $(DPATH) add -A &> /dev/null &&
+DOCKER_GIT_INIT += git -C $(DPATH) commit -m "Initial commit" &> /dev/null &&
+DOCKER_GIT_INIT += git -C $(DPATH) tag -a v0.1.0 -m v0.1.0 &> /dev/null;
+DOCKER_GIT_INIT += fi;
+endif
 ifneq (,$(DGLIDE_YAML))
 DSRCS := $(filter-out glide.yaml,$(DSRCS))
 DSRCS := $(filter-out glide.lock,$(DSRCS))
@@ -88,7 +107,10 @@ docker-init:
 	@if ! $(DIMG_EXISTS); then docker pull $(DIMG); fi
 	@docker run --name $(DNAME) -d $(DIMG) /sbin/init -D &> /dev/null || true && \
 		docker exec $(DNAME) mkdir -p $(DPATH) && \
-		tar -c $(DTARC) .git $(DSRCS) | docker cp - $(DNAME):$(DPATH)
+		tar -c $(DTARC) $(DGIT_DIR) $(DSRCS) | docker cp - $(DNAME):$(DPATH)
+ifeq (,$(strip $(wildcard .git)))
+	@docker exec -t $(DNAME) bash -c '$(DOCKER_GIT_INIT)'
+endif
 ifneq (,$(DGLIDE_YAML))
 	@docker cp $(DGLIDE_YAML) $(DNAME):$(DPATH)/glide.yaml
 endif
@@ -471,7 +493,7 @@ ifeq (,$(strip $(wildcard $(GLIDE_LOCK))))
 $(GLIDE_LOCK_D): $(GLIDE_LOCK) | $(GLIDE)
 	touch $@
 
-$(GLIDE_LOCK): $(GLIDE_YAML)
+$(GLIDE_LOCK): .buildtags $(GLIDE_YAML)
 	$(GLIDE) up
 
 else #ifeq (,$(strip $(wildcard $(GLIDE_LOCK))))
@@ -479,7 +501,7 @@ else #ifeq (,$(strip $(wildcard $(GLIDE_LOCK))))
 $(GLIDE_LOCK_D): $(GLIDE_LOCK) | $(GLIDE)
 	$(GLIDE) install && touch $@
 
-$(GLIDE_LOCK): $(GLIDE_YAML)
+$(GLIDE_LOCK): .buildtags $(GLIDE_YAML)
 	$(GLIDE) up && touch $@ && touch $(GLIDE_LOCK_D)
 
 endif #ifeq (,$(strip $(wildcard $(GLIDE_LOCK))))
@@ -728,7 +750,7 @@ ifneq (1,$$(C_$1))
 
 DEPS_SRCS_$1 := $$(foreach d,$$(INT_DEPS_$1),$$(SRCS_.$$(subst $$(ROOT_IMPORT_PATH),,$$(d))))
 
-$$(PKG_D_$1): $$(filter-out %_generated.go,$$(SRCS_$1))
+$$(PKG_D_$1): .buildtags $$(filter-out %_generated.go,$$(SRCS_$1))
 	$$(file >$$@,$$(PKG_A_$1) $$(PKG_D_$1): $$(filter-out %_generated.go,$$(DEPS_SRCS_$1)))
 
 -include $$(PKG_D_$1)
@@ -766,7 +788,7 @@ ifneq (1,$$(TEST_C_$1))
 
 TEST_DEPS_SRCS_$1 := $$(foreach d,$$(TEST_INT_DEPS_$1),$$(SRCS_.$$(subst $$(ROOT_IMPORT_PATH),,$$(d))))
 
-$$(PKG_TD_$1): $$(filter-out %_generated.go,$$(TEST_SRCS_$1))
+$$(PKG_TD_$1): .buildtags $$(filter-out %_generated.go,$$(TEST_SRCS_$1))
 	$$(file >$$@,$$(PKG_TA_$1) $$(PKG_TD_$1): $$(filter-out %_generated.go,$$(TEST_DEPS_SRCS_$1)))
 
 $$(PKG_TD_$1)-clean:


### PR DESCRIPTION
This patch further enhances the developer documentation. Additionally, two builds that differ only by their build tags will now trigger a rebuild. For example `$ DRIVERS=ebs make` builds libStorage with support for only the EBS driver. Previously a subsequent `$ DRIVERS=scaleio make` would not result in a rebuild. Now it will.