### PR TITLE
TLS Parsing Fix

### DIFF
--- a/api/types/types_paths.go
+++ b/api/types/types_paths.go
@@ -3,7 +3,10 @@ package types
 // PathConfig contains the path configuration for the application.
 type PathConfig struct {
 
-	// Home is the path to the root data directory.
+	// Token is the app token.
+	Token string
+
+	// Home is the path to the system, root, data directory.
 	Home string
 
 	// Etc is the path to the etc directory.
@@ -36,4 +39,11 @@ type PathConfig struct {
 
 	// DefaultTLSKnownHosts is the default path to the TLS known hosts file.
 	DefaultTLSKnownHosts string
+
+	// UserHome is the path to the user, root, data directory.
+	UserHome string
+
+	// UserDefaultTLSKnownHosts is the default path to the user, TLS known
+	// hosts file.
+	UserDefaultTLSKnownHosts string
 }

--- a/api/types/types_tls.go
+++ b/api/types/types_tls.go
@@ -1,6 +1,9 @@
 package types
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+	"fmt"
+)
 
 // TLSConfig is a custom TLS configuration that includes the concept of a
 // peer certificate's fingerprint.
@@ -33,4 +36,9 @@ type TLSKnownHost struct {
 
 	// Fingerprint is known host's certificate's fingerprint.
 	Fingerprint []byte
+}
+
+// String returns a known_hosts string.
+func (kh *TLSKnownHost) String() string {
+	return fmt.Sprintf("%s %s %x", kh.Host, kh.Alg, kh.Fingerprint)
 }

--- a/api/utils/utils_paths.go
+++ b/api/utils/utils_paths.go
@@ -14,8 +14,6 @@ import (
 // NewPathConfig returns a new path configuration object.
 func NewPathConfig(ctx types.Context, home, token string) *types.PathConfig {
 
-	pathConfig := &types.PathConfig{}
-
 	if token == "" {
 		if v := os.Getenv("LIBSTORAGE_APPTOKEN"); v != "" {
 			token = v
@@ -23,6 +21,13 @@ func NewPathConfig(ctx types.Context, home, token string) *types.PathConfig {
 			token = "libstorage"
 		}
 	}
+
+	pathConfig := &types.PathConfig{
+		Token:    token,
+		UserHome: path.Join(gotil.HomeDir(), fmt.Sprintf(".%s", token)),
+	}
+	pathConfig.UserDefaultTLSKnownHosts = path.Join(
+		pathConfig.UserHome, "known_hosts")
 
 	var (
 		ucTok            = strings.ToUpper(token)

--- a/api/utils/utils_paths_test.go
+++ b/api/utils/utils_paths_test.go
@@ -17,6 +17,7 @@ import (
 
 var _ = Describe("Paths", func() {
 	var homeDir string
+	var userHome = gotil.HomeDir()
 
 	BeforeSuite(func() {
 		homeDir = gotil.HomeDir()
@@ -97,6 +98,14 @@ var _ = Describe("Paths", func() {
 					Ω(pathConfig.DefaultTLSKnownHosts).To(Σ(
 						homeDir, ".libstorage", "etc", "tls", "known_hosts"))
 				})
+			It("usr home should be $HOME", func() {
+				Ω(pathConfig.UserHome).To(Σ(userHome, ".libstorage"))
+			})
+			It("usr known_hosts should be $HOME/.libstorage/known_hosts",
+				func() {
+					Ω(pathConfig.UserDefaultTLSKnownHosts).To(
+						Σ(userHome, ".libstorage", "known_hosts"))
+				})
 		})
 
 		Context("With home", func() {
@@ -159,6 +168,14 @@ var _ = Describe("Paths", func() {
 					Ω(pathConfig.DefaultTLSKnownHosts).To(Σ(
 						tmpDir, "etc", "tls", "known_hosts"))
 				})
+			It("usr home should be $HOME", func() {
+				Ω(pathConfig.UserHome).To(Σ(userHome, ".libstorage"))
+			})
+			It("usr known_hosts should be $HOME/.libstorage/known_hosts",
+				func() {
+					Ω(pathConfig.UserDefaultTLSKnownHosts).To(
+						Σ(userHome, ".libstorage", "known_hosts"))
+				})
 		})
 
 		Context("With token", func() {
@@ -220,6 +237,14 @@ var _ = Describe("Paths", func() {
 				func() {
 					Ω(pathConfig.DefaultTLSKnownHosts).To(Σ(
 						homeDir, ".rexray", "etc", "tls", "known_hosts"))
+				})
+			It("usr home should be $HOME", func() {
+				Ω(pathConfig.UserHome).To(Σ(userHome, ".rexray"))
+			})
+			It("usr known_hosts should be $HOME/.rexray/known_hosts",
+				func() {
+					Ω(pathConfig.UserDefaultTLSKnownHosts).To(
+						Σ(userHome, ".rexray", "known_hosts"))
 				})
 		})
 
@@ -285,6 +310,14 @@ var _ = Describe("Paths", func() {
 					Ω(pathConfig.DefaultTLSKnownHosts).To(Σ(
 						tmpDir, "known_hosts"))
 				})
+			It("usr home should be $HOME", func() {
+				Ω(pathConfig.UserHome).To(Σ(userHome, ".rexray"))
+			})
+			It("usr known_hosts should be $HOME/.rexray/known_hosts",
+				func() {
+					Ω(pathConfig.UserDefaultTLSKnownHosts).To(
+						Σ(userHome, ".rexray", "known_hosts"))
+				})
 		})
 
 		Context("With token & TOKEN_HOME", func() {
@@ -349,6 +382,14 @@ var _ = Describe("Paths", func() {
 					Ω(pathConfig.DefaultTLSKnownHosts).To(Σ(
 						tmpDir, "etc", "tls", "known_hosts"))
 				})
+			It("usr home should be $HOME", func() {
+				Ω(pathConfig.UserHome).To(Σ(userHome, ".rexray"))
+			})
+			It("usr known_hosts should be $HOME/.rexray/known_hosts",
+				func() {
+					Ω(pathConfig.UserDefaultTLSKnownHosts).To(
+						Σ(userHome, ".rexray", "known_hosts"))
+				})
 		})
 
 		Context("With LIBSTORAGE_HOME and LIBSTORAGE_HOME_LSX", func() {
@@ -407,6 +448,14 @@ var _ = Describe("Paths", func() {
 				func() {
 					Ω(pathConfig.DefaultTLSKnownHosts).To(Σ(
 						tmpDir, "etc", "tls", "known_hosts"))
+				})
+			It("usr home should be $HOME", func() {
+				Ω(pathConfig.UserHome).To(Σ(userHome, ".libstorage"))
+			})
+			It("usr known_hosts should be $HOME/.libstorage/known_hosts",
+				func() {
+					Ω(pathConfig.UserDefaultTLSKnownHosts).To(
+						Σ(userHome, ".libstorage", "known_hosts"))
 				})
 		})
 	})


### PR DESCRIPTION
This patch fixes the way the TLS configuration section is parsed. It used to behave such that if a child property of `libstorage.tls` was defined via an environment variable or some other way instead of the configuration file that TLS would not be activated unless its root was defined in the configuration file.

/cc @vladimirvivien 