### PR TITLE
ScaleIO, EBS, EFS, increased test coverage (codecov)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - VFS_INSTANCEID_USE_FIELDS=true BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
   - LIBSTORAGE_TEST_TCP=false LIBSTORAGE_TEST_TCP_TLS=true BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
   - LIBSTORAGE_TEST_TCP=false LIBSTORAGE_TEST_TCP_TLS_PEERS=true BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
-  - BUILD_TAGS="gofig pflag libstorage_integration_driver_linux"
+  - BUILD_TAGS="gofig pflag libstorage_integration_driver_linux" TRAVIS_TESTING=true DRIVERS="scaleio ebs efs" COVERAGE_ENABLED=1
   - BUILD_TAGS=""
 
 matrix:
@@ -59,6 +59,7 @@ script:
   - make gometalinter-all
   - make -j build
   - if [ "$BUILD_TAGS" = "$DEFAULT_BUILD_TAGS" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ]; then make -j test; fi
+  - if [ "$COVERAGE_ENABLED" == "1" ] && [ "$TRAVIS_TESTING" == "true" ] && [ "$GOVERSION" == "1.8" ]; then IFS=' ' read -r -a array <<< "$DRIVERS"; for element in "${array[@]}"; do ./drivers/storage/$element/tests/test-env-down.sh; done fi
 
 after_success:
   - if [ "$BUILD_TAGS" = "$DEFAULT_BUILD_TAGS" ] && [ "$TRAVIS_GO_VERSION" = "$COVERED_GO_VERSION" ]; then make -j cover; fi
@@ -69,3 +70,4 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - gcc-4.8
+    - parallel

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,17 @@ ifneq (,$(BUILD_TAGS))
 BUILD_TAGS := $(sort $(BUILD_TAGS))
 endif
 
+#make a new line
+define \n
+
+
+endef
+
+#This allows the ability to enable code coverage testing based on if a
+#a particular driver's file has been modified. If it has, that test is enabled.
+#The issue with this is the code coverage percent jumps up and then back down.
+#FOUND_DRIVERS := $(foreach d,$(DRIVERS),$(foreach f,$(CHANGED_FILES),$(if $d,$(findstring $d,$f),$d)))
+
 all:
 # if docker is running, then let's use docker to build it
 ifneq (,$(shell if docker version &> /dev/null; then echo -; fi))
@@ -806,11 +817,23 @@ GO_PHONY += $$(PKG_TA_$1)-clean
 GO_CLEAN += $$(PKG_TA_$1)-clean
 
 $$(PKG_TC_$1): $$(PKG_TA_$1)
+ifeq (true,$(TRAVIS_TESTING))
+ifeq ($(COVERED_GO_VERSION),$(GOVERSION))
+	if [ -a $1/test-run.sh ] ; \
+	then \
+		$1/test-run.sh $$(PKG_TA_$1) ; \
+	else \
+		$$(PKG_TA_$1) -test.coverprofile $$@  $$(GO_TEST_FLAGS) ; \
+	fi;
+endif
+else
 ifeq (1,$(COVERAGE_ENABLED))
-	$$(PKG_TA_$1) -test.coverprofile $$@ $$(GO_TEST_FLAGS)
+ 	$$(PKG_TA_$1) -test.coverprofile $$@ $$(GO_TEST_FLAGS)
 else
 	$$(PKG_TA_$1) $$(GO_TEST_FLAGS) && touch $$@
 endif
+endif
+
 TEST_PROFILES += $$(PKG_TC_$1)
 
 $$(PKG_TC_$1)-clean:
@@ -1074,12 +1097,36 @@ build-client-nogofig:
 	go build ./client
 
 build:
+	$(MAKE) test-env-up
 	$(MAKE) build-generated
 	$(MAKE) build-libstorage
 ifeq ($(GOOS),$(GOHOSTOS))
 	$(MAKE) libstor-c libstor-s
 endif
 	$(MAKE) build-lss
+ifeq (true,$(TRAVIS_TESTING))
+	$(MAKE) cover
+endif
+	$(MAKE) test-env-down
+
+test-env-up:
+ifeq (true,$(TRAVIS_TESTING))
+ifeq ($(COVERED_GO_VERSION),$(GOVERSION))
+	@echo Begin environment creation
+	$(foreach d,$(DRIVERS), ./drivers/storage/$(d)/tests/test-env-up.sh${\n})
+	@echo Finish environment creation
+endif
+endif
+
+test-env-down:
+ifeq (true,$(TRAVIS_TESTING))
+ifeq ($(COVERED_GO_VERSION),$(GOVERSION))
+	@echo Begin environment teardown
+	$(foreach d,$(DRIVERS), echo ./drivers/storage/$(d)/tests/test-env-down.sh >> ./teardown.txt${\n})
+	NUMOFLINES=$$(wc -l ./teardown.txt | awk '{print $$1}'); parallel --jobs $$NUMOFLINES < ./teardown.txt
+	@echo Finish environment teardown
+endif
+endif
 
 parallel-test: $(filter-out ./drivers/storage/vfs/%,$(GO_TEST))
 vfs-test: $(filter ./drivers/storage/vfs/%,$(GO_TEST))

--- a/drivers/storage/ebs/tests/coverage.mk
+++ b/drivers/storage/ebs/tests/coverage.mk
@@ -1,2 +1,2 @@
 EBS_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/ebs
-TEST_COVERPKG_./drivers/storage/ebs/tests := $(EBS_COVERPKG),$(EBS_COVERPKG)/executor
+TEST_COVERPKG_./drivers/storage/ebs/tests := $(EBS_COVERPKG),$(EBS_COVERPKG)/executor,$(EBS_COVERPKG)/storage

--- a/drivers/storage/ebs/tests/test-cf-template.json
+++ b/drivers/storage/ebs/tests/test-cf-template.json
@@ -31,7 +31,8 @@
         "parent": "19117008-4607-4d30-95d7-9e27b231f551",
         "embeds": [
           "b2904db7-7420-44e0-9bd7-078c253f58e8",
-          "05dd39d3-73fc-4732-be16-9966f7fa4769"
+          "05dd39d3-73fc-4732-be16-9966f7fa4769",
+          "0b3b1e8b-5559-4a13-bf67-7312d43b361c"
         ]
       },
       "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a": {
@@ -168,6 +169,25 @@
         },
         "position": {
           "x": 960,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "0b3b1e8b-5559-4a13-bf67-7312d43b361c": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 1050,
           "y": 270
         },
         "z": 3,
@@ -331,7 +351,121 @@
         }
       }
     },
-    "EfsNode2": {
+    "EbsNode3": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-44831524",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "EbsNode3"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.13",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo EbsNode3 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "0b3b1e8b-5559-4a13-bf67-7312d43b361c"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "EbsNode2": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
@@ -339,7 +473,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "EfsNode2"
+            "Value": "EbsNode2"
           }
         ],
         "KeyName": {
@@ -367,7 +501,7 @@
               "",
               [
                 "#!/bin/bash -xe\n",
-                "echo EfsNode2 > /etc/hostname",
+                "echo EbsNode2 > /etc/hostname",
                 "yum update -y aws-cfn-bootstrap\n",
                 "# Install the files and packages from the metadata\n",
                 "/opt/aws/bin/cfn-init -v ",
@@ -445,7 +579,7 @@
         "PublicRoute"
       ]
     },
-    "EfsNode1": {
+    "EbsNode1": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
@@ -453,7 +587,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "EfsNode1"
+            "Value": "EbsNode1"
           }
         ],
         "KeyName": {
@@ -481,7 +615,7 @@
               "",
               [
                 "#!/bin/bash -xe\n",
-                "echo EfsNode1 > /etc/hostname",
+                "echo EbsNode1 > /etc/hostname",
                 "yum update -y aws-cfn-bootstrap\n",
                 "# Install the files and packages from the metadata\n",
                 "/opt/aws/bin/cfn-init -v ",
@@ -631,7 +765,7 @@
             "http://",
             {
               "Fn::GetAtt": [
-                "EfsNode1",
+                "EbsNode1",
                 "PublicIp"
               ]
             }

--- a/drivers/storage/ebs/tests/test-env-down.sh
+++ b/drivers/storage/ebs/tests/test-env-down.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+# This script cleans up the infrastructure used for tests
+
+#set -e
+
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    apt-get install -y curl
+  else
+    brew install curl
+  fi
+}
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  ./awscli-bundle/install -b ~/bin/aws
+  export PATH=~/bin:$PATH
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    apt-get install -y jq
+  else
+    brew install jq
+  fi
+}
+
+CF_STACK_NAME=$(cat ./ebs-uniquename)
+if [ -z "${CF_STACK_NAME}" ]; then
+  echo "stack-name not found or already deleted"
+  exit 0
+fi
+
+# Get stack ID
+CF_STACK_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${CF_STACK_NAME} \
+  --output text \
+  --query 'Stacks[0].StackId')
+
+# Delete cloud formation stack
+aws cloudformation delete-stack \
+  --stack-name ${CF_STACK_NAME}
+
+echo "Waiting for CF stack to get deleted ..."
+
+aws cloudformation wait stack-delete-complete \
+  --stack-name ${CF_STACK_ID}
+
+VOL1ANAME=$CF_STACK_NAME"_1a"
+VOL1BNAME=$CF_STACK_NAME"_1b"
+VOL2ANAME=$CF_STACK_NAME"_2a"
+VOL2BNAME=$CF_STACK_NAME"_2b"
+VOL3ANAME=$CF_STACK_NAME"_3a"
+VOL3BNAME=$CF_STACK_NAME"_3b"
+
+VOL1A=$(aws ec2 describe-volumes | jq '.Volumes[] | select(.Tags[]?.Value=="'${VOL1ANAME}'")' | jq -r .VolumeId)
+VOL1B=$(aws ec2 describe-volumes | jq '.Volumes[] | select(.Tags[]?.Value=="'${VOL1BNAME}'")' | jq -r .VolumeId)
+VOL2A=$(aws ec2 describe-volumes | jq '.Volumes[] | select(.Tags[]?.Value=="'${VOL2ANAME}'")' | jq -r .VolumeId)
+VOL2B=$(aws ec2 describe-volumes | jq '.Volumes[] | select(.Tags[]?.Value=="'${VOL2BNAME}'")' | jq -r .VolumeId)
+VOL3A=$(aws ec2 describe-volumes | jq '.Volumes[] | select(.Tags[]?.Value=="'${VOL3ANAME}'")' | jq -r .VolumeId)
+VOL3B=$(aws ec2 describe-volumes | jq '.Volumes[] | select(.Tags[]?.Value=="'${VOL3BNAME}'")' | jq -r .VolumeId)
+#echo $VOL1A
+#echo $VOL1B
+#echo $VOL2A
+#echo $VOL2B
+#echo $VOL3A
+#echo $VOL3B
+
+if [ "$VOL1A" != "" ]; then
+  aws ec2 detach-volume --volume-id $VOL1A
+  aws ec2 delete-volume --volume-id $VOL1A
+fi
+if [ "$VOL1B" != "" ]; then
+  aws ec2 detach-volume --volume-id $VOL1B
+  aws ec2 delete-volume --volume-id $VOL1B
+fi
+if [ "$VOL2A" != "" ]; then
+  aws ec2 detach-volume --volume-id $VOL2A
+  aws ec2 delete-volume --volume-id $VOL2A
+fi
+if [ "$VOL2B" != "" ]; then
+  aws ec2 detach-volume --volume-id $VOL2B
+  aws ec2 delete-volume --volume-id $VOL2B
+fi
+if [ "$VOL3A" != "" ]; then
+  aws ec2 detach-volume --volume-id $VOL3A
+  aws ec2 delete-volume --volume-id $VOL3A
+fi
+if [ "$VOL3B" != "" ]; then
+  aws ec2 detach-volume --volume-id $VOL3B
+  aws ec2 delete-volume --volume-id $VOL3B
+fi
+
+rm -f ./ebs-uniquename
+
+echo "Stack has been deleted"

--- a/drivers/storage/ebs/tests/test-env-up.sh
+++ b/drivers/storage/ebs/tests/test-env-up.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script launches infrastructure required for testing the EFS storage driver.
+# This script launches infrastructure required for testing the EBS storage driver.
 # It spins up VPC and EC2 instance so AWS account owner will get charged for time
 # that resources will be running.
 
@@ -89,8 +89,8 @@ else
   exit 1
 fi
 
-rm -f ./efs-uniquename
-echo ${CF_STACK_NAME} > ./efs-uniquename
+rm -f ./ebs-uniquename
+echo ${CF_STACK_NAME} > ./ebs-uniquename
 
 if [ ! -f ~/.aws/credentials ]; then
   aws configure set aws_access_key_id ${AWS_ACCESSKEY}

--- a/drivers/storage/ebs/tests/test-run.sh
+++ b/drivers/storage/ebs/tests/test-run.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+# This script runs tests
+
+# set -e
+
+: ${COVERPROFILE_NAME:="ebs.test.out"}
+
+TEST_BINARY=${TEST_BINARY:-$1}
+CF_EC2_USER=${CF_EC2_USER:-$2}
+
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    apt-get install -y curl
+  else
+    brew install curl
+  fi
+}
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  ./awscli-bundle/install -b ~/bin/aws
+  export PATH=~/bin:$PATH
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    apt-get install -y jq
+  else
+    brew install jq
+  fi
+}
+
+usage() {
+  echo "Usage: ${0} test-binary ec2-user"
+  echo ""
+  echo "   test-binary: Path to compiled and runnable golang binary"
+  echo "   ec2-user: User to log into instance. Default (RHEL7): ec2-user"
+}
+
+if [ -z "${TEST_BINARY}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${CF_EC2_USER}" ]; then
+  CF_EC2_USER="ec2-user"
+fi
+
+CF_STACK_NAME=$(cat ./ebs-uniquename)
+if [ -z "${CF_STACK_NAME}" ]; then
+  echo "stack-name not found"
+  exit 1
+fi
+AWS_ACCESSKEY=$(awk -F "=" '/aws_access_key_id/ {print $2}' ~/.aws/credentials | awk '{$1=$1};1')
+if [ -z "${AWS_ACCESSKEY}" ]; then
+  echo "aws-accesskey not found"
+  exit 1
+fi
+AWS_SECRETKEY=$(awk -F "=" '/aws_secret_access_key/ {print $2}' ~/.aws/credentials | awk '{$1=$1};1')
+if [ -z "${AWS_SECRETKEY}" ]; then
+  echo "aws-secretkey not found"
+  exit 1
+fi
+
+
+echo "Waiting for CF stack to come up ..."
+
+aws cloudformation wait stack-create-complete \
+  --stack-name ${CF_STACK_NAME}
+
+# Get IP address of EC2 machine where tests can be executed
+EBS_NODE1=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="EbsNode1")' | jq -r .PhysicalResourceId)
+#EBS_NODE2=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="EbsNode2")' | jq -r .PhysicalResourceId)
+#EBS_NODE3=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="EbsNode3")' | jq -r .PhysicalResourceId)
+#echo ${EBS_NODE1}
+#echo ${EBS_NODE2}
+#echo ${EBS_NODE3}
+
+EBS_NODE1_FQDN=$(aws ec2 describe-instances --instance-ids ${EBS_NODE1} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#EBS_NODE2_FQDN=$(aws ec2 describe-instances --instance-ids ${EBS_NODE2} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#EBS_NODE3_FQDN=$(aws ec2 describe-instances --instance-ids ${EBS_NODE3} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#echo ${EBS_NODE1_FQDN}
+#echo ${EBS_NODE2_FQDN}
+#echo ${EBS_NODE3_FQDN}
+
+# wait for the OS to be running
+READY1=$(aws ec2 describe-instance-status --instance-ids ${EBS_NODE1} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+while [ "$READY1" != "ok" ];
+do
+  sleep 10
+  echo "Checking EBS Node1..."
+  READY1=$(aws ec2 describe-instance-status --instance-ids ${EBS_NODE1} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+done
+#READY2=$(aws ec2 describe-instance-status --instance-ids ${EBS_NODE2} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#while [ "$READY2" != "ok" ];
+#do
+#  sleep 10
+#  echo "Checking EBS Node2..."
+#  READY2=$(aws ec2 describe-instance-status --instance-ids ${EBS_NODE2} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#done
+#READY3=$(aws ec2 describe-instance-status --instance-ids ${EBS_NODE3} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#while [ "$READY3" != "ok" ];
+#do
+#  sleep 10
+#  echo "Checking EBS Node3..."
+#  READY3=$(aws ec2 describe-instance-status --instance-ids ${EBS_NODE3} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#done
+
+sleep 10
+
+ssh-keyscan -H ${EBS_NODE1_FQDN} >> ~/.ssh/known_hosts
+#ssh-keyscan -H ${EBS_NODE2_FQDN} >> ~/.ssh/known_hosts
+#ssh-keyscan -H ${EBS_NODE3_FQDN} >> ~/.ssh/known_hosts
+
+FIRST_VOLUME=$CF_STACK_NAME"_1a"
+SECOND_VOLUME=$CF_STACK_NAME"_1b"
+
+# ssh key to use
+SSH_KEY_FILE=$(cat ./keyfile)
+
+# Copy go test binary to EC2 instance
+scp -i ~/.ssh/${SSH_KEY_FILE} $TEST_BINARY $CF_EC2_USER@$EBS_NODE1_FQDN:/tmp/ebs.test
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE1_FQDN "sudo chmod +x /tmp/ebs.test"
+
+echo "Executing Tests!"
+# Run tests... note the use of "bash --login -c". this forces a load of the user's
+# env variables while cause the make command to fail.
+# Yes, node1 uses test2 and vice versa
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE1_FQDN "bash --login -c 'AWS_ACCESSKEY=$AWS_ACCESSKEY AWS_SECRETKEY=$AWS_SECRETKEY FIRST_VOLUME=$FIRST_VOLUME SECOND_VOLUME=$SECOND_VOLUME sudo -E /tmp/ebs.test -test.coverprofile ${COVERPROFILE_NAME}'"
+
+# Copy test coverage results
+scp -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EBS_NODE1_FQDN:$COVERPROFILE_NAME $(dirname $0)
+
+echo "Tests passed and coverge results are available at ${COVERPROFILE_NAME}"

--- a/drivers/storage/ebs/utils/utils_test.go
+++ b/drivers/storage/ebs/utils/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/codedellemc/libstorage/api/context"
+	"github.com/codedellemc/libstorage/drivers/storage/ebs"
 )
 
 func skipTest(t *testing.T) {
@@ -20,7 +21,7 @@ func skipTest(t *testing.T) {
 
 func TestInstanceID(t *testing.T) {
 	skipTest(t)
-	iid, err := InstanceID(context.Background())
+	iid, err := InstanceID(context.Background(), ebs.Name)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/drivers/storage/efs/tests/test-run.sh
+++ b/drivers/storage/efs/tests/test-run.sh
@@ -2,37 +2,78 @@
 
 # This script runs tests
 
-set -e
-# set -x
+# set -e
 
-: ${CF_STACK_NAME:="libstorage-efs-integration-test"}
-: ${CF_EC2_USER:="ec2-user"}
 : ${COVERPROFILE_NAME:="efs.test.out"}
 
-TEST_BINARY="$1"
+TEST_BINARY=${TEST_BINARY:-$1}
+CF_EC2_USER=${CF_EC2_USER:-$2}
 
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    apt-get install -y curl
+  else
+    brew install curl
+  fi
+}
 # Make sure that aws cli is installed
 hash aws 2>/dev/null || {
-  echo >&2 "Missing AWS command line. Please install aws cli: https://aws.amazon.com/cli/"
-  exit 1
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  ./awscli-bundle/install -b ~/bin/aws
+  export PATH=~/bin:$PATH
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    apt-get install -y jq
+  else
+    brew install jq
+  fi
 }
 
 usage() {
-  echo "Usage: ${0} test-binary"
+  echo "Usage: ${0} test-binary ec2-user"
   echo ""
   echo "   test-binary: Path to compiled and runnable golang binary"
+  echo "   ec2-user: User to log into instance. Default (RHEL7): ec2-user"
 }
 
 if [ -z "${TEST_BINARY}" ]; then
   usage
   exit 1
 fi
+if [ -z "${CF_EC2_USER}" ]; then
+  CF_EC2_USER="ec2-user"
+fi
 
-# Require valid test binary file
-if [ ! -f "${TEST_BINARY}" ]; then
-  echo >&2 "${TEST_BINARY} is not a valid file"
+CF_STACK_NAME=$(cat ./efs-uniquename)
+if [ -z "${CF_STACK_NAME}" ]; then
+  echo "stack-name not found"
   exit 1
 fi
+AWS_ACCESSKEY=$(awk -F "=" '/aws_access_key_id/ {print $2}' ~/.aws/credentials | awk '{$1=$1};1')
+if [ -z "${AWS_ACCESSKEY}" ]; then
+  echo "aws-accesskey not found"
+  exit 1
+fi
+AWS_SECRETKEY=$(awk -F "=" '/aws_secret_access_key/ {print $2}' ~/.aws/credentials | awk '{$1=$1};1')
+if [ -z "${AWS_SECRETKEY}" ]; then
+  echo "aws-secretkey not found"
+  exit 1
+fi
+
 
 echo "Waiting for CF stack to come up ..."
 
@@ -40,19 +81,68 @@ aws cloudformation wait stack-create-complete \
   --stack-name ${CF_STACK_NAME}
 
 # Get IP address of EC2 machine where tests can be executed
-EC2_IP_ADDRESS=$(aws cloudformation describe-stacks \
-  --stack-name libstorage-efs-integration-test \
-  --query 'Stacks[0].Outputs[?OutputKey==`Ec2IpAddress`].{OutputValue:OutputValue}[0].OutputValue' \
-  --output text)
+EFS_NODE1=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="EfsNode1")' | jq -r .PhysicalResourceId)
+#EFS_NODE2=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="EfsNode2")' | jq -r .PhysicalResourceId)
+#EFS_NODE3=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="EfsNode3")' | jq -r .PhysicalResourceId)
+#echo ${EFS_NODE1}
+#echo ${EFS_NODE2}
+#echo ${EFS_NODE3}
 
-# Copy binary file to EC2 instance
-scp $TEST_BINARY $CF_EC2_USER@$EC2_IP_ADDRESS:efs.test
+EFS_NODE1_FQDN=$(aws ec2 describe-instances --instance-ids ${EFS_NODE1} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#EFS_NODE2_FQDN=$(aws ec2 describe-instances --instance-ids ${EFS_NODE2} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#EFS_NODE3_FQDN=$(aws ec2 describe-instances --instance-ids ${EFS_NODE3} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#echo ${EFS_NODE1_FQDN}
+#echo ${EFS_NODE2_FQDN}
+#echo ${EFS_NODE3_FQDN}
 
-# Run tests
-CMD="./efs.test -test.coverprofile ${COVERPROFILE_NAME}"
-ssh $CF_EC2_USER@$EC2_IP_ADDRESS $CMD
+# wait for the OS to be running
+READY1=$(aws ec2 describe-instance-status --instance-ids ${EFS_NODE1} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+while [ "$READY1" != "ok" ];
+do
+  sleep 10
+  echo "Checking EFS Node1..."
+  READY1=$(aws ec2 describe-instance-status --instance-ids ${EFS_NODE1} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+done
+#READY2=$(aws ec2 describe-instance-status --instance-ids ${EFS_NODE2} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#while [ "$READY2" != "ok" ];
+#do
+#  sleep 10
+#  echo "Checking EFS Node2..."
+#  READY2=$(aws ec2 describe-instance-status --instance-ids ${EFS_NODE2} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#done
+#READY3=$(aws ec2 describe-instance-status --instance-ids ${EFS_NODE3} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#while [ "$READY3" != "ok" ];
+#do
+#  sleep 10
+#  echo "Checking EFS Node3..."
+#  READY3=$(aws ec2 describe-instance-status --instance-ids ${EFS_NODE3} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#done
+
+sleep 10
+
+ssh-keyscan -H ${EFS_NODE1_FQDN} >> ~/.ssh/known_hosts
+#ssh-keyscan -H ${EFS_NODE2_FQDN} >> ~/.ssh/known_hosts
+#ssh-keyscan -H ${EFS_NODE3_FQDN} >> ~/.ssh/known_hosts
+
+FIRST_VOLUME=$CF_STACK_NAME"_1a"
+SECOND_VOLUME=$CF_STACK_NAME"_1b"
+
+# ssh key to use
+SSH_KEY_FILE=$(cat ./keyfile)
+
+# Copy go test binary to EC2 instance
+scp -i ~/.ssh/${SSH_KEY_FILE} $TEST_BINARY $CF_EC2_USER@$EFS_NODE1_FQDN:/tmp/efs.test
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EFS_NODE1_FQDN "sudo chmod +x /tmp/efs.test"
+
+echo "Executing Tests!"
+#reduced EFS testing to single node because of API throttling issue on AWS
+
+# Run tests... note the use of "bash --login -c". this forces a load of the user's
+# env variables while cause the make command to fail.
+# Yes, node1 uses test2 and vice versa
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EFS_NODE1_FQDN "bash --login -c 'AWS_ACCESSKEY=$AWS_ACCESSKEY AWS_SECRETKEY=$AWS_SECRETKEY FIRST_VOLUME=$FIRST_VOLUME SECOND_VOLUME=$SECOND_VOLUME sudo -E /tmp/efs.test -test.coverprofile ${COVERPROFILE_NAME}'"
 
 # Copy test coverage results
-scp $CF_EC2_USER@$EC2_IP_ADDRESS:${COVERPROFILE_NAME} $(dirname $0)
+scp -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$EFS_NODE1_FQDN:$COVERPROFILE_NAME $(dirname $0)
 
-echo "Tests passed and coverge results are available at $(dirname $0)/${COVERPROFILE_NAME}"
+echo "Tests passed and coverge results are available at ${COVERPROFILE_NAME}"

--- a/drivers/storage/scaleio/tests/coverage.mk
+++ b/drivers/storage/scaleio/tests/coverage.mk
@@ -1,2 +1,2 @@
 SCALEIO_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/scaleio
-TEST_COVERPKG_./drivers/storage/scaleio/tests := $(SCALEIO_COVERPKG),$(SCALEIO_COVERPKG)/executor
+TEST_COVERPKG_./drivers/storage/scaleio/tests := $(SCALEIO_COVERPKG),$(SCALEIO_COVERPKG)/executor,$(SCALEIO_COVERPKG)/storage

--- a/drivers/storage/scaleio/tests/test-cf-template.json
+++ b/drivers/storage/scaleio/tests/test-cf-template.json
@@ -31,7 +31,8 @@
         "parent": "19117008-4607-4d30-95d7-9e27b231f551",
         "embeds": [
           "b2904db7-7420-44e0-9bd7-078c253f58e8",
-          "05dd39d3-73fc-4732-be16-9966f7fa4769"
+          "05dd39d3-73fc-4732-be16-9966f7fa4769",
+          "0b3b1e8b-5559-4a13-bf67-7312d43b361c"
         ]
       },
       "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a": {
@@ -168,6 +169,25 @@
         },
         "position": {
           "x": 960,
+          "y": 270
+        },
+        "z": 3,
+        "parent": "e3f368ef-533b-484c-b3f4-897729901208",
+        "embeds": [],
+        "dependson": [
+          "fe5557b3-266c-40ef-b6bd-4ad21f7511c5"
+        ],
+        "isrelatedto": [
+          "d232ad6c-80ca-4c33-ac38-bbbf89e7dd4a"
+        ]
+      },
+      "0b3b1e8b-5559-4a13-bf67-7312d43b361c": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": 1050,
           "y": 270
         },
         "z": 3,
@@ -331,15 +351,129 @@
         }
       }
     },
-    "EfsNode2": {
+    "ScaleIONode3": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
-        "ImageId": "ami-e5861085",
+        "ImageId": "ami-8c8412ec",
         "Tags": [
           {
             "Key": "Name",
-            "Value": "EfsNode2"
+            "Value": "ScaleIONode3"
+          }
+        ],
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "NetworkInterfaces": [
+          {
+            "GroupSet": [
+              {
+                "Ref": "ScaleIOSecGroup"
+              }
+            ],
+            "AssociatePublicIpAddress": "true",
+            "DeviceIndex": "0",
+            "DeleteOnTermination": "true",
+            "PrivateIpAddress": "10.0.0.13",
+            "SubnetId": {
+              "Ref": "ScaleIOSubnet"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash -xe\n",
+                "echo ScaleIONode3 > /etc/hostname",
+                "yum update -y aws-cfn-bootstrap\n",
+                "# Install the files and packages from the metadata\n",
+                "/opt/aws/bin/cfn-init -v ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --configsets All ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n",
+                "# Signal the status from cfn-init\n",
+                "/opt/aws/bin/cfn-signal -e $? ",
+                "         --stack ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                "         --resource WebServerInstance ",
+                "         --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                "\n"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "0b3b1e8b-5559-4a13-bf67-7312d43b361c"
+        },
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "All": [
+              "ConfigureSampleApp"
+            ]
+          },
+          "ConfigureSampleApp": {
+            "packages": {
+              "yum": {
+                "httpd": []
+              }
+            },
+            "files": {
+              "/var/www/html/index.html": {
+                "content": {
+                  "Fn::Join": [
+                    "\n",
+                    [
+                      "<h1>Congratulations, you have successfully launched the AWS CloudFormation sample.</h1>"
+                    ]
+                  ]
+                },
+                "mode": "000644",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "httpd": {
+                  "enabled": "true",
+                  "ensureRunning": "true"
+                }
+              }
+            }
+          }
+        }
+      },
+      "DependsOn": [
+        "PublicRoute"
+      ]
+    },
+    "ScaleIONode2": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "t2.medium",
+        "ImageId": "ami-0e82146e",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "ScaleIONode2"
           }
         ],
         "KeyName": {
@@ -367,7 +501,7 @@
               "",
               [
                 "#!/bin/bash -xe\n",
-                "echo EfsNode2 > /etc/hostname",
+                "echo ScaleIONode2 > /etc/hostname",
                 "yum update -y aws-cfn-bootstrap\n",
                 "# Install the files and packages from the metadata\n",
                 "/opt/aws/bin/cfn-init -v ",
@@ -445,15 +579,15 @@
         "PublicRoute"
       ]
     },
-    "EfsNode1": {
+    "ScaleIONode1": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "t2.medium",
-        "ImageId": "ami-26821446",
+        "ImageId": "ami-fc84129c",
         "Tags": [
           {
             "Key": "Name",
-            "Value": "EfsNode1"
+            "Value": "ScaleIONode1"
           }
         ],
         "KeyName": {
@@ -481,7 +615,7 @@
               "",
               [
                 "#!/bin/bash -xe\n",
-                "echo EfsNode1 > /etc/hostname",
+                "echo ScaleIONode1 > /etc/hostname",
                 "yum update -y aws-cfn-bootstrap\n",
                 "# Install the files and packages from the metadata\n",
                 "/opt/aws/bin/cfn-init -v ",
@@ -631,7 +765,7 @@
             "http://",
             {
               "Fn::GetAtt": [
-                "EfsNode1",
+                "ScaleIONode1",
                 "PublicIp"
               ]
             }

--- a/drivers/storage/scaleio/tests/test-env-down.sh
+++ b/drivers/storage/scaleio/tests/test-env-down.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# This script cleans up the infrastructure used for tests
+
+#set -e
+
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    apt-get install -y curl
+  else
+    brew install curl
+  fi
+}
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  ./awscli-bundle/install -b ~/bin/aws
+  export PATH=~/bin:$PATH
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    apt-get install -y jq
+  else
+    brew install jq
+  fi
+}
+
+CF_STACK_NAME=$(cat ./scaleio-uniquename)
+if [ -z "${CF_STACK_NAME}" ]; then
+  echo "stack-name not found or already deleted"
+  exit 0
+fi
+
+# Get stack ID
+CF_STACK_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${CF_STACK_NAME} \
+  --output text \
+  --query 'Stacks[0].StackId')
+
+# Delete cloud formation stack
+aws cloudformation delete-stack \
+  --stack-name ${CF_STACK_NAME}
+
+echo "Waiting for CF stack to get deleted ..."
+
+aws cloudformation wait stack-delete-complete \
+  --stack-name ${CF_STACK_ID}
+
+rm -f ./scaleio-uniquename
+
+echo "Stack has been deleted"

--- a/drivers/storage/scaleio/tests/test-env-up.sh
+++ b/drivers/storage/scaleio/tests/test-env-up.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script launches infrastructure required for testing the EFS storage driver.
+# This script launches infrastructure required for testing the ScaleIO storage driver.
 # It spins up VPC and EC2 instance so AWS account owner will get charged for time
 # that resources will be running.
 
@@ -89,8 +89,8 @@ else
   exit 1
 fi
 
-rm -f ./efs-uniquename
-echo ${CF_STACK_NAME} > ./efs-uniquename
+rm -f ./scaleio-uniquename
+echo ${CF_STACK_NAME} > ./scaleio-uniquename
 
 if [ ! -f ~/.aws/credentials ]; then
   aws configure set aws_access_key_id ${AWS_ACCESSKEY}

--- a/drivers/storage/scaleio/tests/test-run.sh
+++ b/drivers/storage/scaleio/tests/test-run.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+# This script runs tests
+
+# set -e
+
+: ${COVERPROFILE_NAME:="scaleio.test.out"}
+
+TEST_BINARY=${TEST_BINARY:-$1}
+CF_EC2_USER=${CF_EC2_USER:-$2}
+
+# Make sure that jq is installed
+hash curl 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    yum -y install curl
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    apt-get install -y curl
+  else
+    brew install curl
+  fi
+}
+# Make sure that aws cli is installed
+hash aws 2>/dev/null || {
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+  unzip /tmp/awscli-bundle.zip
+  ./awscli-bundle/install -b ~/bin/aws
+  export PATH=~/bin:$PATH
+}
+# Make sure that jq is installed
+hash jq 2>/dev/null || {
+  if [ -e "/etc/redhat-release" -o \
+         -e "/etc/redhat-version" ]; then
+    yum -y install jq
+  elif [ -e "/etc/debian-release" -o \
+         -e "/etc/debian-version" -o \
+         -e "/etc/lsb-release" ]; then
+    apt-get install -y jq
+  else
+    brew install jq
+  fi
+}
+
+usage() {
+  echo "Usage: ${0} test-binary ec2-user"
+  echo ""
+  echo "   test-binary: Path to compiled and runnable golang binary"
+  echo "   ec2-user: User to log into instance. Default (RHEL7): ec2-user"
+}
+
+if [ -z "${TEST_BINARY}" ]; then
+  usage
+  exit 1
+fi
+if [ -z "${CF_EC2_USER}" ]; then
+  CF_EC2_USER="ec2-user"
+fi
+
+CF_STACK_NAME=$(cat ./scaleio-uniquename)
+if [ -z "${CF_STACK_NAME}" ]; then
+  echo "stack-name not found"
+  exit 1
+fi
+
+echo "Waiting for CF stack to come up ..."
+
+aws cloudformation wait stack-create-complete \
+  --stack-name ${CF_STACK_NAME}
+
+# Get IP address of EC2 machine where tests can be executed
+SCALEIO_NODE1=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="ScaleIONode1")' | jq -r .PhysicalResourceId)
+#SCALEIO_NODE2=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="ScaleIONode2")' | jq -r .PhysicalResourceId)
+#SCALEIO_NODE3=$(aws cloudformation describe-stack-resources --stack-name ${CF_STACK_NAME} | jq '.StackResources[] | select(.LogicalResourceId=="ScaleIONode3")' | jq -r .PhysicalResourceId)
+#echo ${SCALEIO_NODE1}
+#echo ${SCALEIO_NODE2}
+#echo ${SCALEIO_NODE3}
+
+SCALEIO_NODE1_FQDN=$(aws ec2 describe-instances --instance-ids ${SCALEIO_NODE1} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#SCALEIO_NODE2_FQDN=$(aws ec2 describe-instances --instance-ids ${SCALEIO_NODE2} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#SCALEIO_NODE3_FQDN=$(aws ec2 describe-instances --instance-ids ${SCALEIO_NODE3} | jq -r '.Reservations[0].Instances[0].PublicDnsName')
+#echo ${SCALEIO_NODE1_FQDN}
+#echo ${SCALEIO_NODE2_FQDN}
+#echo ${SCALEIO_NODE3_FQDN}
+
+# wait for the OS to be running
+READY1=$(aws ec2 describe-instance-status --instance-ids ${SCALEIO_NODE1} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+while [ "$READY1" != "ok" ];
+do
+  sleep 10
+  echo "Checking ScaleIO Node1..."
+  READY1=$(aws ec2 describe-instance-status --instance-ids ${SCALEIO_NODE1} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+done
+#READY2=$(aws ec2 describe-instance-status --instance-ids ${SCALEIO_NODE2} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#while [ "$READY2" != "ok" ];
+#do
+#  sleep 10
+#  echo "Checking ScaleIO Node2..."
+#  READY2=$(aws ec2 describe-instance-status --instance-ids ${SCALEIO_NODE2} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#done
+#READY3=$(aws ec2 describe-instance-status --instance-ids ${SCALEIO_NODE3} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#while [ "$READY3" != "ok" ];
+#do
+#  sleep 10
+#  echo "Checking ScaleIO Node3..."
+#  READY3=$(aws ec2 describe-instance-status --instance-ids ${SCALEIO_NODE3} | jq -r '.InstanceStatuses[0].SystemStatus.Status')
+#done
+
+sleep 10
+
+ssh-keyscan -H ${SCALEIO_NODE1_FQDN} >> ~/.ssh/known_hosts
+#ssh-keyscan -H ${SCALEIO_NODE2_FQDN} >> ~/.ssh/known_hosts
+#ssh-keyscan -H ${SCALEIO_NODE3_FQDN} >> ~/.ssh/known_hosts
+
+FIRST_VOLUME=$CF_STACK_NAME"_1a"
+SECOND_VOLUME=$CF_STACK_NAME"_1b"
+
+# ssh key to use
+SSH_KEY_FILE=$(cat ./keyfile)
+
+# Copy go test binary to EC2 instance
+scp -i ~/.ssh/${SSH_KEY_FILE} $TEST_BINARY $CF_EC2_USER@$SCALEIO_NODE1_FQDN:/tmp/scaleio.test
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE1_FQDN "sudo chmod +x /tmp/scaleio.test"
+
+echo "Executing Tests!"
+# Run tests... note the use of "bash --login -c". this forces a load of the user's
+# env variables while cause the make command to fail.
+# Yes, node1 uses test2 and vice versa
+ssh -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE1_FQDN "bash --login -c 'FIRST_VOLUME=$FIRST_VOLUME SECOND_VOLUME=$SECOND_VOLUME sudo -E /tmp/scaleio.test -test.coverprofile ${COVERPROFILE_NAME}'"
+
+# Copy test coverage results
+scp -i ~/.ssh/${SSH_KEY_FILE} $CF_EC2_USER@$SCALEIO_NODE1_FQDN:$COVERPROFILE_NAME $(dirname $0)
+
+echo "Tests passed and coverge results are available at ${COVERPROFILE_NAME}"


### PR DESCRIPTION
This adds a mechanism for increased go test coverage for drivers. The high-level behavior is that we only want to run the driver tests on a single sub-build job in Travis CI. It made sense that the selected sub-build would be one in which if the driver tests failed, the build would fail which immediately ruled out using anything that was flagged in the .travis.yml as an allowed failure. All environment creation, testing, and environment teardown are done in parallel meaning that the time added to the build will always be the driver in which it takes the longest stand up and teardown. Based on my testing and observations, the original build time for that sub-build (usually [Build Number].5) took about 7 minutes to complete and with this change has increased by 5 minutes to about 12 minutes for the entire build to complete. Overall project code coverage has increased from ~20% to ~35% with this change.

The driver tests are enabled by the existing COVERAGE_ENABLED(=1), the existing environment variable DRIVERS(="scaleio ebs efs") to select which environment you want to add to the code coverage testing, an existing environment variable COVERED_GO_VERSION=(1.8) to select the specific go version to test on, new environment variables AWS_ACCESSKEY and AWS_SECRETKEY to manage driver test environments in AWS, and a new environment variable LAUNCH_KEY_NAME which is the specified AWS ssh key to use to access the AWS EC2 instances. These parameters can all be set in the environment variable section in Travis CI. **NOTE: the above environment variables have not been set until I have a chance to talk with stakeholders. In the meantime, this PR build will fail.**

This PR leverages some existing functionality that already existed prior. Namely the concept of using 3 scripts already present in some of the driver test folders to create the environment (test-env-up.sh), to runs the tests (test-run.sh), and to teardown the environment (test-env-down.sh). 

Each drivers' test-env-up.sh script signified by the DRIVERS environment will be called in parallel at the very beginning of the build process. This will allow the environments to get created while the build is in progress and test binaries are being created.

A compiled go test binary for that particular driver will then be copied to the test environment via the test-run.sh script, the go coverage data will be created by the use of the -test.coverprofile flag, the raw go test data will be copied from the test environment and at the end, be submitted to codecov via APIs for analysis. 
 
The test-env-down.sh will clean up the environment and any potentially orphaned artifacts that the particular driver test *may* have created in the environment. In the normal "happy path" all artifacts will be cleaned up as a part of the driver test code. Should there be a build failure, the Makefile will short circuit and bomb out early thus skipping the invocation of these scripts. In this case, the Travis CI process will call the test-env-down.sh scripts instead as denoted in the .travis.yml.