### PR TITLE
Go 1.8 Plug-in Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,23 @@ go_import_path: github.com/codedellemc/libstorage
 
 language: go
 go:
-  - 1.6.3
-  - 1.7.5
-  - 1.8
-  - tip
+#  - 1.6.3
+#  - 1.7.5
+  - 1.8.3
+#  - tip
 
 os:
   - linux
 
 env:
   - TRAVIS_GOARCH=amd64 BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
-  - TRAVIS_GOARCH=arm BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
-  - TRAVIS_GOARCH=arm64 BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
-  - VFS_INSTANCEID_USE_FIELDS=true BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
-  - LIBSTORAGE_TEST_TCP=false LIBSTORAGE_TEST_TCP_TLS=true BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
-  - LIBSTORAGE_TEST_TCP=false LIBSTORAGE_TEST_TCP_TLS_PEERS=true BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
-  - BUILD_TAGS="gofig pflag libstorage_integration_driver_linux"
-  - BUILD_TAGS=""
+#  - TRAVIS_GOARCH=arm BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
+#  - TRAVIS_GOARCH=arm64 BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
+#  - VFS_INSTANCEID_USE_FIELDS=true BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
+#  - LIBSTORAGE_TEST_TCP=false LIBSTORAGE_TEST_TCP_TLS=true BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
+#  - LIBSTORAGE_TEST_TCP=false LIBSTORAGE_TEST_TCP_TLS_PEERS=true BUILD_TAGS="gofig pflag libstorage_integration_driver_linux libstorage_storage_driver libstorage_storage_driver_vfs libstorage_storage_executor libstorage_storage_executor_vfs"
+#  - BUILD_TAGS="gofig pflag libstorage_integration_driver_linux"
+#  - BUILD_TAGS=""
 
 matrix:
   fast_finish: true
@@ -55,9 +55,18 @@ before_install:
   - git config --global 'url.https://gopkg.in/fsnotify.v1.insteadof' 'https://gopkg.in/fsnotify.v1/'
   - git config --global 'url.https://github.com/.insteadof' 'git://github.com/'
   - git config --global 'url.https://github.com/.insteadof' 'git@github.com:'
-  - make version
-  - make info
   - make deps
+  - export PROJECT_NAME="libstorage"
+  - export GOPATH_OLD="$GOPATH"
+  - export GOPATH="/tmp/go"
+  - mkdir -p "$GOPATH"/{bin,pkg,src}
+  - mv "$GOPATH_OLD"/bin/* "$GOPATH"/bin/
+  - export PATH="${GOPATH}/bin:${PATH}"
+  - mkdir -p "$GOPATH"/src/github.com/codedellemc
+  - rsync -ax vendor/ "$GOPATH"/src/ && rm -fr vendor
+  - cd .. && mv "$PROJECT_NAME" "$GOPATH"/src/github.com/codedellemc/
+  - cd "$GOPATH"/src/github.com/codedellemc/"$PROJECT_NAME"
+  - make info
 
 script:
   - make gometalinter-all

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ GO_STDLIB := archive archive/tar archive/zip bufio builtin bytes compress \
 			 runtime/trace sort strconv strings sync sync/atomic syscall \
 			 testing testing/iotest testing/quick text text/scanner \
 			 text/tabwriter text/template text/template/parse time unicode \
-			 unicode/utf16 unicode/utf8 unsafe
+			 unicode/utf16 unicode/utf8 unsafe context plugin
 
 
 ################################################################################
@@ -554,6 +554,7 @@ TEST_EXT_DEPS_SRCS := $(sort $(TEST_EXT_DEPS_SRCS))
 ALL_EXT_DEPS := $(sort $(EXT_DEPS) $(TEST_EXT_DEPS))
 ALL_EXT_DEPS_SRCS := $(sort $(EXT_DEPS_SRCS) $(TEST_EXT_DEPS_SRCS))
 
+ifneq (1,$(NODEPS))
 ifneq (1,$(VENDORED))
 
 $(GLIDE):
@@ -595,13 +596,15 @@ GO_PHONY += $(GLIDE_LOCK)-clean
 GO_CLOBBER += $(GLIDE_LOCK)-clean
 
 endif #ifneq (1,$(VENDORED))
-
+endif #ifneq (1,$(NODEPS))
 
 ################################################################################
 ##                                GOBINDATA                                   ##
 ################################################################################
 GO_BINDATA := $(GOPATH)/bin/go-bindata
 go-bindata: $(GO_BINDATA)
+
+ifneq (1,$(NODEPS))
 
 GO_BINDATA_IMPORT_PATH := vendor/github.com/jteeuwen/go-bindata/go-bindata
 ifneq (1,$(VENDORED))
@@ -618,6 +621,7 @@ $(GO_BINDATA):
 	@touch $@
 GO_DEPS += $(GO_BINDATA)
 
+endif #ifneq (1,$(NODEPS))
 
 ################################################################################
 ##                               GOMETALINTER                                 ##
@@ -629,10 +633,12 @@ endif
 ifneq (1,$(GOMETALINTER_DISABLED))
 GOMETALINTER := $(GOPATH)/bin/gometalinter
 
+ifneq (1,$(NODEPS))
 $(GOMETALINTER): | $(GOMETALINTER_TOOLS)
 	GOOS="" GOARCH="" go get -u github.com/alecthomas/gometalinter
 gometalinter: $(GOMETALINTER)
 GO_DEPS += $(GOMETALINTER)
+endif # ifneq (1,$(NODEPS))
 
 GOMETALINTER_TOOLS_D := .gometalinter.tools.d
 $(GOMETALINTER_TOOLS_D): $(GOMETALINTER)
@@ -1377,7 +1383,12 @@ cover-debug:
 ################################################################################
 ##                                  TARGETS                                   ##
 ################################################################################
+ifeq (1,$(NODEPS))
+deps:
+	@echo nodeps
+else
 deps: $(GO_DEPS)
+endif
 
 build-tests: $(GO_BUILD_TESTS)
 

--- a/api/mods/mods.go
+++ b/api/mods/mods.go
@@ -1,0 +1,74 @@
+// +build go1.8,linux
+
+package mods
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"plugin"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/akutz/gotil"
+
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+var (
+	loadedMods     = map[string]bool{}
+	loadedModsLock = sync.Mutex{}
+)
+
+// LoadModules loads the shared objects present on the file system
+// as libStorage plug-ins.
+func LoadModules(
+	ctx types.Context,
+	pathConfig *types.PathConfig) {
+
+	disabled, _ := strconv.ParseBool(
+		os.Getenv("LIBSTORAGE_PLUGINS_DISABLED"))
+	if disabled {
+		ctx.Debug("plugin support disabled")
+		return
+	}
+
+	loadedModsLock.Lock()
+	defer loadedModsLock.Unlock()
+
+	if !gotil.FileExists(pathConfig.Mod) {
+		return
+	}
+	modFiles, err := ioutil.ReadDir(pathConfig.Mod)
+	if err != nil {
+		ctx.WithField("path", pathConfig.Mod).Warn(
+			"failed to list module files")
+		return
+	}
+	for _, f := range modFiles {
+		modFilePath := f.Name()
+		modFilePath = path.Join(pathConfig.Mod, modFilePath)
+		ctx.WithField(
+			"path", modFilePath).Debug(
+			"loading module")
+		lcModFilePath := strings.ToLower(modFilePath)
+		if loaded, ok := loadedMods[lcModFilePath]; ok && loaded {
+			ctx.WithField(
+				"path", modFilePath).Debug(
+				"already loaded")
+			continue
+		}
+		_, err := plugin.Open(modFilePath)
+		if err != nil {
+			ctx.WithError(err).WithField(
+				"path", modFilePath).Error(
+				"error opening module")
+			continue
+		}
+		loadedMods[lcModFilePath] = true
+		ctx.WithField(
+			"path", modFilePath).Info(
+			"loaded module")
+	}
+}

--- a/api/mods/nomods.go
+++ b/api/mods/nomods.go
@@ -1,0 +1,16 @@
+// +build !go1.8 !linux
+
+package mods
+
+import (
+	"github.com/codedellemc/libstorage/api/types"
+)
+
+// LoadModules loads the shared objects present on the file system
+// as libStorage plug-ins.
+func LoadModules(
+	ctx types.Context,
+	pathConfig *types.PathConfig) {
+
+	// NOOP
+}

--- a/api/types/types_paths.go
+++ b/api/types/types_paths.go
@@ -18,6 +18,9 @@ type PathConfig struct {
 	// Log is the path to the log directory.
 	Log string
 
+	// Mod is the path to the mod directory.
+	Mod string
+
 	// Run is the path to the run directory.
 	Run string
 

--- a/api/utils/utils_paths.go
+++ b/api/utils/utils_paths.go
@@ -36,6 +36,7 @@ func NewPathConfig(ctx types.Context, home, token string) *types.PathConfig {
 		envVarHomeEtc    = fmt.Sprintf("%s_HOME_ETC", ucTok)
 		envVarHomeEtcTLS = fmt.Sprintf("%s_HOME_ETC_TLS", ucTok)
 		envVarHomeLib    = fmt.Sprintf("%s_HOME_LIB", ucTok)
+		envVarHomeLibMod = fmt.Sprintf("%s_HOME_LIB_MOD", ucTok)
 		envVarHomeLog    = fmt.Sprintf("%s_HOME_LOG", ucTok)
 		envVarHomeRun    = fmt.Sprintf("%s_HOME_RUN", ucTok)
 		envVarHomeLSX    = fmt.Sprintf("%s_HOME_LSX", ucTok)
@@ -57,6 +58,7 @@ func NewPathConfig(ctx types.Context, home, token string) *types.PathConfig {
 	initPathConfigFieldWithEnvVar(ctx, envVarHomeEtc, &pathConfig.Etc)
 	initPathConfigFieldWithEnvVar(ctx, envVarHomeEtcTLS, &pathConfig.TLS)
 	initPathConfigFieldWithEnvVar(ctx, envVarHomeLib, &pathConfig.Lib)
+	initPathConfigFieldWithEnvVar(ctx, envVarHomeLibMod, &pathConfig.Mod)
 	initPathConfigFieldWithEnvVar(ctx, envVarHomeLog, &pathConfig.Log)
 	initPathConfigFieldWithEnvVar(ctx, envVarHomeRun, &pathConfig.Run)
 	initPathConfigFieldWithEnvVar(ctx, envVarHomeLSX, &pathConfig.LSX)
@@ -84,6 +86,8 @@ func NewPathConfig(ctx types.Context, home, token string) *types.PathConfig {
 		ctx, false, true, token, pathConfig.Etc, "tls", &pathConfig.TLS)
 	initPathConfigFieldWithPath(
 		ctx, root, true, token, pathConfig.Home, "var/lib", &pathConfig.Lib)
+	initPathConfigFieldWithPath(
+		ctx, false, true, token, pathConfig.Lib, "mod", &pathConfig.Mod)
 	initPathConfigFieldWithPath(
 		ctx, root, true, token, pathConfig.Home, "var/log", &pathConfig.Log)
 	initPathConfigFieldWithPath(

--- a/cli/lsx/lsx.go
+++ b/cli/lsx/lsx.go
@@ -14,6 +14,7 @@ import (
 	"github.com/akutz/goof"
 
 	"github.com/codedellemc/libstorage/api/context"
+	apimods "github.com/codedellemc/libstorage/api/mods"
 	"github.com/codedellemc/libstorage/api/registry"
 	apitypes "github.com/codedellemc/libstorage/api/types"
 	"github.com/codedellemc/libstorage/api/utils"
@@ -31,7 +32,12 @@ var cmdRx = regexp.MustCompile(
 func Run() {
 
 	ctx := context.Background()
-	ctx = ctx.WithValue(context.PathConfigKey, utils.NewPathConfig(ctx, "", ""))
+	pathConfig := utils.NewPathConfig(ctx, "", "")
+	ctx = ctx.WithValue(context.PathConfigKey, pathConfig)
+
+	// load shared objects
+	apimods.LoadModules(ctx, pathConfig)
+
 	registry.ProcessRegisteredConfigs(ctx)
 
 	args := os.Args


### PR DESCRIPTION
This patch introduces support for loading Linux shared object (.so) files as Go 1.8 plug-ins. This feature requires Linux.