### PR TITLE
Prevent Stdlib Errs from being squashed

### DIFF
--- a/drivers/storage/vfs/storage/vfs_storage.go
+++ b/drivers/storage/vfs/storage/vfs_storage.go
@@ -3,6 +3,7 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -415,6 +416,17 @@ func (d *driver) VolumeAttach(
 	ctx types.Context,
 	volumeID string,
 	opts *types.VolumeAttachOpts) (*types.Volume, string, error) {
+
+	switch os.Getenv("VFS_STDLIB_GOOF_ERR") {
+	case "1":
+		return nil, "", goof.WithFieldE(
+			"path", "/tmp", "this error has an inner error",
+			goof.New("a bug squashing expedition all died"))
+	case "2":
+		return nil, "", goof.WithFieldE(
+			"path", "/tmp", "this error has an inner error",
+			errors.New("a bug squashing expedition all died"))
+	}
 
 	context.MustSession(ctx)
 

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -959,6 +959,80 @@ func TestVolumeAttach(t *testing.T) {
 	apitests.Run(t, vfs.Name, newTestConfig(t), tf)
 }
 
+func TestVolumeAttachGoofErr(t *testing.T) {
+	os.Setenv("VFS_STDLIB_GOOF_ERR", "1")
+	defer os.Setenv("VFS_STDLIB_GOOF_ERR", "")
+
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		nextDevice, err := client.Executor().NextDevice(
+			context.Background().WithValue(context.ServiceKey, vfs.Name),
+			utils.NewStore())
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		_, _, err = client.API().VolumeAttach(
+			nil, vfs.Name, "vfs-002",
+			&types.VolumeAttachRequest{
+				NextDeviceName: &nextDevice,
+			})
+		if !assert.Error(t, err) {
+			t.FailNow()
+		}
+
+		buf, err := json.Marshal(err)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		if !assert.Equal(t,
+			`{"message":"this error has an inner error",`+
+				`"status":500,"error":{"inner":"a bug squashing `+
+				`expedition all died","path":"/tmp"}}`, string(buf)) {
+			t.FailNow()
+		}
+	}
+
+	apitests.Run(t, vfs.Name, newTestConfig(t), tf)
+}
+
+func TestVolumeAttachStdlibErr(t *testing.T) {
+	os.Setenv("VFS_STDLIB_GOOF_ERR", "2")
+	defer os.Setenv("VFS_STDLIB_GOOF_ERR", "")
+
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		nextDevice, err := client.Executor().NextDevice(
+			context.Background().WithValue(context.ServiceKey, vfs.Name),
+			utils.NewStore())
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		_, _, err = client.API().VolumeAttach(
+			nil, vfs.Name, "vfs-002",
+			&types.VolumeAttachRequest{
+				NextDeviceName: &nextDevice,
+			})
+		if !assert.Error(t, err) {
+			t.FailNow()
+		}
+
+		buf, err := json.Marshal(err)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		if !assert.Equal(t,
+			`{"message":"this error has an inner error",`+
+				`"status":500,"error":{"inner":"a bug squashing `+
+				`expedition all died","path":"/tmp"}}`, string(buf)) {
+			t.FailNow()
+		}
+	}
+
+	apitests.Run(t, vfs.Name, newTestConfig(t), tf)
+}
+
 func TestVolumeAttachWithControllerClient(t *testing.T) {
 	tf := func(config gofig.Config, client types.Client, t *testing.T) {
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f64aa5d751ece92d338c568b18d04eb9627555c5bc2f3c9c617dc5ada3ac7e84
-updated: 2017-04-06T13:10:12.309656987-05:00
+hash: e5d4944f91d05d237d92b6adc8d7c102bff25279b4d67622df1cbdec005b79c9
+updated: 2017-04-12T00:23:04.017156239-05:00
 imports:
 - name: cloud.google.com/go
   version: e4de3dc4493f142c5833f3185e1182025a61f805
@@ -13,7 +13,7 @@ imports:
 - name: github.com/akutz/golf
   version: 296de562c59e98534dc2d7b49f6ba310e3edb69d
 - name: github.com/akutz/goof
-  version: ea06624ca980bae80c1b615b8417723436d235ab
+  version: 72efb1916248a881f8d39e20b9709696c5eda708
 - name: github.com/akutz/gotil
   version: 6fa2e80bd3ac40f15788cfc3d12ebba49a0add92
 - name: github.com/appropriate/go-virtualboxclient
@@ -23,7 +23,7 @@ imports:
   - vboxwebsrv
   - virtualboxclient
 - name: github.com/asaskevich/govalidator
-  version: fdf19785fd3558d619ef81212f5edf1d6c2a5911
+  version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/aws/aws-sdk-go
   version: 3f8f870ec9939e32b3372abf74d24e468bcd285d
   repo: https://github.com/aws/aws-sdk-go
@@ -104,9 +104,9 @@ imports:
 - name: github.com/digitalocean/godo
   version: 84099941ba2381607e1b05ffd4822781af86675e
 - name: github.com/fsnotify/fsnotify
-  version: a904159b9206978bb6d53fcc7a769e5cd726c737
+  version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
 - name: github.com/go-ini/ini
-  version: ee900ca565931451fe4e4409bcbd4316331cec1c
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
 - name: github.com/golang/protobuf
   version: 8ee79997227bf9b34611aee7946ae64735e6fd93
   subpackages:
@@ -120,9 +120,9 @@ imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: 392c28fe23e1c45ddba891b0320b3b5df220beea
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
 - name: github.com/hashicorp/hcl
-  version: 372e8ddaa16fd67e371e9323807d056b799360af
+  version: f74cf8281543a0797d7b4ab7d88e76e7ba125308
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -141,14 +141,20 @@ imports:
   version: 9d302b58e975387d0b4d9be876622c86cefe64be
   repo: https://github.com/kardianos/osext.git
   vcs: git
+- name: github.com/kr/fs
+  version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
 - name: github.com/magiconair/properties
-  version: b3b15ef068fd0b17ddf408a23669f20811d194d2
+  version: 0723e352fa358f9322c938cc2dadda874e9151a9
 - name: github.com/mitchellh/mapstructure
-  version: db1efb556f84b25a0a13a04aad883943538ad2e0
+  version: f3009df150dadf309fdee4a54ed65c124afad715
 - name: github.com/pelletier/go-buffruneio
   version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 - name: github.com/pelletier/go-toml
-  version: c9506ee96398e7571356462217b9e24d6a628d71
+  version: 45932ad32dfdd20826f5671da37a5f3ce9f26a8d
+- name: github.com/pkg/errors
+  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
+- name: github.com/pkg/sftp
+  version: 4d0e916071f68db74f8a73926335f809396d6b42
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -183,13 +189,14 @@ imports:
   version: 5f376aa629ac60c3215cc368e674bd996093a01a
   repo: https://github.com/akutz/logrus
 - name: github.com/spf13/afero
-  version: 72b31426848c6ef12a7a8e216708cb0d1530f074
+  version: 52e4a6cfac46163658bd4f123c49b6ee7dc75f78
   subpackages:
   - mem
+  - sftp
 - name: github.com/spf13/cast
-  version: d1139bab1c07d5ad390a65e7305876b3c1a8370b
+  version: 2580bc98dc0e62908119e4737030cc2fdfc45e4c
 - name: github.com/spf13/jwalterweatherman
-  version: fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66
+  version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
 - name: github.com/spf13/pflag
   version: d16db1e50e33dff1b6cdf37596cef36742128670
 - name: github.com/spf13/viper
@@ -205,8 +212,12 @@ imports:
   repo: https://github.com/golang/crypto.git
   vcs: git
   subpackages:
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
   - pkcs12
   - pkcs12/internal/rc2
+  - ssh
 - name: golang.org/x/net
   version: b336a971b799939dd16ae9b1df8334cb8b977c4d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,14 +9,14 @@ import:
     ref:     d16db1e50e33dff1b6cdf37596cef36742128670
   - package: github.com/akutz/golf
     version: v0.1.2
+  - package: github.com/akutz/goof
+    version: v0.1.1
   - package: github.com/Sirupsen/logrus
     ref:     feature/logrus-aware-types
     repo:    https://github.com/akutz/logrus
   - package: github.com/akutz/gofig
     version: v0.1.6
   - package: github.com/akutz/gotil
-    version: v0.1.0
-  - package: github.com/akutz/goof
     version: v0.1.0
   - package: github.com/codedellemc/gournal
     version: v0.3.0


### PR DESCRIPTION
This patch prevents errors created with the stdlib "errors" package from being squashed when they are returned from a remote API call. This PR fixes #128. This patch updates the Goof dependency to v0.1.1 and relies on akutz/goof#5.

This PR has two tests in the VFS test package to assert that inner, stdlib errors are no longer squashed:
* `TestVolumeAttachStdlibErr`
* `TestVolumeAttachGoofErr`