### PR TITLE
Parse Request Opts Config Option

### DIFF
--- a/api/server/router/snapshot/snapshot.go
+++ b/api/server/router/snapshot/snapshot.go
@@ -81,7 +81,7 @@ func (r *router) initRoutes() {
 				schema.VolumeCreateRequestSchema,
 				schema.VolumeSchema,
 				func() interface{} { return &types.VolumeCreateRequest{} }),
-			handlers.NewPostArgsHandler(),
+			handlers.NewPostArgsHandler(r.config),
 		).Queries("create"),
 
 		// copy snapshot
@@ -97,7 +97,7 @@ func (r *router) initRoutes() {
 				func() interface{} {
 					return &types.SnapshotCopyRequest{}
 				}),
-			handlers.NewPostArgsHandler(),
+			handlers.NewPostArgsHandler(r.config),
 		).Queries("copy"),
 
 		// DELETE

--- a/api/server/router/volume/volume.go
+++ b/api/server/router/volume/volume.go
@@ -92,7 +92,7 @@ func (r *router) initRoutes() {
 				schema.VolumeDetachRequestSchema,
 				schema.VolumeMapSchema,
 				func() interface{} { return &types.VolumeDetachRequest{} }),
-			handlers.NewPostArgsHandler(),
+			handlers.NewPostArgsHandler(r.config),
 		).Queries("detach"),
 
 		// create a new volume
@@ -106,7 +106,7 @@ func (r *router) initRoutes() {
 				schema.VolumeCreateRequestSchema,
 				schema.VolumeSchema,
 				func() interface{} { return &types.VolumeCreateRequest{} }),
-			handlers.NewPostArgsHandler(),
+			handlers.NewPostArgsHandler(r.config),
 		),
 
 		// create a new volume using an existing volume as the baseline
@@ -120,7 +120,7 @@ func (r *router) initRoutes() {
 				schema.VolumeCopyRequestSchema,
 				schema.VolumeSchema,
 				func() interface{} { return &types.VolumeCopyRequest{} }),
-			handlers.NewPostArgsHandler(),
+			handlers.NewPostArgsHandler(r.config),
 		).Queries("copy"),
 
 		// snapshot an existing volume
@@ -134,7 +134,7 @@ func (r *router) initRoutes() {
 				schema.VolumeSnapshotRequestSchema,
 				schema.SnapshotSchema,
 				func() interface{} { return &types.VolumeSnapshotRequest{} }),
-			handlers.NewPostArgsHandler(),
+			handlers.NewPostArgsHandler(r.config),
 		).Queries("snapshot"),
 
 		// attach an existing volume
@@ -148,7 +148,7 @@ func (r *router) initRoutes() {
 				schema.VolumeAttachRequestSchema,
 				schema.VolumeSchema,
 				func() interface{} { return &types.VolumeAttachRequest{} }),
-			handlers.NewPostArgsHandler(),
+			handlers.NewPostArgsHandler(r.config),
 		).Queries("attach"),
 
 		// detach all volumes for all services
@@ -160,7 +160,7 @@ func (r *router) initRoutes() {
 				schema.VolumeDetachRequestSchema,
 				schema.ServiceVolumeMapSchema,
 				func() interface{} { return &types.VolumeDetachRequest{} }),
-			handlers.NewPostArgsHandler(),
+			handlers.NewPostArgsHandler(r.config),
 		).Queries("detach"),
 
 		// detach an individual volume
@@ -174,7 +174,7 @@ func (r *router) initRoutes() {
 				schema.VolumeDetachRequestSchema,
 				schema.VolumeSchema,
 				func() interface{} { return &types.VolumeDetachRequest{} }),
-			handlers.NewPostArgsHandler(),
+			handlers.NewPostArgsHandler(r.config),
 		).Queries("detach"),
 
 		// DELETE

--- a/api/types/types_config.go
+++ b/api/types/types_config.go
@@ -75,6 +75,9 @@ const (
 	// ConfigEndpoints is a config key.
 	ConfigEndpoints = ConfigServer + ".endpoints"
 
+	// ConfigServerParseRequestOpts is a config key.
+	ConfigServerParseRequestOpts = ConfigServer + ".parseRequestOpts"
+
 	// ConfigExecutorPath is a config key.
 	ConfigExecutorPath = ConfigRoot + ".executor.path"
 

--- a/drivers/storage/vfs/storage/vfs_storage.go
+++ b/drivers/storage/vfs/storage/vfs_storage.go
@@ -207,6 +207,32 @@ func (d *driver) VolumeCreate(
 	name string,
 	opts *types.VolumeCreateOpts) (*types.Volume, error) {
 
+	fields := map[string]interface{}{"name": name}
+	if opts != nil {
+		if opts.AvailabilityZone != nil {
+			fields["availabilityZone"] = *opts.AvailabilityZone
+		}
+		if opts.Encrypted != nil {
+			fields["encrypted"] = *opts.Encrypted
+		}
+		if opts.EncryptionKey != nil {
+			fields["encryptionKey"] = *opts.EncryptionKey
+		}
+		if opts.IOPS != nil {
+			fields["iops"] = *opts.IOPS
+		}
+		if opts.Size != nil {
+			fields["size"] = *opts.Size
+		}
+		if opts.Type != nil {
+			fields["type"] = *opts.Type
+		}
+		//if opts.Opts != nil {
+		//	fields["opts"] = opts.Opts
+		//}
+	}
+	ctx.WithFields(fields).Debug("creating volume")
+
 	context.MustSession(ctx)
 
 	v := &types.Volume{
@@ -226,6 +252,9 @@ func (d *driver) VolumeCreate(
 	}
 	if opts.Type != nil {
 		v.Type = *opts.Type
+	}
+	if opts.Encrypted != nil {
+		v.Encrypted = *opts.Encrypted
 	}
 	if customFields := opts.Opts.GetStore("opts"); customFields != nil {
 		for _, k := range customFields.Keys() {

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -499,6 +499,54 @@ func TestVolumeCreate(t *testing.T) {
 		assertVolDir(t, config, reply.ID, true)
 		assert.Equal(t, availabilityZone, reply.AvailabilityZone)
 		assert.Equal(t, iops, reply.IOPS)
+		assert.False(t, reply.Encrypted)
+		assert.Equal(t, volumeName, reply.Name)
+		assert.Equal(t, size, reply.Size)
+		assert.Equal(t, volType, reply.Type)
+		assert.Equal(t, "2", reply.Fields["priority"])
+		assert.Equal(t, "root@example.com", reply.Fields["owner"])
+	}
+
+	apitests.Run(t, vfs.Name, newTestConfig(t), tf)
+}
+
+func TestVolumeCreateParseRequestOpts(t *testing.T) {
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+
+		config.Set(types.ConfigServerParseRequestOpts, true)
+
+		volumeName := "Volume 003"
+		availabilityZone := "US"
+		iops := int64(1000)
+		size := int64(10240)
+		volType := "myType"
+
+		opts := map[string]interface{}{
+			"priority":  2,
+			"owner":     "root@example.com",
+			"encrypted": true,
+		}
+
+		request := &types.VolumeCreateRequest{
+			Name:             volumeName,
+			AvailabilityZone: &availabilityZone,
+			IOPS:             &iops,
+			Size:             &size,
+			Type:             &volType,
+			Opts:             opts,
+		}
+
+		reply, err := client.API().VolumeCreate(nil, vfs.Name, request)
+		assert.NoError(t, err)
+		if err != nil {
+			t.FailNow()
+		}
+		assert.NotNil(t, reply)
+
+		assertVolDir(t, config, reply.ID, true)
+		assert.Equal(t, availabilityZone, reply.AvailabilityZone)
+		assert.Equal(t, iops, reply.IOPS)
+		assert.True(t, reply.Encrypted)
 		assert.Equal(t, volumeName, reply.Name)
 		assert.Equal(t, size, reply.Size)
 		assert.Equal(t, volType, reply.Type)

--- a/imports/config/imports_config_99_gofig.go
+++ b/imports/config/imports_config_99_gofig.go
@@ -81,6 +81,7 @@ func init() {
 	rk(gofig.Bool, false, "", types.ConfigEmbedded)
 	rk(gofig.String, "1m", "", types.ConfigServerTasksExeTimeout)
 	rk(gofig.String, "0s", "", types.ConfigServerTasksLogTimeout)
+	rk(gofig.Bool, false, "", types.ConfigServerParseRequestOpts)
 
 	gofigCore.Register(r)
 }


### PR DESCRIPTION
This patch defines a new configuration property `libstorage.server.parseRequestOpts`. When this property is set to true, incoming POST requests will be parsed for an opts field, and key/value pairs in the opts field's map will be promoted to the request proper.

For example, the following volume creation POST request bodies are now equivalent when the above property is enabled:

## Classic Request
```json
{
    "name":      "newVolume",
    "encrypted": true
}
```

## With Opts Request
```json
{
    "name": "newVolume",
    "opts": {
        "encrypted": true
    }
}
```