### PR TITLE
Announce ec2 removal version

### DIFF
--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -26,6 +26,8 @@ Storage volumes for EC2 instances.
 !!! note
     For backwards compatibility, the driver also registers a storage driver
     named `ec2`. The use of `ec2` in config files is deprecated but functional.
+    The `ec2` driver **will be removed in 0.7.0**, at which point all instances
+    of `ec2` in config files must use `ebs` instead.
 
 !!! note
     The EBS driver does not yet support snapshots or tags, as previously supported


### PR DESCRIPTION
I'd like to see the backwards compatibility of the EBS driver using "ec2" as the driver name removed for REX-Ray 1.0. The docs have long called it out as deprecated, so I think it's fair to say when we are going to remove it.

This will allow us to remove some code and simplify testing scenarios.

Discussed with @akutz, and he is on board.

Would like to hear thoughts from @cduchesne and @clintonskitson as well.