### PR TITLE
The go[bgit] commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.a
 *.d
 *.out
-got
 libstorage.paw
 .site/
 site/

--- a/gob
+++ b/gob
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+BUILD_TAGS="pflag gofig libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_executor"
+DRIVERS=${DRIVERS:=vfs}
+
+for D in $DRIVERS; do
+  BUILD_TAGS="${BUILD_TAGS} libstorage_storage_driver_${D} libstorage_storage_executor_${D}"
+done
+
+go build -tags "$BUILD_TAGS" $*

--- a/gog
+++ b/gog
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+BUILD_TAGS="pflag gofig libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_executor"
+DRIVERS=${DRIVERS:=vfs}
+
+for D in $DRIVERS; do
+  BUILD_TAGS="${BUILD_TAGS} libstorage_storage_driver_${D} libstorage_storage_executor_${D}"
+done
+
+ginkgo -tags "$BUILD_TAGS" $*

--- a/goi
+++ b/goi
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+BUILD_TAGS="pflag gofig libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_executor"
+DRIVERS=${DRIVERS:=vfs}
+
+for D in $DRIVERS; do
+  BUILD_TAGS="${BUILD_TAGS} libstorage_storage_driver_${D} libstorage_storage_executor_${D}"
+done
+
+go install -tags "$BUILD_TAGS" $*

--- a/got
+++ b/got
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+BUILD_TAGS="pflag gofig libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_executor"
+DRIVERS=${DRIVERS:=vfs}
+
+for D in $DRIVERS; do
+  BUILD_TAGS="${BUILD_TAGS} libstorage_storage_driver_${D} libstorage_storage_executor_${D}"
+done
+
+go test -tags "$BUILD_TAGS" $*


### PR DESCRIPTION
This patch introduces the project, root-level commands: `gob`, `gog`, `goi`, and `got`.

These commands execute `go build`, `ginkgo`, `go install`, and `go test` while including the necessary build tags so a developer doesn't need to remember them. The above commands also respect the environment variable `DRIVERS`. Thus, to execute the `TestClient` function from the VFS test package, all one has to do is:

```bash
DRIVERS=vfs ./got ./drivers/storage/vfs/tests -run '^TestClient$'
```