### PR TITLE
Centralize all RBD related shell cmds and logging

### DIFF
--- a/drivers/storage/rbd/tests/rbd_test.go
+++ b/drivers/storage/rbd/tests/rbd_test.go
@@ -62,7 +62,7 @@ func TestInstanceID(t *testing.T) {
 		t.SkipNow()
 	}
 
-	iid, err := rbdx.GetInstanceID(nil, nil)
+	iid, err := rbdx.GetInstanceID(nil, nil, nil)
 	assert.NoError(t, err)
 	if err != nil {
 		t.Error("failed TestInstanceID")
@@ -143,7 +143,8 @@ func TestInstanceIDSimulatedIPs(t *testing.T) {
 	}
 
 	for _, test := range testIPs {
-		iid, err := rbdx.GetInstanceID(test.monIPs, test.interfaces)
+		iid, err := rbdx.GetInstanceID(
+			nil, test.monIPs, test.interfaces)
 
 		assert.NoError(t, err)
 		if err != nil {


### PR DESCRIPTION
Make sure that all calls made using rbd/rados binaries use a command
method for execution, and that the related logging and error reporting
is standardized.

Generated new `rbd.test` and ran suite. All tests pass (unless debugging is enabled, see #528).