### PR TITLE
Path Enhancements

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -10,7 +10,3 @@ var (
 	// `LIBSTORAGE_DEBUG` is set to a boolean true value.
 	Debug, _ = strconv.ParseBool(os.Getenv("LIBSTORAGE_DEBUG"))
 )
-
-func init() {
-	initPaths()
-}

--- a/api/types/types_paths_test.go
+++ b/api/types/types_paths_test.go
@@ -24,6 +24,7 @@ func TestPaths(t *testing.T) {
 	// vet tool just doesn't handle validating custom verbs.
 	t.Logf("%5[1]s  %[2]s", Home.key(), Home)
 	t.Logf("%5[1]s  %[2]s", Etc.key(), Etc)
+	t.Logf("%5[1]s  %[2]s", TLS.key(), TLS)
 	t.Logf("%5[1]s  %[2]s", Lib.key(), Lib)
 	t.Logf("%5[1]s  %[2]s", Log.key(), Log)
 	t.Logf("%5[1]s  %[2]s", Run.key(), Run)


### PR DESCRIPTION
This patch enhances the way libStorage manages its internal file path workflow.

* There is a new path constant, `TLS`. It's default path is `/etc/libstorage/tls`.

* When `LIBSTORAGE_HOME` is set the path structure removes the nested `libstorage` element. For example, while the default configuration directory is `/etc/libstorage`, now if `LIBSTORAGE_HOME` is set to `/tmp/libstorage` the new configuration directory path will be `/tmp/libstorage/etc` instead of `/tmp/libstorage/etc/libstorage`.

* All path constants can now be explicitly specified via environment variables, independent of the value of `LIBSTORAGE_HOME`. For example, if `LIBSTORAGE_HOME` is set to `/tmp/libstorage`, `LIBSTORAGE_PATHS_ETC` can be set to `/etc/libstorage` to ensure that the configuration directory is not nested inside of `LIBSTORAGE_HOME`. Available environment variables are:

    * `LIBSTORAGE_PATHS_ETC`
    * `LIBSTORAGE_PATHS_LIB`
    * `LIBSTORAGE_PATHS_LOG`
    * `LIBSTORAGE_PATHS_RUN`
    * `LIBSTORAGE_PATHS_TLS`
    * `LIBSTORAGE_PATHS_LSX`