### PR TITLE
Handle varying output formats for rbd status

### DIFF
--- a/drivers/storage/rbd/executor/rbd_executor.go
+++ b/drivers/storage/rbd/executor/rbd_executor.go
@@ -76,7 +76,7 @@ func (d *driver) LocalDevices(
 	ctx types.Context,
 	opts *types.LocalDevicesOpts) (*types.LocalDevices, error) {
 
-	devMap, err := utils.GetMappedRBDs()
+	devMap, err := utils.GetMappedRBDs(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The output for rbd status --format json has been updated recently
to have the "watchers" field be an array instead of a map. Account
for that.

Fixes #451 