### PR TITLE
Handle whitespace in ceph.conf mon_hosts entry

### DIFF
--- a/drivers/storage/rbd/tests/rbd_test.go
+++ b/drivers/storage/rbd/tests/rbd_test.go
@@ -21,7 +21,6 @@ import (
 	// load the  driver
 	"github.com/codedellemc/libstorage/drivers/storage/rbd"
 	rbdx "github.com/codedellemc/libstorage/drivers/storage/rbd/executor"
-	rbdu "github.com/codedellemc/libstorage/drivers/storage/rbd/utils"
 )
 
 var (
@@ -155,51 +154,6 @@ func TestInstanceIDSimulatedIPs(t *testing.T) {
 		if test.iid != nil {
 			assert.True(t, test.iid.Equal(net.ParseIP(iid.ID)))
 		}
-	}
-}
-
-type testAddrInput struct {
-	address []string
-	ip      net.IP
-}
-
-var testAddrs = []testAddrInput{
-	{
-		address: []string{"192.168.0.2"},
-		ip:      ipZeroDotTwo,
-	},
-	{
-		address: []string{"192.168.0.2:6789"},
-		ip:      ipZeroDotTwo,
-	},
-	{
-		address: []string{"[2001:db8:85a3::8a2e:370:7334]"},
-		ip:      ipv6,
-	},
-	{
-		address: []string{"[2001:db8:85a3::8a2e:370:7334]:6789"},
-		ip:      ipv6,
-	},
-	{
-		address: []string{"[::1]"},
-		ip:      ipv6Local,
-	},
-}
-
-func TestParseMonitorAddresses(t *testing.T) {
-	if skipTests() {
-		t.SkipNow()
-	}
-
-	for _, test := range testAddrs {
-		ip, err := rbdu.ParseMonitorAddresses(test.address)
-
-		assert.NoError(t, err, "failed with %s", test.address[0])
-		if err != nil {
-			t.Error("failed TestParseMonitorAddresses")
-			t.FailNow()
-		}
-		assert.True(t, test.ip.Equal(ip[0]))
 	}
 }
 

--- a/drivers/storage/rbd/utils/utils.go
+++ b/drivers/storage/rbd/utils/utils.go
@@ -316,6 +316,7 @@ func ParseMonitorAddresses(addrs []string) ([]net.IP, error) {
 	)
 
 	for _, mon := range addrs {
+		mon = strings.TrimSpace(mon)
 		host = mon
 		if hasPort(mon) {
 			host, _, err = net.SplitHostPort(mon)

--- a/drivers/storage/rbd/utils/utils_test.go
+++ b/drivers/storage/rbd/utils/utils_test.go
@@ -1,0 +1,79 @@
+// +build !libstorage_storage_driver libstorage_storage_driver_rbd
+
+package utils
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testAddrInput struct {
+	address []string
+	ip      net.IP
+}
+
+var (
+	ipZeroDotTwo    = net.ParseIP("192.168.0.2")
+	ipOneDotTwo     = net.ParseIP("192.168.1.2")
+	ipZeroDotTen    = net.ParseIP("192.168.0.10")
+	ipZeroDotTwenty = net.ParseIP("192.168.0.20")
+	ipZeroDotThirty = net.ParseIP("192.168.0.30")
+	ipv6            = net.ParseIP("2001:db8:85a3::8a2e:370:7334")
+	ipv6Local       = net.ParseIP("::1")
+)
+
+var testAddrs = []testAddrInput{
+	{
+		address: []string{"192.168.0.2"},
+		ip:      ipZeroDotTwo,
+	},
+	{
+		address: []string{
+			"192.168.0.2",
+			" 192.168.1.2"},
+		ip: ipZeroDotTwo,
+	},
+	{
+		address: []string{"192.168.0.2:6789"},
+		ip:      ipZeroDotTwo,
+	},
+	{
+		address: []string{
+			"192.168.0.2:6789",
+			" 192.168.1.2:6789"},
+		ip: ipZeroDotTwo,
+	},
+	{
+		address: []string{"[2001:db8:85a3::8a2e:370:7334]"},
+		ip:      ipv6,
+	},
+	{
+		address: []string{
+			"[2001:db8:85a3::8a2e:370:7334]",
+			" [2001:db8:85a3::8a2e:370:7335] "},
+		ip: ipv6,
+	},
+	{
+		address: []string{"[2001:db8:85a3::8a2e:370:7334]:6789"},
+		ip:      ipv6,
+	},
+	{
+		address: []string{"[::1]"},
+		ip:      ipv6Local,
+	},
+}
+
+func TestParseMonitorAddresses(t *testing.T) {
+	for _, test := range testAddrs {
+		ip, err := ParseMonitorAddresses(test.address)
+
+		assert.NoError(t, err, "failed with %s", test.address[0])
+		if err != nil {
+			t.Error("failed TestParseMonitorAddresses")
+			t.FailNow()
+		}
+		assert.True(t, test.ip.Equal(ip[0]))
+	}
+}


### PR DESCRIPTION
Move tests for parsing mon hosts line into utils_test.go because these
tests don't require a working storage backend. Therefore, make sure they
are run more often.

Fixes #551 
Fixes codedellemc/rexray#811