### PR TITLE
Correctly handle volume not exist during create

### DIFF
--- a/drivers/storage/isilon/storage/isilon_storage.go
+++ b/drivers/storage/isilon/storage/isilon_storage.go
@@ -259,7 +259,9 @@ func (d *driver) VolumeCreate(ctx types.Context, volumeName string,
 	vol, err := d.VolumeInspect(ctx, volumeName,
 		&types.VolumeInspectOpts{Attachments: types.VolAttReqTrue})
 	if err != nil {
-		return nil, err
+		if _, ok := err.(*types.ErrNotFound); !ok {
+			return nil, err
+		}
 	}
 
 	if vol != nil {


### PR DESCRIPTION
The Isilon driver was checking if a volume with the same name already
exists before attempting to create. A recent change made it such that an
error was returned when querying for the volume, rather than a nil
error, causing the driver to always return the error.

Instead, check if the error is a NotFoundError. If it is *not*, return
it the error. If it *is*, that's expected and move on.

Fixes #556