### PR TITLE
Always return err if volume is not found

### DIFF
--- a/drivers/storage/ebs/storage/ebs_storage.go
+++ b/drivers/storage/ebs/storage/ebs_storage.go
@@ -25,6 +25,7 @@ import (
 	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/registry"
 	"github.com/codedellemc/libstorage/api/types"
+	apiUtils "github.com/codedellemc/libstorage/api/utils"
 	"github.com/codedellemc/libstorage/drivers/storage/ebs"
 	ebsUtils "github.com/codedellemc/libstorage/drivers/storage/ebs/utils"
 )
@@ -271,7 +272,7 @@ func (d *driver) VolumeInspect(
 		return nil, goof.WithError("error getting volume", err)
 	}
 	if len(ec2vols) == 0 {
-		return nil, errNoVolReturned
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 	vols, convErr := d.toTypesVolume(ctx, ec2vols, opts.Attachments)
 	if convErr != nil {

--- a/drivers/storage/efs/storage/efs_storage.go
+++ b/drivers/storage/efs/storage/efs_storage.go
@@ -25,6 +25,7 @@ import (
 	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/registry"
 	"github.com/codedellemc/libstorage/api/types"
+	apiUtils "github.com/codedellemc/libstorage/api/utils"
 	"github.com/codedellemc/libstorage/drivers/storage/efs"
 )
 
@@ -349,14 +350,15 @@ func (d *driver) VolumeInspect(
 	}
 
 	if len(resp.FileSystems) == 0 {
-		return nil, types.ErrNotFound{}
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 
 	fileSystem := resp.FileSystems[0]
 
 	// Only volumes in "available" state
 	if *fileSystem.LifeCycleState != awsefs.LifeCycleStateAvailable {
-		return nil, nil
+		return nil, goof.WithField("volumeID", volumeID,
+			"Volume not available")
 	}
 
 	// Name is optional via tag so make sure it exists

--- a/drivers/storage/fittedcloud/storage/fittedcloud_storage.go
+++ b/drivers/storage/fittedcloud/storage/fittedcloud_storage.go
@@ -274,7 +274,7 @@ func (d *driver) VolumeInspect(
 		return nil, goof.WithError("error getting volume", err)
 	}
 	if len(ec2vols) == 0 {
-		return nil, errNoVolReturned
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 	vols, convErr := d.toTypesVolume(ctx, ec2vols, opts.Attachments)
 	if convErr != nil {

--- a/drivers/storage/gcepd/storage/gce_storage.go
+++ b/drivers/storage/gcepd/storage/gce_storage.go
@@ -23,6 +23,7 @@ import (
 	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/registry"
 	"github.com/codedellemc/libstorage/api/types"
+	apiUtils "github.com/codedellemc/libstorage/api/utils"
 	"github.com/codedellemc/libstorage/drivers/storage/gcepd"
 	"github.com/codedellemc/libstorage/drivers/storage/gcepd/utils"
 
@@ -303,7 +304,7 @@ func (d *driver) VolumeInspect(
 			"Unable to get disk from GCE API", err)
 	}
 	if gceDisk == nil {
-		return nil, goof.New("No Volume Found")
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 
 	gceDisks := []*compute.Disk{gceDisk}
@@ -473,7 +474,7 @@ func (d *driver) VolumeAttach(
 		return nil, "", err
 	}
 	if gceDisk == nil {
-		return nil, "", goof.New("Volume not found")
+		return nil, "", apiUtils.NewNotFoundError(volumeID)
 	}
 
 	if len(gceDisk.Users) > 0 {
@@ -529,7 +530,7 @@ func (d *driver) VolumeDetach(
 		return nil, err
 	}
 	if gceDisk == nil {
-		return nil, goof.New("Volume not found")
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 
 	if len(gceDisk.Users) == 0 {

--- a/drivers/storage/isilon/storage/isilon_storage.go
+++ b/drivers/storage/isilon/storage/isilon_storage.go
@@ -16,6 +16,7 @@ import (
 	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/registry"
 	"github.com/codedellemc/libstorage/api/types"
+	apiUtils "github.com/codedellemc/libstorage/api/utils"
 	"github.com/codedellemc/libstorage/drivers/storage/isilon"
 )
 
@@ -245,7 +246,7 @@ func (d *driver) VolumeInspect(
 	}
 
 	if vols == nil {
-		return nil, nil
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 
 	return vols[0], nil
@@ -349,9 +350,6 @@ func (d *driver) VolumeAttach(
 	if err != nil {
 		return nil, "", err
 	}
-	if vol == nil {
-		return nil, "", goof.New("no volumes returned")
-	}
 
 	exportID, err := d.client.ExportVolume(ctx, volumeID)
 	if err != nil {
@@ -423,14 +421,10 @@ func (d *driver) VolumeDetach(
 	d.Lock()
 	defer d.Unlock()
 
-	vol, err := d.VolumeInspect(ctx, volumeID,
+	_, err := d.VolumeInspect(ctx, volumeID,
 		&types.VolumeInspectOpts{Attachments: 0})
 	if err != nil {
 		return nil, err
-	}
-
-	if vol == nil {
-		return nil, goof.New("no volumes returned")
 	}
 
 	instanceID, err := d.InstanceInspect(ctx, nil)

--- a/drivers/storage/rackspace/storage/rackspace_storage.go
+++ b/drivers/storage/rackspace/storage/rackspace_storage.go
@@ -15,6 +15,7 @@ import (
 	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/registry"
 	"github.com/codedellemc/libstorage/api/types"
+	apiUtils "github.com/codedellemc/libstorage/api/utils"
 	"github.com/codedellemc/libstorage/drivers/storage/rackspace"
 
 	"github.com/rackspace/gophercloud"
@@ -158,7 +159,7 @@ func (d *driver) VolumeInspect(
 	}
 
 	if vols == nil {
-		return nil, nil
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 	return vols[0], nil
 }

--- a/drivers/storage/rbd/storage/rbd_storage.go
+++ b/drivers/storage/rbd/storage/rbd_storage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/registry"
 	"github.com/codedellemc/libstorage/api/types"
+	apiUtils "github.com/codedellemc/libstorage/api/utils"
 	"github.com/codedellemc/libstorage/drivers/storage/rbd"
 	"github.com/codedellemc/libstorage/drivers/storage/rbd/utils"
 )
@@ -115,7 +116,7 @@ func (d *driver) VolumeInspect(
 
 	// no volume returned
 	if info == nil {
-		return nil, nil
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 
 	/* GetRBDInfo returns more details about an image than what we get back
@@ -257,6 +258,9 @@ func (d *driver) VolumeAttach(
 			Attachments: types.VolAttReq,
 		})
 	if err != nil {
+		if _, ok := err.(*types.ErrNotFound); ok {
+			return nil, "", err
+		}
 		return nil, "", goof.WithError("error getting volume", err)
 	}
 

--- a/drivers/storage/s3fs/storage/s3fs_storage.go
+++ b/drivers/storage/s3fs/storage/s3fs_storage.go
@@ -19,7 +19,7 @@ import (
 	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/registry"
 	"github.com/codedellemc/libstorage/api/types"
-	"github.com/codedellemc/libstorage/api/utils"
+	apiUtils "github.com/codedellemc/libstorage/api/utils"
 
 	"github.com/codedellemc/libstorage/drivers/storage/s3fs"
 	s3fsUtils "github.com/codedellemc/libstorage/drivers/storage/s3fs/utils"
@@ -474,9 +474,7 @@ func (d *driver) VolumeAttach(
 
 	vol, err := d.getVolume(ctx, volumeID, types.VolAttReq)
 	if err != nil {
-		return nil, "", goof.WithFieldE(
-			"volumeID", volumeID,
-			"volume is not in bucket list", err)
+		return nil, "", err
 	}
 	return vol, "", nil
 }
@@ -489,9 +487,7 @@ func (d *driver) VolumeDetach(
 
 	vol, err := d.getVolume(ctx, volumeID, types.VolAttReq)
 	if err != nil {
-		return nil, goof.WithFieldE(
-			"volumeID", volumeID,
-			"volume is not in bucket list", err)
+		return nil, err
 	}
 	return vol, nil
 }
@@ -591,7 +587,7 @@ func (d *driver) getVolume(
 	svc, _ := d.getService(ctx, "")
 	req, _ := svc.HeadBucketRequest(&awss3.HeadBucketInput{Bucket: &volumeID})
 	if err := req.Send(); err != nil && req.HTTPResponse.StatusCode != 301 {
-		return nil, utils.NewNotFoundError(volumeID)
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 	return d.toTypeVolume(ctx, volumeID, attachments), nil
 }
@@ -604,7 +600,7 @@ func (d *driver) getServiceForBucket(
 	res, err := svc.GetBucketLocation(
 		&awss3.GetBucketLocationInput{Bucket: &bucket})
 	if err != nil {
-		return nil, utils.NewNotFoundError(bucket)
+		return nil, apiUtils.NewNotFoundError(bucket)
 	}
 	var region string
 	if res.LocationConstraint != nil {

--- a/drivers/storage/vbox/storage/vbox_storage.go
+++ b/drivers/storage/vbox/storage/vbox_storage.go
@@ -17,6 +17,7 @@ import (
 	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/registry"
 	"github.com/codedellemc/libstorage/api/types"
+	apiUtils "github.com/codedellemc/libstorage/api/utils"
 	"github.com/codedellemc/libstorage/drivers/storage/vbox"
 )
 
@@ -163,7 +164,7 @@ func (d *driver) getVolumeMapping(ctx types.Context) ([]*types.Volume, error) {
 		return nil, err
 	}
 
-	if err := m.Refresh(); err != nil {
+	if err = m.Refresh(); err != nil {
 		return nil, err
 	}
 	defer m.Release()
@@ -336,14 +337,14 @@ func (d *driver) VolumeAttach(
 	}
 
 	if len(volumes) == 0 {
-		return nil, "", goof.New("no volume found")
+		return nil, "", apiUtils.NewNotFoundError(volumeID)
 	}
 
 	if len(volumes[0].Attachments) > 0 && !opts.Force {
 		return nil, "", goof.New("volume already attached to a host")
 	}
 	if opts.Force {
-		if _, err := d.VolumeDetach(ctx, volumeID, nil); err != nil {
+		if _, err = d.VolumeDetach(ctx, volumeID, nil); err != nil {
 			return nil, "", err
 		}
 	}
@@ -393,7 +394,7 @@ func (d *driver) VolumeDetach(
 	}
 
 	if len(volumes) == 0 {
-		return nil, goof.New("no volume returned")
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 
 	// TODO: Check if volumes[[0].Attachments > 0?
@@ -474,7 +475,7 @@ func (d *driver) VolumeInspect(
 		return nil, err
 	}
 	if len(vols) == 0 {
-		return nil, goof.New("no volumes returned")
+		return nil, apiUtils.NewNotFoundError(volumeID)
 	}
 	return vols[0], nil
 }
@@ -674,7 +675,7 @@ func (d *driver) attachVolume(
 		return err
 	}
 
-	if err := m.Refresh(); err != nil {
+	if err = m.Refresh(); err != nil {
 		return err
 	}
 	defer m.Release()
@@ -708,7 +709,7 @@ func (d *driver) detachVolume(
 		return err
 	}
 
-	if err := m.Refresh(); err != nil {
+	if err = m.Refresh(); err != nil {
 		return err
 	}
 	defer m.Release()


### PR DESCRIPTION
From VolumeInspect, it is not allowed to return nil, nil if the
referenced volume is not found. However, several drivers do so, and this
can lead to a nil dereference.

Fixes #396 