### PR TITLE
libStorage Token Support (JWT)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1106,6 +1106,9 @@ test-azureud:
 test-azureud-clean:
 	DRIVERS=azureud $(MAKE) clean
 
+test-vfs:
+	DRIVERS=vfs $(MAKE) ./drivers/storage/vfs/tests/vfs.test
+
 clean: $(GO_CLEAN)
 
 clobber: clean $(GO_CLOBBER)

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3,15 +3,8 @@ package client
 import (
 	"net/http"
 
-	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/types"
 )
-
-func init() {
-	context.RegisterCustomKey(transactionHeaderKey, context.CustomHeaderKey)
-	context.RegisterCustomKey(instanceIDHeaderKey, context.CustomHeaderKey)
-	context.RegisterCustomKey(localDevicesHeaderKey, context.CustomHeaderKey)
-}
 
 // Client is the libStorage API client.
 type client struct {

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -293,6 +293,21 @@ func MustSession(ctx context.Context) interface{} {
 	return v
 }
 
+// AuthToken returns the context's security token. This value is valid on
+// both the client and the server.
+func AuthToken(ctx context.Context) (*types.AuthToken, bool) {
+	if v, ok := ctx.Value(AuthTokenKey).(*types.AuthToken); ok {
+		return v, ok
+	}
+	return nil, false
+}
+
+// MustAuthToken returns the context's security token and panics if it does
+// not exist and/or cannot be type cast.
+func MustAuthToken(ctx context.Context) *types.AuthToken {
+	return ctx.Value(AuthTokenKey).(*types.AuthToken)
+}
+
 // InstanceID returns the context's InstanceID. This value is valid on both
 // the client and the server.
 func InstanceID(ctx context.Context) (*types.InstanceID, bool) {

--- a/api/context/context_keys.go
+++ b/api/context/context_keys.go
@@ -36,9 +36,15 @@ const (
 	// SessionKey is the key for the storage driver's session.
 	SessionKey
 
+	// EncodedAuthTokenKey is the key for an encoded authentication token.
+	EncodedAuthTokenKey
+
 	// keyLoggable is the minimum value from which the succeeding keys should
 	// be checked when logging.
 	keyLoggable
+
+	// AuthTokenKey is a context key.
+	AuthTokenKey
 
 	// ClientKey is a context key.
 	ClientKey
@@ -93,6 +99,7 @@ func (k Key) String() string {
 
 var (
 	keyNames = map[Key]string{
+		AuthTokenKey:      "token",
 		TaskKey:           "task",
 		InstanceIDKey:     "instanceID",
 		ProfileKey:        "profile",

--- a/api/server/auth/auth_token.go
+++ b/api/server/auth/auth_token.go
@@ -1,0 +1,215 @@
+package auth
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	jcrypto "github.com/SermoDigital/jose/crypto"
+	"github.com/SermoDigital/jose/jws"
+
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+var rxBearer = regexp.MustCompile(`Bearer (.+)`)
+
+// GetBearerTokenFromReq retrieves the bearer token from the HTTP request.
+func GetBearerTokenFromReq(ctx types.Context, req *http.Request) string {
+	m := rxBearer.FindStringSubmatch(
+		req.Header.Get(types.AuthorizationHeader))
+	if len(m) == 0 {
+		return ""
+	}
+	return m[1]
+}
+
+// ValidateAuthTokenWithCtx validates the auth token from the provided context.
+func ValidateAuthTokenWithCtx(
+	ctx types.Context,
+	config *types.AuthConfig) (*types.AuthToken, error) {
+
+	if tok, ok := context.AuthToken(ctx); ok {
+		logFields := map[string]interface{}{"sub": tok.Subject}
+		err := validateAuthTokenAllowed(ctx, config, logFields, tok)
+		if err != nil {
+			return nil, err
+		}
+		ctx.WithFields(logFields).Info("validated security token")
+		return tok, nil
+	}
+
+	return nil, nil
+}
+
+// ValidateAuthTokenWithCtxOrReq validates the auth token from the provided
+// context. If not present in the context attempt a validation against the
+// provided HTTP request.
+func ValidateAuthTokenWithCtxOrReq(
+	ctx types.Context,
+	config *types.AuthConfig,
+	req *http.Request) (*types.AuthToken, error) {
+
+	tok, err := ValidateAuthTokenWithCtx(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	if tok != nil {
+		return tok, nil
+	}
+	return ValidateAuthTokenWithReq(ctx, config, req)
+}
+
+var jwtRX = regexp.MustCompile(`^(?:(.+):)?(.+\..+\..+)$`)
+
+func getSubject(s string) string {
+	m := jwtRX.FindStringSubmatch(s)
+	if len(m) == 0 {
+		return s
+	}
+	jwt, err := jws.ParseJWT([]byte(m[2]))
+	if err != nil {
+		return s
+	}
+	if v, ok := jwt.Claims().Subject(); ok {
+		return v
+	}
+	return s
+}
+
+func validateAuthTokenAllowed(
+	ctx types.Context,
+	config *types.AuthConfig,
+	logFields map[string]interface{},
+	tok *types.AuthToken) error {
+
+	for _, v := range config.Deny {
+		if strings.EqualFold(getSubject(v), tok.Subject) {
+			ctx.WithFields(logFields).Error("access denied")
+			return &types.ErrSecTokInvalid{Denied: true}
+		}
+	}
+	for _, v := range config.Allow {
+		if strings.EqualFold(getSubject(v), tok.Subject) {
+			return nil
+		}
+	}
+
+	ctx.WithFields(logFields).Error("access not granted")
+	return &types.ErrSecTokInvalid{Denied: true}
+}
+
+// ValidateAuthTokenWithReq validates the auth token from the provided HTTP req.
+func ValidateAuthTokenWithReq(
+	ctx types.Context,
+	config *types.AuthConfig,
+	req *http.Request) (*types.AuthToken, error) {
+
+	return ValidateAuthTokenWithJWT(
+		ctx, config, GetBearerTokenFromReq(ctx, req))
+}
+
+// ValidateAuthTokenWithJWT validates the auth token from the provided JWT.
+func ValidateAuthTokenWithJWT(
+	ctx types.Context,
+	config *types.AuthConfig,
+	encJWT string) (*types.AuthToken, error) {
+
+	lf := map[string]interface{}{"encJWT": encJWT}
+	ctx.WithFields(lf).Debug("validating jwt")
+
+	jwt, err := jws.ParseJWT([]byte(encJWT))
+	if err != nil {
+		ctx.WithFields(lf).WithError(err).Error("error parsing jwt")
+		return nil, &types.ErrSecTokInvalid{InvalidToken: true, InnerError: err}
+	}
+
+	sm := parseSigningMethod(config.Alg)
+	lf["signingMethod"] = sm.Alg()
+	ctx.WithFields(lf).Debug("parsed jwt signing method")
+
+	if err := jwt.Validate(config.Key, sm); err != nil {
+		ctx.WithFields(lf).WithError(err).Error("error validating jwt")
+		return nil, &types.ErrSecTokInvalid{InvalidSig: true, InnerError: err}
+	}
+
+	ctx.WithFields(lf).Debug("validated jwt signature")
+
+	if len(jwt.Claims()) == 0 {
+		ctx.WithFields(lf).Error("jwt missing claims")
+		return nil, &types.ErrSecTokInvalid{}
+	}
+
+	var (
+		sub string
+		iat time.Time
+		exp time.Time
+		nbf time.Time
+		ok  bool
+	)
+
+	if sub, ok = jwt.Claims().Subject(); !ok {
+		ctx.WithFields(lf).Error("jwt missing sub claim")
+		return nil, &types.ErrSecTokInvalid{MissingClaim: "sub"}
+	}
+
+	if iat, ok = jwt.Claims().IssuedAt(); !ok {
+		ctx.WithFields(lf).Error("jwt missing iat claim")
+		return nil, &types.ErrSecTokInvalid{MissingClaim: "iat"}
+	}
+
+	if exp, ok = jwt.Claims().Expiration(); !ok {
+		ctx.WithFields(lf).Error("jwt missing exp claim")
+		return nil, &types.ErrSecTokInvalid{MissingClaim: "exp"}
+	}
+
+	if nbf, ok = jwt.Claims().NotBefore(); !ok {
+		ctx.WithFields(lf).Error("jwt missing nbf claim")
+		return nil, &types.ErrSecTokInvalid{MissingClaim: "nbf"}
+	}
+
+	tok := &types.AuthToken{
+		Subject:   sub,
+		IssuedAt:  iat.UTC().Unix(),
+		Expires:   exp.UTC().Unix(),
+		NotBefore: nbf.UTC().Unix(),
+	}
+
+	lf["sub"] = tok.Subject
+	lf["iat"] = tok.IssuedAt
+	lf["exp"] = tok.Expires
+	lf["nbf"] = tok.NotBefore
+
+	if err := validateAuthTokenAllowed(ctx, config, lf, tok); err != nil {
+		return nil, err
+	}
+
+	ctx.WithFields(lf).Info("validated security token")
+	return tok, nil
+}
+
+var signingMethods = []jcrypto.SigningMethod{
+	jcrypto.SigningMethodES256,
+	jcrypto.SigningMethodES384,
+	jcrypto.SigningMethodES512,
+	jcrypto.SigningMethodHS256,
+	jcrypto.SigningMethodHS384,
+	jcrypto.SigningMethodHS512,
+	jcrypto.SigningMethodPS256,
+	jcrypto.SigningMethodPS384,
+	jcrypto.SigningMethodPS512,
+	jcrypto.SigningMethodRS256,
+	jcrypto.SigningMethodRS384,
+	jcrypto.SigningMethodRS512,
+}
+
+// parseSigningMethod parses the signing method from the provided method name.
+func parseSigningMethod(methodName string) jcrypto.SigningMethod {
+	for _, v := range signingMethods {
+		if strings.EqualFold(v.Alg(), methodName) {
+			return v
+		}
+	}
+	return jcrypto.SigningMethodHS256
+}

--- a/api/server/auth/auth_token_test.go
+++ b/api/server/auth/auth_token_test.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+const (
+	jwtAlg       = "HS256"
+	jwtKey       = "key"
+	jwtAkutz     = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1MjI2ODg1NTAsImlhdCI6MTQ5MTIzODk1MCwibmJmIjoxNDkxMjM4OTUwLCJzdWIiOiJha3V0eiJ9.3eAA7AQZUGrwA42H64qKbu8QF_AHpSsJSMR0FALnKj8`
+	jwtCduchesne = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1MjI2OTM1ODQsImlhdCI6MTQ5MTI0Mzk4NCwibmJmIjoxNDkxMjQzOTg0LCJzdWIiOiJjZHVjaGVzbmUifQ.AUOrtC41LQB5FO1NsBE357o_Zsx-lhZ-3I7v_UMsTh4`
+)
+
+func TestValidateAuthToken_ValidTokSigKey(t *testing.T) {
+	sc := &types.AuthConfig{
+		Key:   []byte(jwtKey),
+		Alg:   jwtAlg,
+		Allow: []string{"akutz"},
+	}
+	tok, err := ValidateAuthTokenWithJWT(context.Background(), sc, jwtAkutz)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	if !assert.NotNil(t, tok) {
+		t.FailNow()
+	}
+	if !assert.Equal(t, "akutz", tok.Subject) {
+		t.FailNow()
+	}
+}
+
+func TestValidateAuthToken_NotInAllowList(t *testing.T) {
+	sc := &types.AuthConfig{
+		Key: []byte(jwtKey),
+		Alg: jwtAlg,
+	}
+	tok, err := ValidateAuthTokenWithJWT(context.Background(), sc, jwtAkutz)
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	if !assert.Nil(t, tok) {
+		t.FailNow()
+	}
+	if !assert.IsType(t, &types.ErrSecTokInvalid{}, err) {
+		t.FailNow()
+	}
+	terr := err.(*types.ErrSecTokInvalid)
+	if !assert.True(t, terr.Denied) {
+		t.FailNow()
+	}
+}
+
+func TestValidateAuthToken_InDenyList(t *testing.T) {
+	sc := &types.AuthConfig{
+		Key:  []byte(jwtKey),
+		Alg:  jwtAlg,
+		Deny: []string{"akutz"},
+	}
+	tok, err := ValidateAuthTokenWithJWT(context.Background(), sc, jwtAkutz)
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	if !assert.Nil(t, tok) {
+		t.FailNow()
+	}
+	if !assert.IsType(t, &types.ErrSecTokInvalid{}, err) {
+		t.FailNow()
+	}
+	terr := err.(*types.ErrSecTokInvalid)
+	if !assert.True(t, terr.Denied) {
+		t.FailNow()
+	}
+}
+
+func TestValidateAuthToken_InvalidKey(t *testing.T) {
+	sc := &types.AuthConfig{
+		Key: []byte("invalidKey"),
+		Alg: jwtAlg,
+	}
+	tok, err := ValidateAuthTokenWithJWT(context.Background(), sc, jwtAkutz)
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	if !assert.Nil(t, tok) {
+		t.FailNow()
+	}
+	if !assert.IsType(t, &types.ErrSecTokInvalid{}, err) {
+		t.FailNow()
+	}
+	terr := err.(*types.ErrSecTokInvalid)
+	if !assert.True(t, terr.InvalidSig) {
+		t.FailNow()
+	}
+}

--- a/api/server/handlers/handlers_auth_all_services.go
+++ b/api/server/handlers/handlers_auth_all_services.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/codedellemc/libstorage/api/server/auth"
+	"github.com/codedellemc/libstorage/api/server/services"
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+// authAllSvcsHandler is an HTTP filter for validating the JWT.
+type authAllSvcsHandler struct {
+	handler types.APIFunc
+}
+
+// NewAuthAllSvcsHandler returns a new authAllSvcsHandler.
+func NewAuthAllSvcsHandler() types.Middleware {
+	return &authAllSvcsHandler{}
+}
+
+func (h *authAllSvcsHandler) Name() string {
+	return "auth-svc-handler"
+}
+
+func (h *authAllSvcsHandler) Handler(m types.APIFunc) types.APIFunc {
+	return (&authAllSvcsHandler{m}).Handle
+}
+
+// Handle is the type's Handler function.
+func (h *authAllSvcsHandler) Handle(
+	ctx types.Context,
+	w http.ResponseWriter,
+	req *http.Request,
+	store types.Store) error {
+
+	for svc := range services.StorageServices(ctx) {
+		if svc.AuthConfig() == nil {
+			ctx.WithField("service", svc.Name()).Debug(
+				"skipping service auth handler; empty auth config")
+			continue
+		}
+		if len(svc.AuthConfig().Allow) == 0 && len(svc.AuthConfig().Deny) == 0 {
+			ctx.Debug("skipping svc auth handler; empty allow & deny lists")
+			continue
+		}
+		_, err := auth.ValidateAuthTokenWithCtxOrReq(
+			ctx, svc.AuthConfig(), req)
+		if err != nil {
+			return err
+		}
+	}
+
+	ctx.Debug("validated all services access")
+
+	return h.handler(ctx, w, req, store)
+}

--- a/api/server/handlers/handlers_auth_global.go
+++ b/api/server/handlers/handlers_auth_global.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/server/auth"
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+// authGlobalHandler is an HTTP filter for validating the JWT.
+type authGlobalHandler struct {
+	handler types.APIFunc
+	config  *types.AuthConfig
+}
+
+// NewAuthGlobalHandler returns a new authGlobalHandler.
+func NewAuthGlobalHandler(
+	config *types.AuthConfig) types.Middleware {
+	return &authGlobalHandler{config: config}
+}
+
+func (h *authGlobalHandler) Name() string {
+	return "auth-global-handler"
+}
+
+func (h *authGlobalHandler) Handler(m types.APIFunc) types.APIFunc {
+	return (&authGlobalHandler{m, h.config}).Handle
+}
+
+// Handle is the type's Handler function.
+func (h *authGlobalHandler) Handle(
+	ctx types.Context,
+	w http.ResponseWriter,
+	req *http.Request,
+	store types.Store) error {
+
+	if h.config == nil {
+		ctx.Debug("skipping global auth handler; empty auth config")
+		return h.handler(ctx, w, req, store)
+	}
+
+	if len(h.config.Allow) == 0 && len(h.config.Deny) == 0 {
+		ctx.Debug("skipping global auth handler; empty allow & deny lists")
+		return h.handler(ctx, w, req, store)
+	}
+
+	tok, err := auth.ValidateAuthTokenWithReq(ctx, h.config, req)
+	if err != nil {
+		return err
+	}
+
+	if tok == nil {
+		panic("token should never be nil here")
+	}
+
+	ctx.Debug("validated global security token")
+
+	return h.handler(
+		ctx.WithValue(context.AuthTokenKey, tok), w, req, store)
+}

--- a/api/server/handlers/handlers_auth_service.go
+++ b/api/server/handlers/handlers_auth_service.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/api/server/auth"
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+// authSvcHandler is an HTTP filter for validating the JWT.
+type authSvcHandler struct {
+	handler types.APIFunc
+}
+
+// NewAuthSvcHandler returns a new authSvcHandler.
+func NewAuthSvcHandler() types.Middleware {
+	return &authSvcHandler{}
+}
+
+func (h *authSvcHandler) Name() string {
+	return "auth-svc-handler"
+}
+
+func (h *authSvcHandler) Handler(m types.APIFunc) types.APIFunc {
+	return (&authSvcHandler{m}).Handle
+}
+
+// Handle is the type's Handler function.
+func (h *authSvcHandler) Handle(
+	ctx types.Context,
+	w http.ResponseWriter,
+	req *http.Request,
+	store types.Store) error {
+
+	svc, ok := context.Service(ctx)
+	if !ok {
+		return types.ErrMissingStorageService
+	}
+
+	if svc.AuthConfig() == nil {
+		ctx.Debug("skipping service auth handler; empty auth config")
+		return h.handler(ctx, w, req, store)
+	}
+
+	if len(svc.AuthConfig().Allow) == 0 && len(svc.AuthConfig().Deny) == 0 {
+		ctx.Debug("skipping svc auth handler; empty allow & deny lists")
+		return h.handler(ctx, w, req, store)
+	}
+
+	tok, err := auth.ValidateAuthTokenWithCtxOrReq(ctx, svc.AuthConfig(), req)
+	if err != nil {
+		return err
+	}
+
+	if tok == nil {
+		panic("token should never be nil here")
+	}
+
+	ctx.Debug("validated service security token")
+
+	return h.handler(
+		ctx.WithValue(context.AuthTokenKey, tok), w, req, store)
+}

--- a/api/server/handlers/handlers_errors.go
+++ b/api/server/handlers/handlers_errors.go
@@ -47,8 +47,12 @@ func (h *errorHandler) Handle(
 }
 
 func getStatus(err error) int {
+	if err == types.ErrMissingStorageService {
+		return http.StatusInternalServerError
+	}
 	switch err.(type) {
-	case *types.ErrBadAdminToken:
+	case *types.ErrBadAdminToken,
+		*types.ErrSecTokInvalid:
 		return http.StatusUnauthorized
 	case *types.ErrNotFound:
 		return http.StatusNotFound

--- a/api/server/router/service/service.go
+++ b/api/server/router/service/service.go
@@ -40,6 +40,7 @@ func (r *router) initRoutes() {
 			"services",
 			"/services",
 			r.servicesList,
+			handlers.NewAuthAllSvcsHandler(),
 			handlers.NewSchemaValidator(nil, schema.ServiceInfoMapSchema, nil)),
 
 		httputils.NewGetRoute(
@@ -47,6 +48,7 @@ func (r *router) initRoutes() {
 			"/services/{service}",
 			r.serviceInspect,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewSchemaValidator(nil, schema.ServiceInfoSchema, nil)),
 	}
 }

--- a/api/server/router/snapshot/snapshot.go
+++ b/api/server/router/snapshot/snapshot.go
@@ -43,6 +43,7 @@ func (r *router) initRoutes() {
 			"snapshots",
 			"/snapshots",
 			r.snapshots,
+			handlers.NewAuthAllSvcsHandler(),
 			handlers.NewSchemaValidator(
 				nil, schema.ServiceSnapshotMapSchema, nil),
 		),
@@ -53,6 +54,7 @@ func (r *router) initRoutes() {
 			"/snapshots/{service}",
 			r.snapshotsForService,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				nil, schema.SnapshotMapSchema, nil),
@@ -64,6 +66,7 @@ func (r *router) initRoutes() {
 			"/snapshots/{service}/{snapshotID}",
 			r.snapshotInspect,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(nil, schema.SnapshotSchema, nil),
 		),
@@ -76,6 +79,7 @@ func (r *router) initRoutes() {
 			"/snapshots/{service}/{snapshotID}",
 			r.volumeCreate,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeCreateRequestSchema,
@@ -90,6 +94,7 @@ func (r *router) initRoutes() {
 			"/snapshots/{service}/{snapshotID}",
 			r.snapshotCopy,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.SnapshotCopyRequestSchema,
@@ -106,6 +111,7 @@ func (r *router) initRoutes() {
 			"/snapshots/{service}/{snapshotID}",
 			r.snapshotRemove,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 		),
 	}

--- a/api/server/router/volume/volume.go
+++ b/api/server/router/volume/volume.go
@@ -56,6 +56,7 @@ func (r *router) initRoutes() {
 			"volumes",
 			"/volumes",
 			r.volumes,
+			handlers.NewAuthAllSvcsHandler(),
 			handlers.NewSchemaValidator(nil, schema.ServiceVolumeMapSchema, nil),
 		),
 
@@ -65,6 +66,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}",
 			r.volumesForService,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(nil, schema.VolumeMapSchema, nil),
 		),
@@ -75,6 +77,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeInspect,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(nil, schema.VolumeSchema, nil),
 		),
@@ -87,6 +90,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}",
 			r.volumeDetachAllForService,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeDetachRequestSchema,
@@ -101,6 +105,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}",
 			r.volumeCreate,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeCreateRequestSchema,
@@ -115,6 +120,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeCopy,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeCopyRequestSchema,
@@ -129,6 +135,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeSnapshot,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeSnapshotRequestSchema,
@@ -143,6 +150,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeAttach,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeAttachRequestSchema,
@@ -156,6 +164,7 @@ func (r *router) initRoutes() {
 			"volumesDetachAll",
 			"/volumes",
 			r.volumeDetachAll,
+			handlers.NewAuthAllSvcsHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeDetachRequestSchema,
 				schema.ServiceVolumeMapSchema,
@@ -169,6 +178,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeDetach,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 			handlers.NewSchemaValidator(
 				schema.VolumeDetachRequestSchema,
@@ -183,6 +193,7 @@ func (r *router) initRoutes() {
 			"/volumes/{service}/{volumeID}",
 			r.volumeRemove,
 			handlers.NewServiceValidator(),
+			handlers.NewAuthSvcHandler(),
 			handlers.NewStorageSessionHandler(),
 		),
 	}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -41,6 +41,7 @@ type server struct {
 	ctx          types.Context
 	addrs        []string
 	config       gofig.Config
+	authConfig   *types.AuthConfig
 	servers      []*HTTPServer
 	closeSignal  chan int
 	closedSignal chan int
@@ -146,6 +147,17 @@ func newServer(goCtx gocontext.Context, config gofig.Config) (*server, error) {
 	// always update the server context's log level
 	context.SetLogLevel(s.ctx, logConfig.Level)
 	s.ctx.WithFields(logFields).Info("configured logging")
+
+	authFields := log.Fields{}
+	authConfig, err := utils.ParseAuthConfig(
+		s.ctx, config, authFields, types.ConfigServer)
+	if err != nil {
+		return nil, err
+	}
+	s.authConfig = authConfig
+	if s.authConfig != nil {
+		s.ctx.WithFields(authFields).Info("configured global auth")
+	}
 
 	s.ctx.Info("initializing server")
 

--- a/api/server/server_middleware.go
+++ b/api/server/server_middleware.go
@@ -9,16 +9,15 @@ import (
 func (s *server) initGlobalMiddleware() {
 
 	s.addGlobalMiddleware(handlers.NewQueryParamsHandler())
-
 	if s.logHTTPEnabled {
 		s.addGlobalMiddleware(handlers.NewLoggingHandler(
 			s.stdOut,
 			s.logHTTPRequests,
 			s.logHTTPResponses))
 	}
-
 	s.addGlobalMiddleware(handlers.NewTransactionHandler())
 	s.addGlobalMiddleware(handlers.NewErrorHandler())
+	s.addGlobalMiddleware(handlers.NewAuthGlobalHandler(s.authConfig))
 	s.addGlobalMiddleware(
 		handlers.NewInstanceIDHandler(services.StorageServices(s.ctx)))
 	s.addGlobalMiddleware(handlers.NewLocalDevicesHandler())

--- a/api/types/types_auth.go
+++ b/api/types/types_auth.go
@@ -1,0 +1,45 @@
+package types
+
+// AuthToken is a JSON Web Token.
+//
+// All fields related to times are stored as UTC epochs in seconds.
+type AuthToken struct {
+	// Subject is the intended principal of the token.
+	Subject string `json:"sub"`
+
+	// Expires is the time at which the token expires.
+	Expires int64 `json:"exp"`
+
+	// NotBefore is the the time at which the token becomes valid.
+	NotBefore int64 `json:"nbf"`
+
+	// IssuedAt is the time at which the token was issued.
+	IssuedAt int64 `json:"iat"`
+
+	// Encoded is the encoded JWT string.
+	Encoded string `json:"enc"`
+}
+
+// String returns the subject of the security token.
+func (s *AuthToken) String() string {
+	return s.Subject
+}
+
+// AuthConfig is the auth configuration.
+type AuthConfig struct {
+
+	// Disabled is a flag indicating whether the auth configuration is disabled.
+	Disabled bool
+
+	// Allow is a list of allowed tokens.
+	Allow []string
+
+	// Deny is a list of denied tokens.
+	Deny []string
+
+	// Key is the signing key.
+	Key []byte
+
+	// Alg is the cryptographic algorithm used to sign and verify the token.
+	Alg string
+}

--- a/api/types/types_config.go
+++ b/api/types/types_config.go
@@ -129,4 +129,28 @@ const (
 
 	// ConfigServerTasksLogTimeout is a config key.
 	ConfigServerTasksLogTimeout = ConfigServerTasks + ".logTimeout"
+
+	// ConfigClientAuth is a config key.
+	ConfigClientAuth = ConfigClient + ".auth"
+
+	// ConfigClientAuthToken is a config key.
+	ConfigClientAuthToken = ConfigClientAuth + ".token"
+
+	// ConfigServerAuth is a config key.
+	ConfigServerAuth = ConfigServer + ".auth"
+
+	// ConfigServerAuthKey is a config key.
+	ConfigServerAuthKey = ConfigServerAuth + ".key"
+
+	// ConfigServerAuthAlg is a config key.
+	ConfigServerAuthAlg = ConfigServerAuth + ".alg"
+
+	// ConfigServerAuthAllow is a config key.
+	ConfigServerAuthAllow = ConfigServerAuth + ".allow"
+
+	// ConfigServerAuthDeny is a config key.
+	ConfigServerAuthDeny = ConfigServerAuth + ".deny"
+
+	// ConfigServerAuthDisabled is a config key.
+	ConfigServerAuthDisabled = ConfigServerAuth + ".disabled"
 )

--- a/api/types/types_errors.go
+++ b/api/types/types_errors.go
@@ -51,3 +51,34 @@ type ErrBatchProcess struct{ goof.Goof }
 // ErrBadFilter occurs when a bad filter is supplied via the filter query
 // string.
 type ErrBadFilter struct{ goof.Goof }
+
+// ErrMissingStorageService occurs when the storage service is expected in
+// the provided context but is not there.
+var ErrMissingStorageService = goof.New("missing storage service")
+
+// ErrSecTokInvalid occurs when a security token is invalid.
+type ErrSecTokInvalid struct {
+	// InvalidToken is a flag that indicates whether or not the token was able
+	// to be parsed at all.
+	InvalidToken bool `json:"invalidToken"`
+
+	// InvalidSig is a flag that indicates whether or not the security token
+	// has a valid signature.
+	InvalidSig bool `json:"invalidSig"`
+
+	// MissingClaim is empty if all claims are missing or set to the name
+	// of the first, detected, missing claim.
+	MissingClaim string `json:"claim"`
+
+	// Denied is a flag that indicates whether or not the security token
+	// was denied access.
+	Denied bool
+
+	// InnerError is the inner error that caused this one.
+	InnerError error `json:"innerError,omitempty"`
+}
+
+// Error returns the error string.
+func (e *ErrSecTokInvalid) Error() string {
+	return "invalid security token"
+}

--- a/api/types/types_http_headers.go
+++ b/api/types/types_http_headers.go
@@ -18,4 +18,8 @@ const (
 	// for the first time. This header is provided with every response sent
 	// from the server.
 	ServerNameHeader = "Libstorage-Servername"
+
+	// AuthorizationHeader is the HTTP header that contains the Authorization
+	// information.
+	AuthorizationHeader = "Authorization"
 )

--- a/api/types/types_services.go
+++ b/api/types/types_services.go
@@ -36,6 +36,9 @@ type StorageService interface {
 		ctx Context,
 		run StorageTaskRunFunc,
 		schema []byte) *Task
+
+	// AuthConfig returns the storage service's authentication configuration.
+	AuthConfig() *AuthConfig
 }
 
 // TaskTrackingService a service for tracking tasks.

--- a/api/utils/utils_auth.go
+++ b/api/utils/utils_auth.go
@@ -1,0 +1,77 @@
+package utils
+
+import (
+	"io/ioutil"
+
+	log "github.com/Sirupsen/logrus"
+	gofig "github.com/akutz/gofig/types"
+	"github.com/akutz/gotil"
+
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+// ParseAuthConfig returns a new AuthTokenConfig instance.
+func ParseAuthConfig(
+	ctx types.Context,
+	config gofig.Config,
+	fields log.Fields,
+	roots ...string) (*types.AuthConfig, error) {
+
+	const prefix = types.ConfigServer + "."
+
+	if !isSetPrefix(config, prefix, types.ConfigServerAuthAllow, roots...) {
+		ctx.Debug("server auth config not defined")
+		return nil, nil
+	}
+
+	f := func(k string, v interface{}) {
+		if fields == nil {
+			return
+		}
+		fields[k] = v
+		ctx.WithField(k, v).Debug("parsed server auth property")
+	}
+
+	authConfig := &types.AuthConfig{Alg: "HS256"}
+
+	if isSetPrefix(config, prefix, types.ConfigServerAuthDisabled, roots...) {
+		authConfig.Disabled = getBool(
+			config, types.ConfigServerAuthDisabled, roots...)
+		f(types.ConfigServerAuthDisabled, authConfig.Disabled)
+	}
+
+	if isSetPrefix(config, prefix, types.ConfigServerAuthKey, roots...) {
+		szKey := getStringPrefix(
+			config, prefix, types.ConfigServerAuthKey, roots...)
+		f(types.ConfigServerAuthKey, szKey)
+		if gotil.FileExists(szKey) {
+			buf, err := ioutil.ReadFile(szKey)
+			if err != nil {
+				return nil, err
+			}
+			authConfig.Key = buf
+		} else {
+			authConfig.Key = []byte(szKey)
+		}
+	}
+
+	if isSetPrefix(config, prefix, types.ConfigServerAuthAlg, roots...) {
+		authConfig.Alg = getStringPrefix(
+			config, prefix, types.ConfigServerAuthAlg, roots...)
+	}
+	f(types.ConfigServerAuthAlg, authConfig.Alg)
+
+	if isSetPrefix(config, prefix, types.ConfigServerAuthAllow, roots...) {
+		authConfig.Allow = getStringSlicePrefix(
+			config, prefix, types.ConfigServerAuthAllow, roots...)
+		f(types.ConfigServerAuthAllow, authConfig.Allow)
+	}
+
+	if isSetPrefix(config, prefix, types.ConfigServerAuthDeny, roots...) {
+		authConfig.Deny = getStringSlicePrefix(
+			config, prefix, types.ConfigServerAuthDeny, roots...)
+		f(types.ConfigServerAuthDeny, authConfig.Deny)
+	}
+
+	return authConfig, nil
+}

--- a/api/utils/utils_config.go
+++ b/api/utils/utils_config.go
@@ -12,8 +12,16 @@ func isSet(
 	key string,
 	roots ...string) bool {
 
+	return isSetPrefix(config, "libstorage.", key, roots...)
+}
+
+func isSetPrefix(
+	config gofig.Config,
+	prefix, key string,
+	roots ...string) bool {
+
 	for _, r := range roots {
-		rk := strings.Replace(key, "libstorage.", fmt.Sprintf("%s.", r), 1)
+		rk := strings.Replace(key, prefix, fmt.Sprintf("%s.", r), 1)
 		if config.IsSet(rk) {
 			return true
 		}
@@ -31,10 +39,18 @@ func getString(
 	key string,
 	roots ...string) string {
 
+	return getStringPrefix(config, "libstorage.", key, roots...)
+}
+
+func getStringPrefix(
+	config gofig.Config,
+	prefix, key string,
+	roots ...string) string {
+
 	var val string
 
 	for _, r := range roots {
-		rk := strings.Replace(key, "libstorage.", fmt.Sprintf("%s.", r), 1)
+		rk := strings.Replace(key, prefix, fmt.Sprintf("%s.", r), 1)
 		if val = config.GetString(rk); val != "" {
 			return val
 		}
@@ -53,8 +69,16 @@ func getBool(
 	key string,
 	roots ...string) bool {
 
+	return getBoolPrefix(config, "libstorage.", key, roots...)
+}
+
+func getBoolPrefix(
+	config gofig.Config,
+	prefix, key string,
+	roots ...string) bool {
+
 	for _, r := range roots {
-		rk := strings.Replace(key, "libstorage.", fmt.Sprintf("%s.", r), 1)
+		rk := strings.Replace(key, prefix, fmt.Sprintf("%s.", r), 1)
 		if config.IsSet(rk) {
 			return config.GetBool(rk)
 		}
@@ -65,4 +89,29 @@ func getBool(
 	}
 
 	return false
+}
+
+func getStringSlice(
+	config gofig.Config,
+	key string,
+	roots ...string) []string {
+
+	return getStringSlicePrefix(config, "libstorage.", key, roots...)
+}
+
+func getStringSlicePrefix(
+	config gofig.Config,
+	prefix, key string,
+	roots ...string) []string {
+
+	var val []string
+
+	for _, r := range roots {
+		rk := strings.Replace(key, prefix, fmt.Sprintf("%s.", r), 1)
+		if val = config.GetStringSlice(rk); len(val) > 0 {
+			return val
+		}
+	}
+
+	return config.GetStringSlice(key)
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c152642862b8e0f7841860a41c38308af5eba138069012cafc42ba3559a2fedc
-updated: 2017-04-05T13:11:28.80051104-07:00
+hash: f64aa5d751ece92d338c568b18d04eb9627555c5bc2f3c9c617dc5ada3ac7e84
+updated: 2017-04-06T13:10:12.309656987-05:00
 imports:
 - name: cloud.google.com/go
   version: e4de3dc4493f142c5833f3185e1182025a61f805
@@ -23,7 +23,7 @@ imports:
   - vboxwebsrv
   - virtualboxclient
 - name: github.com/asaskevich/govalidator
-  version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
+  version: fdf19785fd3558d619ef81212f5edf1d6c2a5911
 - name: github.com/aws/aws-sdk-go
   version: 3f8f870ec9939e32b3372abf74d24e468bcd285d
   repo: https://github.com/aws/aws-sdk-go
@@ -104,9 +104,9 @@ imports:
 - name: github.com/digitalocean/godo
   version: 84099941ba2381607e1b05ffd4822781af86675e
 - name: github.com/fsnotify/fsnotify
-  version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
+  version: a904159b9206978bb6d53fcc7a769e5cd726c737
 - name: github.com/go-ini/ini
-  version: 6e4869b434bd001f6983749881c7ead3545887d8
+  version: ee900ca565931451fe4e4409bcbd4316331cec1c
 - name: github.com/golang/protobuf
   version: 8ee79997227bf9b34611aee7946ae64735e6fd93
   subpackages:
@@ -120,9 +120,9 @@ imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: 757bef944d0f21880861c2dd9c871ca543023cba
+  version: 392c28fe23e1c45ddba891b0320b3b5df220beea
 - name: github.com/hashicorp/hcl
-  version: f74cf8281543a0797d7b4ab7d88e76e7ba125308
+  version: 372e8ddaa16fd67e371e9323807d056b799360af
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -138,23 +138,17 @@ imports:
   version: 1dd44b25b79c4d9060e582e90798e4d72537818c
   repo: https://github.com/akutz/go-bindata
 - name: github.com/kardianos/osext
-  version: 9b883c5eb462dd5cb1b0a7a104fe86bc6b9bd391
+  version: 9d302b58e975387d0b4d9be876622c86cefe64be
   repo: https://github.com/kardianos/osext.git
   vcs: git
-- name: github.com/kr/fs
-  version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
 - name: github.com/magiconair/properties
-  version: 0723e352fa358f9322c938cc2dadda874e9151a9
+  version: b3b15ef068fd0b17ddf408a23669f20811d194d2
 - name: github.com/mitchellh/mapstructure
-  version: f3009df150dadf309fdee4a54ed65c124afad715
+  version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/pelletier/go-buffruneio
   version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 - name: github.com/pelletier/go-toml
-  version: 45932ad32dfdd20826f5671da37a5f3ce9f26a8d
-- name: github.com/pkg/errors
-  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
-- name: github.com/pkg/sftp
-  version: 4d0e916071f68db74f8a73926335f809396d6b42
+  version: c9506ee96398e7571356462217b9e24d6a628d71
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -179,18 +173,23 @@ imports:
   repo: https://github.com/codenrhoden/go-vhd
   subpackages:
   - vhd
+- name: github.com/SermoDigital/jose
+  version: f6df55f235c24f236d11dbcf665249a59ac2021f
+  subpackages:
+  - crypto
+  - jws
+  - jwt
 - name: github.com/Sirupsen/logrus
   version: 5f376aa629ac60c3215cc368e674bd996093a01a
   repo: https://github.com/akutz/logrus
 - name: github.com/spf13/afero
-  version: 52e4a6cfac46163658bd4f123c49b6ee7dc75f78
+  version: 72b31426848c6ef12a7a8e216708cb0d1530f074
   subpackages:
   - mem
-  - sftp
 - name: github.com/spf13/cast
-  version: 2580bc98dc0e62908119e4737030cc2fdfc45e4c
+  version: d1139bab1c07d5ad390a65e7305876b3c1a8370b
 - name: github.com/spf13/jwalterweatherman
-  version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
+  version: fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66
 - name: github.com/spf13/pflag
   version: d16db1e50e33dff1b6cdf37596cef36742128670
 - name: github.com/spf13/viper
@@ -206,12 +205,8 @@ imports:
   repo: https://github.com/golang/crypto.git
   vcs: git
   subpackages:
-  - curve25519
-  - ed25519
-  - ed25519/internal/edwards25519
   - pkcs12
   - pkcs12/internal/rc2
-  - ssh
 - name: golang.org/x/net
   version: b336a971b799939dd16ae9b1df8334cb8b977c4d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,6 +21,8 @@ import:
   - package: github.com/codedellemc/gournal
     version: v0.3.0
   - package: github.com/cesanta/validate-json
+  - package: github.com/SermoDigital/jose
+    version: 1.1
 
 
 ################################################################################

--- a/imports/config/imports_config_99_gofig.go
+++ b/imports/config/imports_config_99_gofig.go
@@ -83,5 +83,15 @@ func init() {
 	rk(gofig.String, "0s", "", types.ConfigServerTasksLogTimeout)
 	rk(gofig.Bool, false, "", types.ConfigServerParseRequestOpts)
 
+	// auth config - client
+	rk(gofig.String, "", "", types.ConfigClientAuthToken)
+
+	// auth config - server
+	rk(gofig.String, "", "", types.ConfigServerAuthKey)
+	rk(gofig.String, "HS256", "", types.ConfigServerAuthAlg)
+	rk(gofig.String, "", "", types.ConfigServerAuthAllow)
+	rk(gofig.String, "", "", types.ConfigServerAuthDeny)
+	rk(gofig.Bool, false, "", types.ConfigServerAuthDisabled)
+
 	gofigCore.Register(r)
 }

--- a/libstorage.apib
+++ b/libstorage.apib
@@ -168,6 +168,56 @@ Please see [this section](#def-instance-id) for more information.
 The `Libstorage-Servername` header is returned with every response for
 clients that use it for logging purposes.
 
+## Security
+The libStorage API is primarily hosted via HTTP-REST and therefore
+an HTTP proxy such as [NGINX](https://www.nginx.com) can be leveraged
+to provide security features such as authentication and authorization.
+
+In the absence of an HTTP proxy, software that implements the
+libStorage API should also support
+[JSON Web Tokens (JWT)](https://jwt.io/) to restrict access to
+API resources.
+
+The payload of the libStorage API's JWT follows the below format:
+
+```
+{
+  "exp": 1493592581,
+  "iat": 1491000581,
+  "nbf": 1491000581,
+  "sub": "akutz",
+}
+```
+
+The above payload's claims (fields) are:
+
+Name | Description
+-----|------------
+`exp` | The time at which the token expires. A value of `0` means the token does not expire.
+`iat` | The time at which the token was issued.
+`nbf` | The time at which the token becomes valid.
+`sub` | The principal for whom the token is intended.
+
+All of the above time values are specified as UTC epochs in seconds.
+
+A client transmits the JWT as a
+[_Bearer_](https://tools.ietf.org/html/rfc6750#section-2.1)
+token in the HTTP `Authorization` header. For example:
+
+```
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1MjI2ODg1NTAsImlhdCI6MTQ5MTIzODk1MCwibmJmIjoxNDkxMjM4OTUwLCJzdWIiOiJha3V0eiJ9.3eAA7AQZUGrwA42H64qKbu8QF_AHpSsJSMR0FALnKj8
+```
+
+If the provided token is invalid then the libStorage server should return an
+HTTP status of 401, _Unauthorized_.
+
+Implementations of the libStorage API should support restricting access via
+JWTs both globally and per configured service.
+
+If a `GET /volumes` request is issued and the provided token lacks access to
+one of the services, a 401 `Unauthorized` status will be returned instead of a
+partial dataset.
+
 # Group Root
 
 # Root Resource [/]


### PR DESCRIPTION
This patch introduces support for JSON Web Tokens, used to restrict access to API resources to clients that provide valid tokens with sufficient claims. Please see the commit's doc section for additional information. The docs are also [built](http://libstorage-akutz.readthedocs.io/en/feature-token-support/user-guide/config/#authentication) on my fork at RTFD.