### PR TITLE
Add minimum vol size, reject request too small

### DIFF
--- a/drivers/storage/azureud/storage/azure_storage.go
+++ b/drivers/storage/azureud/storage/azure_storage.go
@@ -46,6 +46,8 @@ const (
 
 	// Default new disk size
 	defaultNewDiskSizeGB int32 = 128
+
+	minSizeGiB = 1
 )
 
 type driver struct {
@@ -347,14 +349,14 @@ func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
 	}
 
 	size := int64(defaultNewDiskSizeGB)
-	if opts.Size != nil && *opts.Size != 0 {
+	if opts.Size != nil && *opts.Size >= minSizeGiB {
 		size = *opts.Size
 	}
 	size *= size1GB
 
 	fields := map[string]interface{}{
-		"volumeName":    volumeName,
-		"size_in_bytes": size,
+		"volumeName":  volumeName,
+		"sizeInBytes": size,
 	}
 
 	blobClient := mustSession(ctx).blobClient

--- a/drivers/storage/fittedcloud/storage/fittedcloud_storage.go
+++ b/drivers/storage/fittedcloud/storage/fittedcloud_storage.go
@@ -40,6 +40,8 @@ const (
 	waitVolumeAttach = "attach"
 	// waitVolumeDetach signifies to wait for volume detachment to complete
 	waitVolumeDetach = "detach"
+
+	minSizeGiB = 1
 )
 
 type driver struct {
@@ -296,7 +298,19 @@ func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
 		"opts":       opts,
 	}
 
-	log.WithFields(fields).Debug("creating volume")
+	ctx.WithFields(fields).Debug("creating volume")
+
+	if opts.Size == nil {
+		size := int64(minSizeGiB)
+		opts.Size = &size
+	}
+
+	fields["size"] = *opts.Size
+
+	if *opts.Size < minSizeGiB {
+		fields["minSize"] = minSizeGiB
+		return nil, goof.WithFields(fields, "volume size too small")
+	}
 
 	// Check if volume with same name exists
 	ec2vols, err := d.getVolume(ctx, "", volumeName)

--- a/drivers/storage/vfs/storage/vfs_storage.go
+++ b/drivers/storage/vfs/storage/vfs_storage.go
@@ -18,6 +18,10 @@ import (
 	"github.com/codedellemc/libstorage/drivers/storage/vfs"
 )
 
+const (
+	minSizeGiB = 1
+)
+
 type driver struct {
 	ctx    types.Context
 	config gofig.Config
@@ -221,9 +225,11 @@ func (d *driver) VolumeCreate(
 		if opts.IOPS != nil {
 			fields["iops"] = *opts.IOPS
 		}
-		if opts.Size != nil {
-			fields["size"] = *opts.Size
+		if opts.Size == nil {
+			size := int64(minSizeGiB)
+			opts.Size = &size
 		}
+		fields["size"] = *opts.Size
 		if opts.Type != nil {
 			fields["type"] = *opts.Type
 		}
@@ -247,9 +253,8 @@ func (d *driver) VolumeCreate(
 	if opts.IOPS != nil {
 		v.IOPS = *opts.IOPS
 	}
-	if opts.Size != nil {
-		v.Size = *opts.Size
-	}
+	v.Size = *opts.Size
+
 	if opts.Type != nil {
 		v.Type = *opts.Type
 	}


### PR DESCRIPTION
For each driver that uses the opt.Size field to create a volume with the
requested size, set a minimum volume size. If the incoming request does
not set a size, default to that minimum size. If the incoming request
does set a size, make sure that it is >= to the minimum size. If it is
not, return an error.

This touches all drivers except those that are not block devices -- Isilon, S3FS, EFS.

Fixes #459 