### PR TITLE
Rename TaskExecute to TaskEnqueue for clarity

### DIFF
--- a/api/server/router/snapshot/snapshot_routes.go
+++ b/api/server/router/snapshot/snapshot_routes.go
@@ -49,7 +49,7 @@ func (r *router) snapshots(
 			return objMap, nil
 		}
 
-		task := service.TaskExecute(ctx, run, schema.SnapshotMapSchema)
+		task := service.TaskEnqueue(ctx, run, schema.SnapshotMapSchema)
 		taskIDs = append(taskIDs, task.ID)
 		tasks[service.Name()] = task
 	}
@@ -79,7 +79,7 @@ func (r *router) snapshots(
 		r.config,
 		w,
 		store,
-		services.TaskExecute(ctx, run, schema.ServiceSnapshotMapSchema),
+		services.TaskEnqueue(ctx, run, schema.ServiceSnapshotMapSchema),
 		http.StatusOK)
 }
 
@@ -113,7 +113,7 @@ func (r *router) snapshotsForService(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.SnapshotMapSchema),
+		service.TaskEnqueue(ctx, run, schema.SnapshotMapSchema),
 		http.StatusOK)
 }
 
@@ -140,7 +140,7 @@ func (r *router) snapshotInspect(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.SnapshotSchema),
+		service.TaskEnqueue(ctx, run, schema.SnapshotSchema),
 		http.StatusOK)
 }
 
@@ -167,7 +167,7 @@ func (r *router) snapshotRemove(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, nil),
+		service.TaskEnqueue(ctx, run, nil),
 		http.StatusResetContent)
 }
 
@@ -217,7 +217,7 @@ func (r *router) volumeCreate(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.VolumeSchema),
+		service.TaskEnqueue(ctx, run, schema.VolumeSchema),
 		http.StatusCreated)
 }
 
@@ -246,6 +246,6 @@ func (r *router) snapshotCopy(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.SnapshotSchema),
+		service.TaskEnqueue(ctx, run, schema.SnapshotSchema),
 		http.StatusCreated)
 }

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -57,7 +57,7 @@ func (r *router) volumes(
 			return getFilteredVolumes(ctx, req, store, svc, opts, filter)
 		}
 
-		task := service.TaskExecute(ctx, run, schema.VolumeMapSchema)
+		task := service.TaskEnqueue(ctx, run, schema.VolumeMapSchema)
 		taskIDs = append(taskIDs, task.ID)
 		tasks[service.Name()] = task
 	}
@@ -87,7 +87,7 @@ func (r *router) volumes(
 		r.config,
 		w,
 		store,
-		services.TaskExecute(ctx, run, schema.ServiceVolumeMapSchema),
+		services.TaskEnqueue(ctx, run, schema.ServiceVolumeMapSchema),
 		http.StatusOK)
 }
 
@@ -124,7 +124,7 @@ func (r *router) volumesForService(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.VolumeMapSchema),
+		service.TaskEnqueue(ctx, run, schema.VolumeMapSchema),
 		http.StatusOK)
 }
 
@@ -373,7 +373,7 @@ func (r *router) volumeInspect(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.VolumeSchema),
+		service.TaskEnqueue(ctx, run, schema.VolumeSchema),
 		http.StatusOK)
 }
 
@@ -427,7 +427,7 @@ func (r *router) volumeCreate(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.VolumeSchema),
+		service.TaskEnqueue(ctx, run, schema.VolumeSchema),
 		http.StatusCreated)
 }
 
@@ -474,7 +474,7 @@ func (r *router) volumeCopy(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.VolumeSchema),
+		service.TaskEnqueue(ctx, run, schema.VolumeSchema),
 		http.StatusCreated)
 }
 
@@ -502,7 +502,7 @@ func (r *router) volumeSnapshot(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.SnapshotSchema),
+		service.TaskEnqueue(ctx, run, schema.SnapshotSchema),
 		http.StatusCreated)
 }
 
@@ -559,7 +559,7 @@ func (r *router) volumeAttach(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.VolumeAttachResponseSchema),
+		service.TaskEnqueue(ctx, run, schema.VolumeAttachResponseSchema),
 		http.StatusOK)
 }
 
@@ -616,7 +616,7 @@ func (r *router) volumeDetach(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, nil),
+		service.TaskEnqueue(ctx, run, nil),
 		http.StatusResetContent)
 }
 
@@ -708,7 +708,7 @@ func (r *router) volumeDetachAll(
 			return nil, nil
 		}
 
-		task := service.TaskExecute(ctx, run, nil)
+		task := service.TaskEnqueue(ctx, run, nil)
 		taskIDs = append(taskIDs, task.ID)
 		tasks[service.Name()] = task
 	}
@@ -728,7 +728,7 @@ func (r *router) volumeDetachAll(
 		r.config,
 		w,
 		store,
-		services.TaskExecute(ctx, run, schema.ServiceVolumeMapSchema),
+		services.TaskEnqueue(ctx, run, schema.ServiceVolumeMapSchema),
 		http.StatusResetContent)
 }
 
@@ -801,7 +801,7 @@ func (r *router) volumeDetachAllForService(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, schema.VolumeMapSchema),
+		service.TaskEnqueue(ctx, run, schema.VolumeMapSchema),
 		http.StatusResetContent)
 }
 
@@ -831,7 +831,7 @@ func (r *router) volumeRemove(
 		r.config,
 		w,
 		store,
-		service.TaskExecute(ctx, run, nil),
+		service.TaskEnqueue(ctx, run, nil),
 		http.StatusNoContent)
 }
 

--- a/api/server/services/services.go
+++ b/api/server/services/services.go
@@ -173,12 +173,12 @@ func TaskTrack(ctx types.Context) *types.Task {
 	return getTaskService(ctx).TaskTrack(ctx)
 }
 
-// TaskExecute enqueues a task for execution.
-func TaskExecute(
+// TaskEnqueue enqueues a task for execution.
+func TaskEnqueue(
 	ctx types.Context,
 	run types.TaskRunFunc,
 	schema []byte) *types.Task {
-	return getTaskService(ctx).TaskExecute(ctx, run, schema)
+	return getTaskService(ctx).TaskEnqueue(ctx, run, schema)
 }
 
 // TaskInspect returns the task with the specified ID.

--- a/api/server/services/services_storage.go
+++ b/api/server/services/services_storage.go
@@ -69,7 +69,7 @@ func (s *storageService) Driver() types.StorageDriver {
 	return s.driver
 }
 
-func (s *storageService) TaskExecute(
+func (s *storageService) TaskEnqueue(
 	ctx types.Context,
 	run types.StorageTaskRunFunc,
 	schema []byte) *types.Task {

--- a/api/server/services/services_task.go
+++ b/api/server/services/services_task.go
@@ -184,7 +184,7 @@ func (s *globalTaskService) taskTrack(ctx types.Context) *task {
 }
 
 // TaskExecute enqueues a task for execution.
-func (s *globalTaskService) TaskExecute(
+func (s *globalTaskService) TaskEnqueue(
 	ctx types.Context,
 	run types.TaskRunFunc,
 	schema []byte) *types.Task {

--- a/api/types/types_services.go
+++ b/api/types/types_services.go
@@ -31,8 +31,8 @@ type StorageService interface {
 	// Driver returns the service's StorageDriver.
 	Driver() StorageDriver
 
-	// TaskExecute enqueues a task for execution.
-	TaskExecute(
+	// TaskEnqueue enqueues a task for execution.
+	TaskEnqueue(
 		ctx Context,
 		run StorageTaskRunFunc,
 		schema []byte) *Task
@@ -49,8 +49,8 @@ type TaskTrackingService interface {
 	// TaskTrack creates a new, trackable task.
 	TaskTrack(ctx Context) *Task
 
-	// TaskExecute enqueues a task for execution.
-	TaskExecute(
+	// TaskEnqueue enqueues a task for execution.
+	TaskEnqueue(
 		ctx Context,
 		run TaskRunFunc,
 		schema []byte) *Task
@@ -77,8 +77,8 @@ type TaskTrackingService interface {
 type TaskExecutionService interface {
 	Service
 
-	// TaskExecute enqueues a task for execution.
-	TaskExecute(
+	// TaskEnqueue enqueues a task for execution.
+	TaskEnqueue(
 		ctx Context,
 		run TaskRunFunc,
 		schema []byte) *Task


### PR DESCRIPTION
Calling TaskExecute() is really putting a task on a queue, not executing
that task immediately/directly. Clarify that by renaming the function.