### PR TITLE
TLS Boolean Property Fix

### DIFF
--- a/imports/config/imports_config_99_gofig.go
+++ b/imports/config/imports_config_99_gofig.go
@@ -119,9 +119,9 @@ func init() {
 				"",
 				types.ConfigTLSKnownHosts)
 			rk(gofig.String, "", "", types.ConfigTLSServerName)
-			rk(gofig.Bool, false, "", types.ConfigTLSDisabled)
-			rk(gofig.Bool, false, "", types.ConfigTLSInsecure)
-			rk(gofig.Bool, false, "", types.ConfigTLSClientCertRequired)
+			rk(gofig.String, "", "", types.ConfigTLSDisabled)
+			rk(gofig.String, "", "", types.ConfigTLSInsecure)
+			rk(gofig.String, "", "", types.ConfigTLSClientCertRequired)
 
 			// auth config - client
 			rk(gofig.String, "", "", types.ConfigClientAuthToken)


### PR DESCRIPTION
This patch changes the TLS boolean properties to strings so that they can have a default, empty value. As boolean properties their default, empty value was false, overriding any auto-magic functionality that flipped the TLS insecure bit to true. This way the properties can have three states: empty, false, and true.

Thanks to @cduchesne for helping me figure this out. This is partially related to codedellemc/rexray#833.