### PR TITLE
Enable Override of EBS Region, AZ, & Endpoint Props

### DIFF
--- a/drivers/storage/ebs/ebs.go
+++ b/drivers/storage/ebs/ebs.go
@@ -53,6 +53,9 @@ const (
 	// Endpoint is a key constant.
 	Endpoint = "endpoint"
 
+	// AvaiZone is a key constant.
+	AvaiZone = "availabilityZone"
+
 	// MaxRetries is a key constant.
 	MaxRetries = "maxRetries"
 
@@ -92,6 +95,7 @@ func init() {
 	r.Key(gofig.String, "", "", "", Name+"."+SecretKey)
 	r.Key(gofig.String, "", "", "", Name+"."+Region)
 	r.Key(gofig.String, "", "", "", Name+"."+Endpoint)
+	r.Key(gofig.String, "", "", "", Name+"."+AvaiZone)
 	r.Key(gofig.Int, "", DefaultMaxRetries, "", Name+"."+MaxRetries)
 	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", Name+"."+Tag)
 	r.Key(gofig.String, "", "", "", Name+"."+KmsKeyID)
@@ -106,6 +110,7 @@ func init() {
 	r.Key(gofig.String, "", "", "", NameEC2+"."+SecretKey)
 	r.Key(gofig.String, "", "", "", NameEC2+"."+Region)
 	r.Key(gofig.String, "", "", "", NameEC2+"."+Endpoint)
+	r.Key(gofig.String, "", "", "", NameEC2+"."+AvaiZone)
 	r.Key(gofig.Int, "", DefaultMaxRetries, "", NameEC2+"."+MaxRetries)
 	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", NameEC2+"."+Tag)
 	r.Key(gofig.String, "", "", "", NameEC2+"."+KmsKeyID)
@@ -114,6 +119,7 @@ func init() {
 	r.Key(gofig.String, "", "", "", NameAWS+"."+SecretKey)
 	r.Key(gofig.String, "", "", "", NameAWS+"."+Region)
 	r.Key(gofig.String, "", "", "", NameAWS+"."+Endpoint)
+	r.Key(gofig.String, "", "", "", NameAWS+"."+AvaiZone)
 	r.Key(gofig.Int, "", DefaultMaxRetries, "", NameAWS+"."+MaxRetries)
 	r.Key(gofig.String, "", "", "Tag prefix for EBS naming", NameAWS+"."+Tag)
 	r.Key(gofig.String, "", "", "", NameAWS+"."+KmsKeyID)

--- a/drivers/storage/ebs/ebs_config_compat.go
+++ b/drivers/storage/ebs/ebs_config_compat.go
@@ -20,6 +20,9 @@ const (
 	// ConfigEBSRegion is a config key.
 	ConfigEBSRegion = ConfigEBS + "." + Region
 
+	// ConfigEBSAvaiZone is a config key.
+	ConfigEBSAvaiZone = ConfigEBS + "." + AvaiZone
+
 	// ConfigEBSEndpoint is a config key.
 	ConfigEBSEndpoint = ConfigEBS + "." + Endpoint
 
@@ -43,6 +46,9 @@ const (
 
 	// ConfigEC2SecretKey is a config key.
 	ConfigEC2SecretKey = ConfigEC2 + "." + SecretKey
+
+	// ConfigEC2AvaiZone is a config key.
+	ConfigEC2AvaiZone = ConfigEC2 + "." + AvaiZone
 
 	// ConfigEC2Region is a config key.
 	ConfigEC2Region = ConfigEC2 + "." + Region
@@ -70,6 +76,9 @@ const (
 
 	// ConfigAWSSecretKey is a config key.
 	ConfigAWSSecretKey = ConfigAWS + "." + SecretKey
+
+	// ConfigAWSAvaiZone is a config key.
+	ConfigAWSAvaiZone = ConfigAWS + "." + AvaiZone
 
 	// ConfigAWSRegion is a config key.
 	ConfigAWSRegion = ConfigAWS + "." + Region

--- a/drivers/storage/ebs/storage/ebs_storage.go
+++ b/drivers/storage/ebs/storage/ebs_storage.go
@@ -6,6 +6,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"hash"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +47,7 @@ type driver struct {
 	config        gofig.Config
 	region        *string
 	endpoint      *string
+	avaiZone      *string
 	maxRetries    *int
 	accessKey     string
 	kmsKeyID      string
@@ -78,6 +80,9 @@ func (d *driver) Init(context types.Context, config gofig.Config) error {
 	ebs.BackCompat(config)
 	d.config = config
 	d.accessKey = d.getAccessKey()
+	if v := d.getAvaiZone(); v != "" {
+		d.avaiZone = &v
+	}
 	if v := d.getRegion(); v != "" {
 		d.region = &v
 	}
@@ -126,18 +131,27 @@ func (d *driver) Login(ctx types.Context) (interface{}, error) {
 	defer sessionsL.Unlock()
 
 	var (
-		endpoint *string
-		ckey     string
-		hkey     = md5.New()
-		akey     = d.accessKey
-		region   = d.mustRegion(ctx)
+		endpoint            *string
+		endpointIsImportant bool
+		ckey                string
+		hkey                = md5.New()
+		akey                = d.accessKey
+		region              = d.mustRegion(ctx)
 	)
 
-	if region != nil {
-		szEndpint := fmt.Sprintf("ec2.%s.amazonaws.com", *region)
-		endpoint = &szEndpint
-	} else {
-		endpoint = d.endpoint
+	if d.endpoint != nil {
+		if v, ok := isImportant(*d.endpoint); ok {
+			endpoint = &v
+			endpointIsImportant = true
+		}
+	}
+	if !endpointIsImportant {
+		if region != nil {
+			szEndpint := fmt.Sprintf("ec2.%s.amazonaws.com", *region)
+			endpoint = &szEndpint
+		} else {
+			endpoint = d.endpoint
+		}
 	}
 
 	writeHkey(hkey, region)
@@ -213,7 +227,22 @@ func mustInstanceIDID(ctx types.Context) *string {
 	return &context.MustInstanceID(ctx).ID
 }
 
+var rxImportant = regexp.MustCompile(`^(?i)(.+?)\s+!important$`)
+
+func isImportant(s string) (string, bool) {
+	m := rxImportant.FindStringSubmatch(s)
+	if len(m) == 0 {
+		return "", false
+	}
+	return m[1], true
+}
+
 func (d *driver) mustRegion(ctx types.Context) *string {
+	if d.region != nil {
+		if region, ok := isImportant(*d.region); ok {
+			return &region
+		}
+	}
 	if iid, ok := context.InstanceID(ctx); ok {
 		if v, ok := iid.Fields[ebs.InstanceIDFieldRegion]; ok && v != "" {
 			return &v
@@ -223,6 +252,11 @@ func (d *driver) mustRegion(ctx types.Context) *string {
 }
 
 func (d *driver) mustAvailabilityZone(ctx types.Context) *string {
+	if d.avaiZone != nil {
+		if az, ok := isImportant(*d.avaiZone); ok {
+			return &az
+		}
+	}
 	if iid, ok := context.InstanceID(ctx); ok {
 		if v, ok := iid.Fields[ebs.InstanceIDFieldAvailabilityZone]; ok {
 			if v != "" {
@@ -1387,6 +1421,16 @@ func (d *driver) getRegion() string {
 		return region
 	}
 	return d.config.GetString(ebs.ConfigEC2Region)
+}
+
+func (d *driver) getAvaiZone() string {
+	if az := d.config.GetString(ebs.ConfigEBSAvaiZone); az != "" {
+		return az
+	}
+	if az := d.config.GetString(ebs.ConfigAWSAvaiZone); az != "" {
+		return az
+	}
+	return d.config.GetString(ebs.ConfigEC2AvaiZone)
 }
 
 func (d *driver) getEndpoint() string {


### PR DESCRIPTION
This patch introduces the ability for the EBS driver to override the client's provided region, availability zone, and endpoint properties by specifying them in the server-side config with a suffix of !important (like CSS).

Many thanks to libStorage & REX-Ray community member @shamimgeek for discovering this! Thanks Shamim!