### PR TITLE
TLS Known Hosts Fix

### DIFF
--- a/api/utils/utils_tls.go
+++ b/api/utils/utils_tls.go
@@ -128,6 +128,7 @@ func ParseTLSConfig(
 		newTLS("usrKnownHosts", pathConfig.UserDefaultTLSKnownHosts)
 		f("usrKnownHosts", pathConfig.UserDefaultTLSKnownHosts)
 		tlsConfig.UsrKnownHosts = pathConfig.UserDefaultTLSKnownHosts
+		tlsConfig.InsecureSkipVerify = true
 		tlsConfig.VerifyPeers = true
 	}
 


### PR DESCRIPTION
This patch updates the TLS parser to fix the issue where a user-scoped known_hosts file wasn't enabling TLS insecure in conjunction with peer validation.