### PR TITLE
Move dobs client to storage package

### DIFF
--- a/drivers/storage/dobs/storage/dobs_client.go
+++ b/drivers/storage/dobs/storage/dobs_client.go
@@ -1,6 +1,6 @@
 // +build !libstorage_storage_driver libstorage_storage_driver_dobs
 
-package utils
+package storage
 
 import (
 	"github.com/codedellemc/libstorage/api"

--- a/drivers/storage/dobs/storage/dobs_storage.go
+++ b/drivers/storage/dobs/storage/dobs_storage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/codedellemc/libstorage/api/types"
 
 	do "github.com/codedellemc/libstorage/drivers/storage/dobs"
-	doUtils "github.com/codedellemc/libstorage/drivers/storage/dobs/utils"
 )
 
 const (
@@ -60,7 +59,7 @@ func (d *driver) Init(
 
 	fields["region"] = d.config.GetString(do.ConfigDORegion)
 
-	client, err := doUtils.Client(token)
+	client, err := Client(token)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The dobs client code was in the utils package, which is imported by the
executor. The dobs client also imports the "godo" package, which is a
non standard lib package that we try to keep out of the executors. The
executor was not using the dobs client at all, so instead move that code
into the actual dobs storage driver package.