### PR TITLE
xcli error enhancements

### DIFF
--- a/cli/lsx/lsx.go
+++ b/cli/lsx/lsx.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/akutz/goof"
+
 	"github.com/codedellemc/libstorage/api/context"
 	"github.com/codedellemc/libstorage/api/registry"
 	apitypes "github.com/codedellemc/libstorage/api/types"
@@ -270,8 +272,16 @@ func Run() {
 		if strings.EqualFold(err.Error(), apitypes.ErrNotImplemented.Error()) {
 			exitCode = apitypes.LSXExitCodeNotImplemented
 		}
+		var errStr string
+		switch e := err.(type) {
+		case goof.Goof:
+			e.IncludeFieldsInError(true)
+			errStr = e.Error()
+		default:
+			errStr = e.Error()
+		}
 		fmt.Fprintf(os.Stderr,
-			"error: error getting %s: %v\n", op, err)
+			"error: error getting %s: %v\n", op, errStr)
 		os.Exit(exitCode)
 	}
 

--- a/drivers/storage/libstorage/libstorage_client_xcli.go
+++ b/drivers/storage/libstorage/libstorage_client_xcli.go
@@ -469,10 +469,17 @@ func (c *client) runExecutor(
 		case types.LSXExitCodeTimedOut:
 			return nil, types.ErrTimedOut
 		}
+		stderr := string(exitError.Stderr)
+		ctx.WithFields(log.Fields{
+			"cmd":    lsxBin,
+			"args":   args,
+			"stderr": stderr,
+		}).Error("error from executor cli")
 		return nil, goof.WithFieldsE(
 			map[string]interface{}{
-				"lsx":  lsxBin,
-				"args": args,
+				"lsx":    lsxBin,
+				"args":   args,
+				"stderr": stderr,
 			},
 			"error executing xcli",
 			err)

--- a/drivers/storage/rbd/executor/rbd_executor.go
+++ b/drivers/storage/rbd/executor/rbd_executor.go
@@ -155,7 +155,11 @@ func GetInstanceID(
 func getCephMonIPs() ([]net.IP, error) {
 	out, err := exec.Command("ceph-conf", "--lookup", "mon_host").Output()
 	if err != nil {
-		return nil, goof.WithError("Unable to get Ceph monitors", err)
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			return nil, goof.WithField("stderr", string(exiterr.Stderr),
+				"unable to get Ceph monitors")
+		}
+		return nil, goof.WithError("unable to get Ceph monitors", err)
 	}
 
 	monStrings := strings.Split(strings.TrimSpace(string(out)), ",")


### PR DESCRIPTION
This patch makes the executor binary emit more detailed error messages
to the stderr when they are encountered. It also modifies the libStorage
client to log the stderr of the lsx command when it sees an error.

