### PR TITLE
Volume Requests w Missing IID/LocDevs ret 400

### DIFF
--- a/api/server/handlers/handlers_errors.go
+++ b/api/server/handlers/handlers_errors.go
@@ -52,6 +52,9 @@ func getStatus(err error) int {
 		return http.StatusUnauthorized
 	case *types.ErrNotFound:
 		return http.StatusNotFound
+	case *types.ErrMissingInstanceID,
+		*types.ErrMissingLocalDevices:
+		return http.StatusBadRequest
 	default:
 		return http.StatusInternalServerError
 	}

--- a/api/types/types_errors.go
+++ b/api/types/types_errors.go
@@ -22,6 +22,10 @@ type ErrBadAdminToken struct{ goof.Goof }
 // resource that cannot be found.
 type ErrNotFound struct{ goof.Goof }
 
+// ErrMissingLocalDevices occurs when an operation requires local devices
+// and they're missing.
+type ErrMissingLocalDevices struct{ goof.Goof }
+
 // ErrMissingInstanceID occurs when an operation requires the instance ID for
 // the configured service to be avaialble.
 type ErrMissingInstanceID struct{ goof.Goof }

--- a/api/utils/utils_errors.go
+++ b/api/utils/utils_errors.go
@@ -38,6 +38,13 @@ func NewMissingInstanceIDError(service string) error {
 	}
 }
 
+// NewMissingLocalDevicesError returns a new ErrMissingLocalDevices error.
+func NewMissingLocalDevicesError(service string) error {
+	return &types.ErrMissingLocalDevices{
+		Goof: goof.WithField("service", service, "missing local devices"),
+	}
+}
+
 // NewStoreKeyErr returns a new ErrStoreKey error.
 func NewStoreKeyErr(key string) error {
 	return &types.ErrStoreKey{


### PR DESCRIPTION
This patch handles issue #352 so that API requests with an attachment mask that requires either an instance ID or local devices map will return HTTP status 400 (bad request) rather than HTTP status 500 (server-side error).