### PR TITLE
Enable TLS for UNIX Sockets via Env Var

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -361,6 +361,23 @@ when necessary and without any explicit configuration. However, if a file's
 related configuration property is set explicitly to some other, non-default
 value, the default file will not be loaded even if it is present.
 
+#### TLS and UNIX Sockets
+TLS is disabled by default when a server's endpoint or client-side host is
+configured for use with a UNIX socket. This is for two reasons:
+
+1. TLS isn't strictly necessary to provide transport security via a file-backed
+socket. The file's UNIX permissions take care of which users can read and/or
+write to the socket.
+2. The certificate verification step in a TLS negotiation is complicated when
+the endpoint to which the client is connecting is a file path, not a FQDN or
+IP address. This issue can be resolved by setting the property
+`libstorage.tls.serverName` on the client so that the value matches the
+server certificate's common name (CN) or one of its subject alternate names
+(SAN).
+
+To explicitly enable TLS for use with UNIX sockets, set the environment
+variable `LIBSTORAGE_TLS_SOCKITTOME` to a truthy value.
+
 #### Insecure TLS
 The following example illustrates how to configure the libStorage client to
 skip validation of a provided server-side certificate:

--- a/api/server/server_http.go
+++ b/api/server/server_http.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strings"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -125,19 +124,10 @@ func (s *server) initEndpoints(ctx types.Context) error {
 			"address":  laddr,
 		}
 
-		var tlsConfig *types.TLSConfig
-
-		// disable TLS for UNIX sockets
-		if !strings.EqualFold(proto, "unix") {
-			if tlsConfig, err =
-				utils.ParseTLSConfig(
-					s.ctx,
-					s.config.Scope(endpoint),
-					logFields,
-					types.ConfigServer,
-					endpoint); err != nil {
-				return err
-			}
+		tlsConfig, err := utils.ParseTLSConfig(
+			s.ctx, s.config, proto, logFields, types.ConfigServer)
+		if err != nil {
+			return err
 		}
 
 		ctx.WithFields(logFields).Info("configured endpoint")

--- a/api/utils/utils_tls.go
+++ b/api/utils/utils_tls.go
@@ -54,8 +54,18 @@ func ParseKnownHost(
 func ParseTLSConfig(
 	ctx types.Context,
 	config gofig.Config,
+	proto string,
 	fields log.Fields,
 	roots ...string) (tlsConfig *types.TLSConfig, tlsErr error) {
+
+	if strings.EqualFold(proto, "unix") {
+		enable, _ := strconv.ParseBool(
+			os.Getenv("LIBSTORAGE_TLS_SOCKITTOME"))
+		if !enable {
+			ctx.Debug("disabling tls for unix sockets")
+			return nil, nil
+		}
+	}
 
 	ctx.Debug("parsing tls config")
 

--- a/drivers/storage/libstorage/libstorage_driver.go
+++ b/drivers/storage/libstorage/libstorage_driver.go
@@ -68,15 +68,10 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 		return err
 	}
 
-	var tlsConfig *types.TLSConfig
-
-	// disable TLS for UNIX sockets
-	if !strings.EqualFold(proto, "unix") {
-		tlsConfig, err = utils.ParseTLSConfig(
-			d.ctx, config, logFields, types.ConfigClient)
-		if err != nil {
-			return err
-		}
+	tlsConfig, err := utils.ParseTLSConfig(
+		d.ctx, config, proto, logFields, types.ConfigClient)
+	if err != nil {
+		return err
 	}
 
 	host := getHost(d.ctx, proto, lAddr, tlsConfig)


### PR DESCRIPTION
This patch provides a way to reenable TLS for UNIX sockets by setting the environment variable `LIBSTORAGE_TLS_SOCKITTOME` to a truthy value.