### PR TITLE
Test Harness Fix

### DIFF
--- a/api/tests/tests.go
+++ b/api/tests/tests.go
@@ -329,9 +329,9 @@ func (th *testHarness) run(
 	if ctx == nil {
 		ctx = context.Background()
 		if _, ok := context.PathConfig(ctx); !ok {
+			pathConfig := utils.NewPathConfig(ctx, "", "")
+			ctx = ctx.WithValue(context.PathConfigKey, pathConfig)
 			once.Do(func() {
-				pathConfig := utils.NewPathConfig(ctx, "", "")
-				ctx = ctx.WithValue(context.PathConfigKey, pathConfig)
 				registry.ProcessRegisteredConfigs(ctx)
 			})
 		}


### PR DESCRIPTION
This patch fixes the test harness so that it only registers configs once but creates a context every time that it's nil.