### PR TITLE
Embed Apiary Docs

### DIFF
--- a/.docs/.themes/yeti/base.html
+++ b/.docs/.themes/yeti/base.html
@@ -47,13 +47,19 @@
 
     </head>
 
-    <body>
+    <body {% if page_title == "API" %}class="body-api"{% endif %}>
 
         {% include "nav.html" %}
+        {% if page_title == "API" %}
+        <!-- import the apiary embed js -->
+        <script src="https://api.apiary.io/seeds/embed.js"></script>
+        {{ content }}
+        {% else %}
         <div class="container {% if not page_title %}index{% endif %}">
             <div class="col-md-3">{% include "toc.html" %}</div>
             <div class="col-md-9" role="main">{% include "content.html" %}</div>
         </div>
+        {% endif %}
 
         <script src="{{ base_url }}/js/jquery-1.10.2.min.js"></script>
         <script src="{{ base_url }}/js/bootstrap-3.0.3.min.js"></script>
@@ -64,6 +70,7 @@
         <script src="{{ path }}"></script>
         {%- endfor %}
         -->
+
     </body>
 
 </html>

--- a/.docs/.themes/yeti/css/emccode.css
+++ b/.docs/.themes/yeti/css/emccode.css
@@ -18,3 +18,7 @@ a.headerlink.hiddenanchor {
     padding:     0 !important;
     margin:      0 !important;
 }
+
+body.body-api {
+    padding-top: 45px;
+}

--- a/.docs/api.md
+++ b/.docs/api.md
@@ -1,0 +1,12 @@
+<script>
+var embed = new Apiary.Embed({
+    "subdomain": "libstorage",
+    "preferences": {
+        "console":                          false,
+        "collapseMachineColumnByDefault":   true,
+        "fluidHumanColumn":                 true,
+        "permalinks":                       true,
+        "displayHttpMethods":               true
+  }
+});
+</script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ pages:
     - Project Guidelines: dev-guide/project-guidelines.md
     - Build Reference: dev-guide/build-reference.md
     - Release Process: dev-guide/release-process.md
+- API: api.md
 - About:
     - Contributing: about/contributing.md
     - License: about/license.md


### PR DESCRIPTION
This patch adds a new top-level API menu to the RTFD site and embeds the Apiary documentation as part of the RTFD pages. The Apiary documentation even generates links relative to the RTFD site:

![image](https://cloud.githubusercontent.com/assets/101085/24391491/0b89ce96-1355-11e7-879b-a1909b1d6a5c.png)

