### PR TITLE
Disable TLS for UNIX sockets

### DIFF
--- a/api/server/server_http.go
+++ b/api/server/server_http.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -124,15 +125,19 @@ func (s *server) initEndpoints(ctx types.Context) error {
 			"address":  laddr,
 		}
 
-		tlsConfig, err :=
-			utils.ParseTLSConfig(
-				s.ctx,
-				s.config.Scope(endpoint),
-				logFields,
-				types.ConfigServer,
-				endpoint)
-		if err != nil {
-			return err
+		var tlsConfig *types.TLSConfig
+
+		// disable TLS for UNIX sockets
+		if !strings.EqualFold(proto, "unix") {
+			if tlsConfig, err =
+				utils.ParseTLSConfig(
+					s.ctx,
+					s.config.Scope(endpoint),
+					logFields,
+					types.ConfigServer,
+					endpoint); err != nil {
+				return err
+			}
 		}
 
 		ctx.WithFields(logFields).Info("configured endpoint")

--- a/drivers/storage/libstorage/libstorage_driver.go
+++ b/drivers/storage/libstorage/libstorage_driver.go
@@ -68,10 +68,15 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 		return err
 	}
 
-	tlsConfig, err := utils.ParseTLSConfig(
-		d.ctx, config, logFields, types.ConfigClient)
-	if err != nil {
-		return err
+	var tlsConfig *types.TLSConfig
+
+	// disable TLS for UNIX sockets
+	if !strings.EqualFold(proto, "unix") {
+		tlsConfig, err = utils.ParseTLSConfig(
+			d.ctx, config, logFields, types.ConfigClient)
+		if err != nil {
+			return err
+		}
 	}
 
 	host := getHost(d.ctx, proto, lAddr, tlsConfig)
@@ -86,6 +91,7 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 
 	httpTransport := &http.Transport{
 		Dial: func(string, string) (net.Conn, error) {
+
 			if tlsConfig == nil {
 				conn, err := net.Dial(proto, lAddr)
 				if err != nil {


### PR DESCRIPTION
This patch explicitly disables TLS for libStorage as a client or server when connecting to or serving on a UNIX socket.

/cc @koensayr @cduchesne @codenrhoden 