### PR TITLE
LSX Stdout Fix

### DIFF
--- a/api/context/context.go
+++ b/api/context/context.go
@@ -62,7 +62,7 @@ func newContext(
 			Formatter: log.StandardLogger().Formatter,
 			Hooks:     log.StandardLogger().Hooks,
 			Level:     lvl,
-			Out:       types.Stdout,
+			Out:       types.Stderr,
 		}
 	}
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -130,7 +130,7 @@ func newServer(goCtx gocontext.Context, config gofig.Config) (*server, error) {
 	if logger, ok := s.ctx.Value(context.LoggerKey).(*log.Logger); ok {
 		s.PrintServerStartupHeader(logger.Out)
 	} else {
-		s.PrintServerStartupHeader(types.Stdout)
+		s.PrintServerStartupHeader(types.Stderr)
 	}
 
 	if lvl, err := log.ParseLevel(
@@ -257,7 +257,7 @@ func Serve(
 	if logger, ok := s.ctx.Value(context.LoggerKey).(*log.Logger); ok {
 		s.PrintServerStartupFooter(logger.Out)
 	} else {
-		s.PrintServerStartupFooter(types.Stdout)
+		s.PrintServerStartupFooter(types.Stderr)
 	}
 
 	return s, errs, nil


### PR DESCRIPTION
This patch fixes an issue that occurred when standardizing output streams. The default logger implementation, Logrus, [uses Stderr for output](https://github.com/sirupsen/logrus/blob/master/logger.go#L67-L75), but a recent patch explicitly used Stdout. This has been changed back to using Stderr to no longer effect the LSX output.

This patch fixes issue #528.