### PR TITLE
Allow disabling of RBD modprobe

### DIFF
--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -411,6 +411,7 @@ example see the [Examples](./storage-providers.md#ceph-rbd-examples) section.
 ```yaml
 rbd:
   defaultPool: rbd
+  testModule: true
 ```
 
 ##### Configuration Notes
@@ -418,6 +419,10 @@ rbd:
 * The `defaultPool` parameter is optional, and defaults to "rbd". When set, all
   volume requests that do not reference a specific pool will use the
   `defaultPool` value as the destination storage pool.
+* The `testModule` parameter is optional, and defaults to "true". This setting
+  indicates whether the libStorage client should test if the `rbd` kernel module
+  is loaded, with the side-effect of loading it if is not already loaded. This
+  setting should be disabled when the driver is executing inside of a container.
 
 #### Runtime behavior
 

--- a/drivers/storage/rbd/executor/rbd_executor.go
+++ b/drivers/storage/rbd/executor/rbd_executor.go
@@ -21,7 +21,8 @@ import (
 )
 
 type driver struct {
-	config gofig.Config
+	config     gofig.Config
+	doModprobe bool
 }
 
 func init() {
@@ -34,6 +35,7 @@ func newdriver() types.StorageExecutor {
 
 func (d *driver) Init(context types.Context, config gofig.Config) error {
 	d.config = config
+	d.doModprobe = config.GetBool(rbd.ConfigTestModule)
 	return nil
 }
 
@@ -57,9 +59,11 @@ func (d *driver) Supported(
 		return false, nil
 	}
 
-	cmd := exec.Command("modprobe", "rbd")
-	if _, _, err := utils.RunCommand(ctx, cmd); err != nil {
-		return false, nil
+	if d.doModprobe {
+		cmd := exec.Command("modprobe", "rbd")
+		if _, _, err := utils.RunCommand(ctx, cmd); err != nil {
+			return false, nil
+		}
 	}
 
 	return true, nil

--- a/drivers/storage/rbd/rbd.go
+++ b/drivers/storage/rbd/rbd.go
@@ -10,6 +10,12 @@ import (
 const (
 	// Name is the name of the storage driver
 	Name = "rbd"
+
+	// ConfigDefaultPool is the config key for default pool
+	ConfigDefaultPool = Name + ".defaultPool"
+
+	// ConfigTestModule is the config key for testing kernel module presence
+	ConfigTestModule = Name + ".testModule"
 )
 
 func init() {
@@ -18,6 +24,7 @@ func init() {
 
 func registerConfig() {
 	r := gofigCore.NewRegistration("RBD")
-	r.Key(gofig.String, "", "rbd", "", "rbd.defaultPool")
+	r.Key(gofig.String, "", "rbd", "", ConfigDefaultPool)
+	r.Key(gofig.Bool, "", true, "", ConfigTestModule)
 	gofigCore.Register(r)
 }

--- a/drivers/storage/rbd/storage/rbd_storage.go
+++ b/drivers/storage/rbd/storage/rbd_storage.go
@@ -370,7 +370,7 @@ func (d *driver) SnapshotRemove(
 }
 
 func (d *driver) defaultPool() string {
-	return d.config.GetString("rbd.defaultPool")
+	return d.config.GetString(rbd.ConfigDefaultPool)
 }
 
 func (d *driver) toTypeVolumes(


### PR DESCRIPTION
When RBD driver is running in a container, using `modprobe` to check if
the RBD module is already inserted is not apprpriate. Keep that
behavior as the default, but add a config option to disable it that can
be used for container deployments.