### PR TITLE
Fix the API test harness

### DIFF
--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestClient(t *testing.T) {
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t),
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t),
 		func(config gofig.Config, client types.Client, t *testing.T) {
 			ctx := context.Background()
 			iid, err := client.Executor().InstanceID(
@@ -137,7 +137,8 @@ test:
 		}
 	}
 
-	apitests.RunWithOnClientError(tCtx, t, oce, vfs.Name, buf.Bytes(), tf)
+	apitests.RunWithContextOnClientError(
+		tCtx, t, oce, vfs.Name, buf.Bytes(), tf)
 }
 
 func TestClientKnownHostInvalidHost(t *testing.T) {
@@ -207,11 +208,12 @@ test:
 		}
 	}
 
-	apitests.RunWithOnClientError(tCtx, t, oce, vfs.Name, buf.Bytes(), tf)
+	apitests.RunWithContextOnClientError(
+		tCtx, t, oce, vfs.Name, buf.Bytes(), tf)
 }
 
 func TestRoot(t *testing.T) {
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), apitests.TestRoot)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), apitests.TestRoot)
 }
 
 var testServicesFunc = func(
@@ -226,7 +228,8 @@ var testServicesFunc = func(
 }
 
 func TestServices(t *testing.T) {
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), testServicesFunc)
+	apitests.RunWithContext(
+		tCtx, t, vfs.Name, newTestConfig(t), testServicesFunc)
 }
 
 func TestServicesWithAuthToken(t *testing.T) {
@@ -243,11 +246,11 @@ libstorage:
 `
 	buf := bytes.NewBuffer(newTestConfig(t))
 	fmt.Fprintln(buf, cy)
-	apitests.Run(tCtx, t, vfs.Name, buf.Bytes(), testServicesFunc)
+	apitests.RunWithContext(tCtx, t, vfs.Name, buf.Bytes(), testServicesFunc)
 }
 
 func TestServicesWithControllerClient(t *testing.T) {
-	apitests.RunWithClientType(
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient,
 		vfs.Name, newTestConfig(t), testServicesFunc)
 }
@@ -261,7 +264,7 @@ func TestServiceInspect(t *testing.T) {
 		assert.Equal(t, vfs.Name, reply.Driver.Name)
 		assert.True(t, reply.Driver.NextDevice.Ignore)
 	}
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestServiceInspectWithAuthToken(t *testing.T) {
@@ -286,7 +289,7 @@ libstorage:
 		assert.Equal(t, vfs.Name, reply.Driver.Name)
 		assert.True(t, reply.Driver.NextDevice.Ignore)
 	}
-	apitests.Run(tCtx, t, vfs.Name, buf.Bytes(), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, buf.Bytes(), tf)
 }
 
 func TestServiceInspectWithAuthTokenInFile(t *testing.T) {
@@ -324,7 +327,7 @@ libstorage:
 		assert.Equal(t, vfs.Name, reply.Driver.Name)
 		assert.True(t, reply.Driver.NextDevice.Ignore)
 	}
-	apitests.Run(tCtx, t, vfs.Name, buf.Bytes(), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, buf.Bytes(), tf)
 }
 
 func TestServiceInspectWithAuthTokenDeniedForService(t *testing.T) {
@@ -354,7 +357,8 @@ libstorage:
 			t.FailNow()
 		}
 	}
-	apitests.RunWithOnClientError(tCtx, t, oce, vfs.Name, buf.Bytes(), tf)
+	apitests.RunWithContextOnClientError(
+		tCtx, t, oce, vfs.Name, buf.Bytes(), tf)
 }
 
 func TestServiceInspectWithAuthTokenInvalidToken(t *testing.T) {
@@ -379,7 +383,8 @@ libstorage:
 			t.FailNow()
 		}
 	}
-	apitests.RunWithOnClientError(tCtx, t, oce, vfs.Name, buf.Bytes(), tf)
+	apitests.RunWithContextOnClientError(
+		tCtx, t, oce, vfs.Name, buf.Bytes(), tf)
 }
 
 func TestServicesListWithAuthToken(t *testing.T) {
@@ -413,7 +418,7 @@ libstorage:
 			t.FailNow()
 		}
 	}
-	apitests.Run(tCtx, t, vfs.Name, buf.Bytes(), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, buf.Bytes(), tf)
 }
 
 func TestServicesListWithAuthTokenAllowInJWTFormat(t *testing.T) {
@@ -447,7 +452,7 @@ libstorage:
 			t.FailNow()
 		}
 	}
-	apitests.Run(tCtx, t, vfs.Name, buf.Bytes(), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, buf.Bytes(), tf)
 }
 
 func TestServicesListWithInvalidAuthToken(t *testing.T) {
@@ -478,21 +483,22 @@ libstorage:
 			t.FailNow()
 		}
 	}
-	apitests.RunWithOnClientError(tCtx, t, oce, vfs.Name, buf.Bytes(), tf)
+	apitests.RunWithContextOnClientError(
+		tCtx, t, oce, vfs.Name, buf.Bytes(), tf)
 }
 
 func TestExecutors(t *testing.T) {
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), apitests.TestExecutors)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), apitests.TestExecutors)
 }
 
 func TestExecutorsWithControllerClient(t *testing.T) {
-	apitests.RunWithClientType(
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient, vfs.Name, newTestConfig(t),
 		apitests.TestExecutorsWithControllerClient)
 }
 
 func TestExecutorHead(t *testing.T) {
-	apitests.RunGroup(
+	apitests.RunGroupWithContext(
 		tCtx, t, vfs.Name, newTestConfig(t),
 		apitests.TestHeadExecutorLinux)
 	//apitests.TestHeadExecutorDarwin)
@@ -500,7 +506,7 @@ func TestExecutorHead(t *testing.T) {
 }
 
 func TestExecutorGet(t *testing.T) {
-	apitests.RunGroup(
+	apitests.RunGroupWithContext(
 		tCtx, t, vfs.Name, newTestConfig(t),
 		apitests.TestGetExecutorLinux)
 	//	apitests.TestGetExecutorDarwin)
@@ -508,7 +514,7 @@ func TestExecutorGet(t *testing.T) {
 }
 
 func TestStorageDriverVolumes(t *testing.T) {
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t),
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t),
 		func(config gofig.Config, client types.Client, t *testing.T) {
 
 			vols, err := client.Storage().Volumes(
@@ -535,8 +541,8 @@ func TestVolumes(t *testing.T) {
 			assert.EqualValues(t, volume, reply["vfs"][volumeID])
 		}
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
-	apitests.RunWithClientType(
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient, vfs.Name, tc, tf)
 }
 
@@ -554,7 +560,7 @@ func TestVolumesWithAttachmentsTrue(t *testing.T) {
 		assert.EqualValues(t, vols["vfs-000"], reply["vfs"]["vfs-000"])
 		assert.EqualValues(t, vols["vfs-001"], reply["vfs"]["vfs-001"])
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumesWithAttachmentsRequested(t *testing.T) {
@@ -572,7 +578,7 @@ func TestVolumesWithAttachmentsRequested(t *testing.T) {
 		assert.EqualValues(t, vols["vfs-001"], reply["vfs"]["vfs-001"])
 		assert.Len(t, reply["vfs"]["vfs-002"].Attachments, 0)
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumesWithAttachmentsNone(t *testing.T) {
@@ -590,7 +596,7 @@ func TestVolumesWithAttachmentsNone(t *testing.T) {
 		assert.Len(t, reply["vfs"]["vfs-001"].Attachments, 0)
 		assert.Len(t, reply["vfs"]["vfs-002"].Attachments, 0)
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumesWithAttachmentsAttached(t *testing.T) {
@@ -607,7 +613,7 @@ func TestVolumesWithAttachmentsAttached(t *testing.T) {
 		assert.EqualValues(t, vols["vfs-000"], reply["vfs"]["vfs-000"])
 		assert.EqualValues(t, vols["vfs-001"], reply["vfs"]["vfs-001"])
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumesWithAttachmentsUnattached(t *testing.T) {
@@ -624,7 +630,7 @@ func TestVolumesWithAttachmentsUnattached(t *testing.T) {
 		assert.NotNil(t, reply["vfs"]["vfs-002"])
 		assert.Len(t, reply["vfs"]["vfs-002"].Attachments, 0)
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumesWithAttachmentsAttachedAndUnattached(t *testing.T) {
@@ -642,7 +648,7 @@ func TestVolumesWithAttachmentsAttachedAndUnattached(t *testing.T) {
 		assert.EqualValues(t, vols["vfs-000"], reply["vfs"]["vfs-000"])
 		assert.EqualValues(t, vols["vfs-001"], reply["vfs"]["vfs-001"])
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumesWithAttachmentsAttachedToMeAndAvailable(t *testing.T) {
@@ -666,7 +672,7 @@ func TestVolumesWithAttachmentsAttachedToMeAndAvailable(t *testing.T) {
 		assert.Equal(
 			t, types.VolumeAvailable, reply["vfs"]["vfs-002"].AttachmentState)
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumesWithAttachmentsMineWithNotMyInstanceID(
@@ -692,7 +698,7 @@ func TestVolumesWithAttachmentsMineWithNotMyInstanceID(
 		assert.Len(t, reply["vfs"]["vfs-001"].Attachments, 0)
 		assert.Len(t, reply["vfs"]["vfs-002"].Attachments, 0)
 	}
-	apitests.RunWithClientType(
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient, vfs.Name, tc, tf)
 }
 
@@ -723,7 +729,7 @@ func TestVolumesWithAttachmentsAttachedAndMineWithNotMyInstanceID(
 			t.FailNow()
 		}
 	}
-	apitests.RunWithClientType(
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient, vfs.Name, tc, tf)
 }
 
@@ -755,7 +761,7 @@ func TestVolumesWithAttachmentsAttachedAndMineOrUnattachedWithNotMyInstanceID(
 			t.FailNow()
 		}
 	}
-	apitests.RunWithClientType(
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient, vfs.Name, tc, tf)
 }
 
@@ -768,7 +774,7 @@ func TestVolumesWithAttachmentsWithControllerClient(t *testing.T) {
 		assert.Equal(t, "batch processing error", err.Error())
 	}
 
-	apitests.RunWithClientType(
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient, vfs.Name, tc, tf)
 }
 
@@ -785,7 +791,7 @@ func TestVolumesByService(t *testing.T) {
 			assert.EqualValues(t, volume, reply[volumeID])
 		}
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumesByServiceWithAttachments(t *testing.T) {
@@ -802,7 +808,7 @@ func TestVolumesByServiceWithAttachments(t *testing.T) {
 		assert.EqualValues(t, vols["vfs-000"], reply["vfs-000"])
 		assert.EqualValues(t, vols["vfs-001"], reply["vfs-001"])
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumeInspect(t *testing.T) {
@@ -816,7 +822,7 @@ func TestVolumeInspect(t *testing.T) {
 		assert.NotNil(t, reply)
 		assert.EqualValues(t, vols[reply.ID], reply)
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumeInspectWithAttachments(t *testing.T) {
@@ -830,7 +836,7 @@ func TestVolumeInspectWithAttachments(t *testing.T) {
 		assert.NotNil(t, reply)
 		assert.EqualValues(t, vols[reply.ID], reply)
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestSnapshots(t *testing.T) {
@@ -845,7 +851,7 @@ func TestSnapshots(t *testing.T) {
 			assert.EqualValues(t, snapshot, reply["vfs"][snapshotID])
 		}
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestSnapshotsByService(t *testing.T) {
@@ -860,7 +866,7 @@ func TestSnapshotsByService(t *testing.T) {
 			assert.EqualValues(t, snapshot, reply[snapshotID])
 		}
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumeCreate(t *testing.T) {
@@ -903,7 +909,7 @@ func TestVolumeCreate(t *testing.T) {
 		assert.Equal(t, "root@example.com", reply.Fields["owner"])
 	}
 
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestVolumeCreateParseRequestOpts(t *testing.T) {
@@ -950,7 +956,7 @@ func TestVolumeCreateParseRequestOpts(t *testing.T) {
 		assert.Equal(t, "root@example.com", reply.Fields["owner"])
 	}
 
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestVolumeCopy(t *testing.T) {
@@ -978,7 +984,7 @@ func TestVolumeCopy(t *testing.T) {
 		assert.Equal(t, request.Opts["owner"], reply.Fields["owner"])
 	}
 
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestVolumeRemove(t *testing.T) {
@@ -990,7 +996,7 @@ func TestVolumeRemove(t *testing.T) {
 		assertVolDir(t, config, "vfs-002", false)
 	}
 
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf1)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf1)
 
 	tf2 := func(config gofig.Config, client types.Client, t *testing.T) {
 		err := client.API().VolumeRemove(nil, vfs.Name, "vfs-002", false)
@@ -1000,7 +1006,7 @@ func TestVolumeRemove(t *testing.T) {
 		assert.Equal(t, 404, httpErr.Status())
 	}
 
-	apitests.RunGroup(tCtx, t, vfs.Name, newTestConfig(t), tf1, tf2)
+	apitests.RunGroupWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf1, tf2)
 }
 
 func TestVolumeSnapshot(t *testing.T) {
@@ -1048,7 +1054,7 @@ func TestVolumeSnapshot(t *testing.T) {
 		}
 		assert.True(t, snapCountEqual)
 	}
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestVolumeCreateFromSnapshot(t *testing.T) {
@@ -1089,7 +1095,7 @@ func TestVolumeCreateFromSnapshot(t *testing.T) {
 		assert.Equal(t, request.Opts["owner"], reply.Fields["owner"])
 
 	}
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestVolumeAttach(t *testing.T) {
@@ -1118,7 +1124,7 @@ func TestVolumeAttach(t *testing.T) {
 		assert.Equal(t, "/dev/xvdc", reply.Attachments[0].DeviceName)
 
 	}
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestVolumeAttachGoofErr(t *testing.T) {
@@ -1155,7 +1161,7 @@ func TestVolumeAttachGoofErr(t *testing.T) {
 		}
 	}
 
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestVolumeAttachStdlibErr(t *testing.T) {
@@ -1192,7 +1198,7 @@ func TestVolumeAttachStdlibErr(t *testing.T) {
 		}
 	}
 
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestVolumeAttachWithControllerClient(t *testing.T) {
@@ -1210,7 +1216,7 @@ func TestVolumeAttachWithControllerClient(t *testing.T) {
 		assert.Equal(t, "unsupported op for client type", err.Error())
 	}
 
-	apitests.RunWithClientType(
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient, vfs.Name, newTestConfig(t), tf)
 }
 
@@ -1229,7 +1235,7 @@ func TestVolumeDetach(t *testing.T) {
 		assert.Equal(t, "vfs-001", reply.ID)
 		assert.Equal(t, 0, len(reply.Attachments))
 	}
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestVolumeDetachWithControllerClient(t *testing.T) {
@@ -1239,7 +1245,7 @@ func TestVolumeDetachWithControllerClient(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, "unsupported op for client type", err.Error())
 	}
-	apitests.RunWithClientType(
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient, vfs.Name, newTestConfig(t), tf)
 }
 
@@ -1267,7 +1273,7 @@ func TestVolumeDetachAllForService(t *testing.T) {
 		assert.Equal(t, 3, len(reply))
 		assert.EqualValues(t, vols, reply)
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumeDetachAllForServiceWithControllerClient(t *testing.T) {
@@ -1277,7 +1283,7 @@ func TestVolumeDetachAllForServiceWithControllerClient(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, "unsupported op for client type", err.Error())
 	}
-	apitests.RunWithClientType(
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient, vfs.Name, newTestConfig(t), tf)
 }
 
@@ -1305,7 +1311,7 @@ func TestVolumeDetachAll(t *testing.T) {
 		assert.Equal(t, 1, len(reply))
 		assert.Equal(t, 3, len(reply[vfs.Name]))
 	}
-	apitests.Run(tCtx, t, vfs.Name, tc, tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
 func TestVolumeDetachAllWithControllerClient(t *testing.T) {
@@ -1315,7 +1321,7 @@ func TestVolumeDetachAllWithControllerClient(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, "unsupported op for client type", err.Error())
 	}
-	apitests.RunWithClientType(
+	apitests.RunWithContextClientType(
 		tCtx, t, types.ControllerClient, vfs.Name, newTestConfig(t), tf)
 }
 
@@ -1344,7 +1350,7 @@ func TestSnapshotCopy(t *testing.T) {
 		assert.Equal(t, "root@example.com", reply.Fields["owner"])
 
 	}
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestSnapshotRemove(t *testing.T) {
@@ -1362,7 +1368,7 @@ func TestSnapshotRemove(t *testing.T) {
 		assert.Nil(t, reply)
 
 	}
-	apitests.Run(tCtx, t, vfs.Name, newTestConfig(t), tf)
+	apitests.RunWithContext(tCtx, t, vfs.Name, newTestConfig(t), tf)
 }
 
 func TestInstanceID(t *testing.T) {
@@ -1371,7 +1377,7 @@ func TestInstanceID(t *testing.T) {
 	if err != nil {
 		t.FailNow()
 	}
-	apitests.Run(
+	apitests.RunWithContext(
 		tCtx, t, vfs.Name, newTestConfig(t),
 		(&apitests.InstanceIDTest{
 			Driver:   vfs.Name,
@@ -1385,7 +1391,7 @@ func TestInstance(t *testing.T) {
 	if err != nil {
 		t.FailNow()
 	}
-	apitests.Run(
+	apitests.RunWithContext(
 		tCtx, t, vfs.Name, nil,
 		(&apitests.InstanceTest{
 			Driver: vfs.Name,
@@ -1397,7 +1403,7 @@ func TestInstance(t *testing.T) {
 }
 
 func TestNextDevice(t *testing.T) {
-	apitests.RunGroup(
+	apitests.RunGroupWithContext(
 		tCtx, t, vfs.Name, newTestConfig(t),
 		(&apitests.NextDeviceTest{
 			Driver:   vfs.Name,
@@ -1421,7 +1427,7 @@ func TestLocalDevices(t *testing.T) {
 		}
 	}
 
-	apitests.RunGroup(
+	apitests.RunGroupWithContext(
 		tCtx, t, vfs.Name, cfg,
 		(&apitests.LocalDevicesTest{
 			Driver:   vfs.Name,
@@ -1472,7 +1478,7 @@ func TestExecutorMountUnmount(t *testing.T) {
 	}
 
 	cfg, _, _, _ := newTestConfigAll(t)
-	apitests.RunGroup(tCtx, t, vfs.Name, cfg, mf, uf)
+	apitests.RunGroupWithContext(tCtx, t, vfs.Name, cfg, mf, uf)
 }
 
 func removeTestDirs() {


### PR DESCRIPTION
This patch changes the test harness's function signatures back to the way they used to be and introduces contextual variants for test packages that require it.