### PR TITLE
Fixed Context Logger Recursion Bug

### DIFF
--- a/api/context/context_keys.go
+++ b/api/context/context_keys.go
@@ -187,8 +187,8 @@ func RegisterCustomKeyWithContext(
 
 	customKeys[newCustomKey.externalID] = newCustomKey
 
-	if ctx != nil {
-		ctx.WithFields(map[string]interface{}{
+	if ctx, ok := ctx.(*lsc); ok && ctx.logger != nil {
+		ctx.logger.WithFields(map[string]interface{}{
 			"internalID": newCustomKey.internalID,
 			"externalID": newCustomKey.externalID,
 			"keyBitmask": newCustomKey.keyBitmask,

--- a/api/server/server_http.go
+++ b/api/server/server_http.go
@@ -335,5 +335,8 @@ func (wc *writeCloser) Write(p []byte) (n int, err error) {
 }
 
 func (wc *writeCloser) Close() error {
+	if c, ok := wc.writer.(io.Closer); ok {
+		return c.Close()
+	}
 	return nil
 }


### PR DESCRIPTION
This patch fixes a critical bug where context logging during the `RegisterCustomKeyWithContext` function resulted in a recursive lock that froze the running process. This error was only able to be reproduced when `DEBUG` logging was enabled.