### PR TITLE
make sure storage driver polling functions have timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1078,12 +1078,40 @@ test:
 test-debug:
 	LIBSTORAGE_DEBUG=true $(MAKE) test
 
-test-rbd:
-	DRIVERS=rbd $(MAKE) deps
-	DRIVERS=rbd $(MAKE) ./drivers/storage/rbd/tests/rbd.test
+test-azureud:
+	DRIVERS=azureud $(MAKE) deps
+	DRIVERS=azureud $(MAKE) ./drivers/storage/azureud/tests/azureud.test
 
-test-rbd-clean:
-	DRIVERS=rbd $(MAKE) clean
+test-azureud-clean:
+	DRIVERS=azureud $(MAKE) clean
+
+test-dobs:
+	DRIVERS=dobs $(MAKE) deps
+	DRIVERS=dobs $(MAKE) ./drivers/storage/dobs/tests/dobs.test
+
+test-dobs-clean:
+	DRIVERS=dobs $(MAKE) clean
+
+test-ebs:
+	DRIVERS=ebs $(MAKE) deps
+	DRIVERS=ebs $(MAKE) ./drivers/storage/ebs/tests/ebs.test
+
+test-ebs-clean:
+	DRIVERS=ebs $(MAKE) clean
+
+test-efs:
+	DRIVERS=efs $(MAKE) deps
+	DRIVERS=efs $(MAKE) ./drivers/storage/efs/tests/efs.test
+
+test-efs-clean:
+	DRIVERS=efs $(MAKE) clean
+
+test-fittedcloud:
+	DRIVERS=fittedcloud $(MAKE) deps
+	DRIVERS=fittedcloud $(MAKE) ./drivers/storage/fittedcloud/tests/fittedcloud.test
+
+test-fittedcloud-clean:
+	DRIVERS=fittedcloud $(MAKE) clean
 
 test-gcepd:
 	DRIVERS=gcepd $(MAKE) deps
@@ -1092,19 +1120,13 @@ test-gcepd:
 test-gcepd-clean:
 	DRIVERS=gcepd $(MAKE) clean
 
-test-digitalocean:
-	DRIVERS=digitalocean $(MAKE) deps
-	DRIVERS=digitalocean $(MAKE) ./drivers/storage/digitalocean/tests/digitalocean.test
+test-rbd:
+	DRIVERS=rbd $(MAKE) deps
+	DRIVERS=rbd $(MAKE) ./drivers/storage/rbd/tests/rbd.test
 
-test-digitalocean-clean:
-	DRIVERS=digitalocean $(MAKE) clean
+test-rbd-clean:
+	DRIVERS=rbd $(MAKE) clean
 
-test-azureud:
-	DRIVERS=azureud $(MAKE) deps
-	DRIVERS=azureud $(MAKE) ./drivers/storage/azureud/tests/azureud.test
-
-test-azureud-clean:
-	DRIVERS=azureud $(MAKE) clean
 
 test-vfs:
 	DRIVERS=vfs $(MAKE) ./drivers/storage/vfs/tests/vfs.test

--- a/api/utils/utils_waitfor.go
+++ b/api/utils/utils_waitfor.go
@@ -1,0 +1,32 @@
+package utils
+
+import "time"
+
+// WaitFor waits for a lambda to complete or aborts after a specified amount
+// of time. If the function fails to complete in the specified amount of time
+// then the second return value is a boolean false. Otherwise the return value
+// and possible error of the provided lambda are returned.
+func WaitFor(
+	f func() (interface{}, error),
+	timeout time.Duration) (interface{}, bool, error) {
+
+	var (
+		res interface{}
+		err error
+
+		fc = make(chan bool, 1)
+	)
+
+	go func() {
+		res, err = f()
+		fc <- true
+	}()
+	tc := time.After(timeout)
+
+	select {
+	case <-fc:
+		return res, true, err
+	case <-tc:
+		return nil, false, nil
+	}
+}

--- a/drivers/storage/dobs/dobs.go
+++ b/drivers/storage/dobs/dobs.go
@@ -11,6 +11,16 @@ const (
 	// Name is the name of the driver
 	Name = "dobs"
 
+	defaultStatusMaxAttempts = 10
+	defaultStatusInitDelay   = "100ms"
+
+	/* This is hard deadline when waiting for the volume status to change to
+	a desired state. At minimum is has to be more than the expontential
+	backoff of sum 100*2^x, x=0 to 9 == 102s3ms, but should also account for
+	RTT of API requests, and how many API requests would be made to
+	exhaust retries */
+	defaultStatusTimeout = "2m"
+
 	// InstanceIDFieldRegion is the key used to retrive the region from the
 	// instance id map
 	InstanceIDFieldRegion = "region"
@@ -27,11 +37,23 @@ const (
 	// Please see https://goo.gl/MwReS6 for more information.
 	VolumePrefix = "scsi-0DO_Volume_"
 
-	// ConfigDOToken is the key for the token in the config file
-	ConfigDOToken = Name + ".token"
+	// ConfigToken is the key for the token in the config file
+	ConfigToken = Name + ".token"
 
-	// ConfigDORegion is the key for the region in the config file
-	ConfigDORegion = Name + ".region"
+	// ConfigRegion is the key for the region in the config file
+	ConfigRegion = Name + ".region"
+
+	// ConfigStatusMaxAttempts is the key for the maximum number of times
+	// a volume status will be queried when waiting for an action to finish
+	ConfigStatusMaxAttempts = Name + ".statusMaxAttempts"
+
+	// ConfigStatusInitDelay is the key for the initial time duration
+	// for exponential backoff
+	ConfigStatusInitDelay = Name + ".statusInitialDelay"
+
+	// ConfigStatusTimeout is the key for the time duration for a timeout
+	// on how long to wait for a desired volume status to appears
+	ConfigStatusTimeout = Name + ".statusTimeout"
 )
 
 func init() {
@@ -40,17 +62,15 @@ func init() {
 
 func registerConfig() {
 	r := gofigCore.NewRegistration("DigitalOcean Block Storage")
-	r.Key(
-		gofig.String,
-		"",
-		"",
-		"The DigitalOcean access token",
-		ConfigDOToken)
-	r.Key(
-		gofig.String,
-		"",
-		"",
-		"The DigitalOcean region",
-		ConfigDORegion)
+	r.Key(gofig.String, "", "", "The DigitalOcean access token",
+		ConfigToken)
+	r.Key(gofig.String, "", "", "The DigitalOcean region",
+		ConfigRegion)
+	r.Key(gofig.Int, "", defaultStatusMaxAttempts, "Max Status Attempts",
+		ConfigStatusMaxAttempts)
+	r.Key(gofig.String, "", defaultStatusInitDelay, "Status Initial Delay",
+		ConfigStatusInitDelay)
+	r.Key(gofig.String, "", defaultStatusTimeout, "Status Timeout",
+		ConfigStatusTimeout)
 	gofigCore.Register(r)
 }

--- a/drivers/storage/dobs/executor/dobs_executor.go
+++ b/drivers/storage/dobs/executor/dobs_executor.go
@@ -86,7 +86,3 @@ func (d *driver) LocalDevices(
 func (d *driver) Supported(ctx types.Context, opts types.Store) (bool, error) {
 	return doUtils.IsDroplet(ctx)
 }
-
-func (d *driver) token() string {
-	return d.config.GetString(do.ConfigDOToken)
-}

--- a/drivers/storage/dobs/tests/README.md
+++ b/drivers/storage/dobs/tests/README.md
@@ -1,4 +1,4 @@
-# Testing the DigitalOcean triver
+# Testing the DigitalOcean Block Storage (DOBS) Driver
 
 The tests for the DigitalOcean driver assume that you have access to a
 DigitalOcean account that has a token that with read/write access. There are
@@ -32,18 +32,29 @@ Once you have your environment set up, you can build and copy the tests to your 
 
 Running the build comamand:
 ```
-GOOS=linux GOARCH=amd64 BUILD_TAGS="gofig pflag libstorage_integration_docker libstorage_storage_driver libstorage_storage_executor libstorage_storage_driver_digitalocean libstorage_storage_executor_digitalocean" make build-tests
+GOOS=linux make test-dobs
 ```
-will create a `digitalocean.test` in the tests directory. You can scp that to
-your droplet and then run the tests. You will also need to configure libstorage
-to use the digitalocean driver by setting the following fields in
-`/etc/libstorage/config.yaml`:
+will create a `dobs.test` in the tests directory. You can scp that to
+your droplet and then run the tests. You will also need to configure libStorage
+to use the dobs driver by exportiing the required config parameters:
+
+```bash
+export DOBS_TOKEN=<your API token>
+export DOBS_REGION=<region you are testing in>
 
 ```
-digitalocean:
-  token: $YOUR_API_KEY
-  # You can use other regions here
-  region: sfo2
+
+The tests may now be executed with the following command:
+
+```bash
+./dobs.test
+```
+
+An exit code of `0` means the tests completed successfully. If there are errors
+then it may be useful to run the tests once more with increased logging:
+
+```bash
+LIBSTORAGE_LOGGING_LEVEL=debug ./dobs.test -test.v
 ```
 
 #### Deleting an environment

--- a/drivers/storage/dobs/tests/coverage.mk
+++ b/drivers/storage/dobs/tests/coverage.mk
@@ -1,2 +1,2 @@
-DIGITALOCEAN_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/digitalocean
-TEST_COVERPKG_./drivers/storage/digitalocean/tests := $(DIGITALOCEAN_COVERPKG),$(DIGITALOCEAN_COVERPKG)/executor
+DOBS_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/dobs
+TEST_COVERPKG_./drivers/storage/dobs/tests := $(DOBS_COVERPKG),$(DOBS_COVERPKG)/executor

--- a/drivers/storage/dobs/tests/dobs_test.go
+++ b/drivers/storage/dobs/tests/dobs_test.go
@@ -68,8 +68,8 @@ func TestConfig(t *testing.T) {
 	}
 
 	tfDO := func(config gofig.Config, client types.Client, t *testing.T) {
-		assert.NotEqual(t, config.GetString(do.ConfigDORegion), "")
-		assert.NotEqual(t, config.GetString(do.ConfigDOToken), "")
+		assert.NotEqual(t, config.GetString(do.ConfigRegion), "")
+		assert.NotEqual(t, config.GetString(do.ConfigToken), "")
 	}
 
 	apitests.Run(t, do.Name, configYAML, tfDO)

--- a/drivers/storage/ebs/ebs.go
+++ b/drivers/storage/ebs/ebs.go
@@ -17,6 +17,16 @@ const (
 	// NameAWS is the provider's old AWS name.
 	NameAWS = "aws"
 
+	defaultStatusMaxAttempts = 10
+	defaultStatusInitDelay   = "100ms"
+
+	/* This is hard deadline when waiting for the volume status to change to
+	a desired state. At minimum is has to be more than the expontential
+	backoff of sum 100*2^x, x=0 to 9 == 102s3ms, but should also account for
+	RTT of API requests, and how many API requests would be made to
+	exhaust retries */
+	defaultStatusTimeout = "2m"
+
 	// TagDelimiter separates tags from volume or snapshot names
 	TagDelimiter = "/"
 
@@ -62,6 +72,18 @@ const (
 	// If a KmsKeyID is specified, all volumes will be created with their
 	// Encrypted flag set to true.
 	KmsKeyID = "kmsKeyID"
+
+	// ConfigStatusMaxAttempts is the key for the maximum number of times
+	// a volume status will be queried when waiting for an action to finish
+	ConfigStatusMaxAttempts = Name + ".statusMaxAttempts"
+
+	// ConfigStatusInitDelay is the key for the initial time duration
+	// for exponential backoff
+	ConfigStatusInitDelay = Name + ".statusInitialDelay"
+
+	// ConfigStatusTimeout is the key for the time duration for a timeout
+	// on how long to wait for a desired volume status to appears
+	ConfigStatusTimeout = Name + ".statusTimeout"
 )
 
 func init() {
@@ -73,6 +95,12 @@ func init() {
 	r.Key(gofig.Int, "", DefaultMaxRetries, "", Name+"."+MaxRetries)
 	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", Name+"."+Tag)
 	r.Key(gofig.String, "", "", "", Name+"."+KmsKeyID)
+	r.Key(gofig.Int, "", defaultStatusMaxAttempts, "Max Status Attempts",
+		ConfigStatusMaxAttempts)
+	r.Key(gofig.String, "", defaultStatusInitDelay, "Status Initial Delay",
+		ConfigStatusInitDelay)
+	r.Key(gofig.String, "", defaultStatusTimeout, "Status Timeout",
+		ConfigStatusTimeout)
 
 	r.Key(gofig.String, "", "", "", NameEC2+"."+AccessKey)
 	r.Key(gofig.String, "", "", "", NameEC2+"."+SecretKey)

--- a/drivers/storage/ebs/executor/ebs_executor.go
+++ b/drivers/storage/ebs/executor/ebs_executor.go
@@ -65,7 +65,7 @@ func (d *driver) Supported(
 func (d *driver) InstanceID(
 	ctx types.Context,
 	opts types.Store) (*types.InstanceID, error) {
-	return ebsUtils.InstanceID(ctx)
+	return ebsUtils.InstanceID(ctx, d.Name())
 }
 
 var errNoAvaiDevice = goof.New("no available device")

--- a/drivers/storage/ebs/tests/README.md
+++ b/drivers/storage/ebs/tests/README.md
@@ -12,7 +12,7 @@ to EBS. In order to execute the tests either compile the test binary locally or
 on the instance. From the root of the libStorage project execute the following:
 
 ```bash
-make deps && make ./drivers/storage/ebs/tests/ebs.test
+make test-ebs
 ```
 
 Once the test binary is compiled, if it was built locally, copy it to the EC2

--- a/drivers/storage/ebs/utils/utils.go
+++ b/drivers/storage/ebs/utils/utils.go
@@ -49,7 +49,7 @@ type instanceIdentityDoc struct {
 }
 
 // InstanceID returns the instance ID for the local host.
-func InstanceID(ctx types.Context) (*types.InstanceID, error) {
+func InstanceID(ctx types.Context, driverName string) (*types.InstanceID, error) {
 	req, err := http.NewRequest(http.MethodGet, iidURL, nil)
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ func InstanceID(ctx types.Context) (*types.InstanceID, error) {
 
 	return &types.InstanceID{
 		ID:     iid.InstanceID,
-		Driver: ebs.Name,
+		Driver: driverName,
 		Fields: map[string]string{
 			ebs.InstanceIDFieldRegion:           iid.Region,
 			ebs.InstanceIDFieldAvailabilityZone: iid.AvailabilityZone,

--- a/drivers/storage/efs/executor/efs_executor.go
+++ b/drivers/storage/efs/executor/efs_executor.go
@@ -11,6 +11,7 @@ import (
 
 	gofig "github.com/akutz/gofig/types"
 
+	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/registry"
 	"github.com/codedellemc/libstorage/api/types"
 	"github.com/codedellemc/libstorage/drivers/storage/efs"
@@ -56,7 +57,7 @@ func (d *driver) Supported(
 
 // InstanceID returns the local instance ID for the test
 func InstanceID() (*types.InstanceID, error) {
-	return newDriver().InstanceID(nil, nil)
+	return newDriver().InstanceID(context.Background(), nil)
 }
 
 // InstanceID returns the aws instance configuration

--- a/drivers/storage/efs/tests/efs_test.go
+++ b/drivers/storage/efs/tests/efs_test.go
@@ -198,7 +198,7 @@ func TestVolumeCreateRemove(t *testing.T) {
 func volumeRemove(t *testing.T, client types.Client, volumeID string) {
 	log.WithField("volumeID", volumeID).Info("removing volume")
 	err := client.API().VolumeRemove(
-		nil, efs.Name, volumeID)
+		nil, efs.Name, volumeID, false)
 	assert.NoError(t, err)
 	if err != nil {
 		t.Error("failed volumeRemove")

--- a/drivers/storage/fittedcloud/fittedcloud.go
+++ b/drivers/storage/fittedcloud/fittedcloud.go
@@ -11,6 +11,16 @@ const (
 	// Name is the provider's name.
 	Name = "fittedcloud"
 
+	defaultStatusMaxAttempts = 10
+	defaultStatusInitDelay   = "100ms"
+
+	/* This is hard deadline when waiting for the volume status to change to
+	a desired state. At minimum is has to be more than the expontential
+	backoff of sum 100*2^x, x=0 to 9 == 102s3ms, but should also account for
+	RTT of API requests, and how many API requests would be made to
+	exhaust retries */
+	defaultStatusTimeout = "2m"
+
 	// TagDelimiter separates tags from volume or snapshot names
 	TagDelimiter = "/"
 
@@ -57,6 +67,10 @@ const (
 	// Encrypted flag set to true.
 	KmsKeyID = "kmsKeyID"
 
+	statusMaxAttempts  = "statusMaxAttempts"
+	statusInitialDelay = "statusInitialDelay"
+	statusTimeout      = "statusTimeout"
+
 	// ConfigEBS is a config key.
 	ConfigEBS = "ebs"
 
@@ -80,6 +94,18 @@ const (
 
 	// ConfigEBSKmsKeyID is a config key.
 	ConfigEBSKmsKeyID = ConfigEBS + "." + KmsKeyID
+
+	// ConfigStatusMaxAttempts is the key for the maximum number of times
+	// a volume status will be queried when waiting for an action to finish
+	ConfigStatusMaxAttempts = ConfigEBS + "." + statusMaxAttempts
+
+	// ConfigStatusInitDelay is the key for the initial time duration
+	// for exponential backoff
+	ConfigStatusInitDelay = ConfigEBS + "." + statusInitialDelay
+
+	// ConfigStatusTimeout is the key for the time duration for a timeout
+	// on how long to wait for a desired volume status to appears
+	ConfigStatusTimeout = ConfigEBS + "." + statusTimeout
 )
 
 func init() {
@@ -91,6 +117,12 @@ func init() {
 	r.Key(gofig.Int, "", DefaultMaxRetries, "", ConfigEBSMaxRetries)
 	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", ConfigEBSTag)
 	r.Key(gofig.String, "", "", "", ConfigEBSKmsKeyID)
+	r.Key(gofig.Int, "", defaultStatusMaxAttempts, "Max Status Attempts",
+		ConfigStatusMaxAttempts)
+	r.Key(gofig.String, "", defaultStatusInitDelay, "Status Initial Delay",
+		ConfigStatusInitDelay)
+	r.Key(gofig.String, "", defaultStatusTimeout, "Status Timeout",
+		ConfigStatusTimeout)
 
 	gofigCore.Register(r)
 }

--- a/drivers/storage/gcepd/gcepd.go
+++ b/drivers/storage/gcepd/gcepd.go
@@ -11,6 +11,16 @@ const (
 	// Name is the provider's name.
 	Name = "gcepd"
 
+	defaultStatusMaxAttempts = 10
+	defaultStatusInitDelay   = "100ms"
+
+	/* This is hard deadline when waiting for the volume status to change to
+	a desired state. At minimum is has to be more than the expontential
+	backoff of sum 100*2^x, x=0 to 9 == 102s3ms, but should also account for
+	RTT of API requests, and how many API requests would be made to
+	exhaust retries */
+	defaultStatusTimeout = "2m"
+
 	// InstanceIDFieldProjectID is the key to retrieve the ProjectID value
 	// from the InstanceID Field map.
 	InstanceIDFieldProjectID = "projectID"
@@ -27,6 +37,30 @@ const (
 
 	// DefaultDiskType indicates what type of disk to create by default
 	DefaultDiskType = DiskTypeSSD
+
+	// ConfigKeyfile is the key for the service account JSON credential file
+	ConfigKeyfile = Name + ".keyfile"
+
+	// ConfigZone is the key for the availability zone
+	ConfigZone = Name + ".zone"
+
+	// ConfigDefaultDiskType is the key for the default disk type to use
+	ConfigDefaultDiskType = Name + ".defaultDiskType"
+
+	// ConfigTag is the key for the tag to apply to and filter disks
+	ConfigTag = Name + ".tag"
+
+	// ConfigStatusMaxAttempts is the key for the maximum number of times
+	// a volume status will be queried when waiting for an action to finish
+	ConfigStatusMaxAttempts = Name + ".statusMaxAttempts"
+
+	// ConfigStatusInitDelay is the key for the initial time duration
+	// for exponential backoff
+	ConfigStatusInitDelay = Name + ".statusInitialDelay"
+
+	// ConfigStatusTimeout is the key for the time duration for a timeout
+	// on how long to wait for a desired volume status to appears
+	ConfigStatusTimeout = Name + ".statusTimeout"
 )
 
 func init() {
@@ -40,6 +74,12 @@ func init() {
 		"gcepd.defaultDiskType")
 	r.Key(gofig.String, "", "", "Tag to apply and filter disks",
 		"gcepd.tag")
+	r.Key(gofig.Int, "", defaultStatusMaxAttempts, "Max Status Attempts",
+		ConfigStatusMaxAttempts)
+	r.Key(gofig.String, "", defaultStatusInitDelay, "Status Initial Delay",
+		ConfigStatusInitDelay)
+	r.Key(gofig.String, "", defaultStatusTimeout, "Status Timeout",
+		ConfigStatusTimeout)
 
 	gofigCore.Register(r)
 }


### PR DESCRIPTION
Introduce a new `WaitFor` API utility that takes a lambda function and a
timeout. The function will call the lambda and return its results, or
the timeout will expire first and callers can check for this.

For each driver that was entering a loop to poll for some kind of volume
status, make sure they use this `WaitFor` utility so that the polling
loop has a hard timeout associated with it so it does not block the
driver indefinitely. It is also important that the polling loop itself
has a hard limit on the number of times it will run.

Since the polling loop (lambda) will be run in a goroutine, even if the
timeout is reached, the polling loop will still be running in the
background.

Fixes #480

Tests:

- [x] DigitalOcean
- [x] EBS
- [x] EFS
- [x] GCE