### PR TITLE
Fix invalid querystring for InspectVolumeByName

### DIFF
--- a/api/client/client_api_funcs.go
+++ b/api/client/client_api_funcs.go
@@ -129,7 +129,7 @@ func (c *client) VolumeInspectByName(
 
 	reply := types.Volume{}
 	url := fmt.Sprintf(
-		"/volumes/%s/%s?attachments=%v?byName", service, volumeName,
+		"/volumes/%s/%s?attachments=%v&byName", service, volumeName,
 		attachments)
 	if _, err := c.httpGet(ctx, url, &reply); err != nil {
 		return nil, err

--- a/drivers/storage/vfs/tests/vfs_test.go
+++ b/drivers/storage/vfs/tests/vfs_test.go
@@ -827,6 +827,21 @@ func TestVolumeInspect(t *testing.T) {
 	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
 }
 
+func TestVolumeInspectByName(t *testing.T) {
+	tc, _, vols, _ := newTestConfigAll(t)
+	tf := func(config gofig.Config, client types.Client, t *testing.T) {
+		reply, err := client.API().VolumeInspectByName(
+			nil, "vfs", "Volume 000", 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		vols[reply.ID].Attachments = nil
+		assert.NotNil(t, reply)
+		assert.EqualValues(t, vols[reply.ID], reply)
+	}
+	apitests.RunWithContext(tCtx, t, vfs.Name, tc, tf)
+}
+
 func TestVolumeInspectWithAttachments(t *testing.T) {
 	tc, _, vols, _ := newTestConfigAll(t)
 	tf := func(config gofig.Config, client types.Client, t *testing.T) {


### PR DESCRIPTION
Second querystring param was separated by a ? instead of &.