### PR TITLE
Enable Forced Vol Removal via Ig Drvr

### DIFF
--- a/.docs/user-guide/config.md
+++ b/.docs/user-guide/config.md
@@ -1138,6 +1138,13 @@ parameter|description
 `libstorage.integration.volume.operations.create.default.fsType`|Type of filesystem for new volumes (ext4/xfs)
 `libstorage.integration.volume.operations.create.default.availabilityZone`|Extensible parameter per storage driver
 
+The properties in the next table are the configurable parameters that affect
+the default values for volume remove requests.
+
+parameter|description
+---------|-----------
+`libstorage.integration.volume.operations.remove.force`|Force remove volumes
+
 #### Disable Create
 The disable create feature enables you to disallow any volume creation activity.
 Any requests will be returned in a successful manner, but the create will not
@@ -1164,6 +1171,19 @@ libstorage:
       operations:
         remove:
           disable: true
+```
+
+#### Force Remove
+The force remove feature enables the forced removal of a volume despite
+its current contents or state:
+
+```yaml
+libstorage:
+  integration:
+    volume:
+      operations:
+        remove:
+          force: true
 ```
 
 #### Preemption

--- a/api/types/types_config_integration.go
+++ b/api/types/types_config_integration.go
@@ -78,4 +78,7 @@ const (
 
 	// ConfigIgVolOpsRemoveDisable is a config key.
 	ConfigIgVolOpsRemoveDisable = ConfigIgVolOpsRemove + ".disable"
+
+	// ConfigIgVolOpsRemoveForce is a config key.
+	ConfigIgVolOpsRemoveForce = ConfigIgVolOpsRemove + ".force"
 )

--- a/drivers/integration/linux/linux.go
+++ b/drivers/integration/linux/linux.go
@@ -536,6 +536,11 @@ func (d *driver) Remove(
 
 	client := context.MustClient(ctx)
 
+	// check to see if there is a config override for force remove
+	if !opts.Force {
+		opts.Force = d.volumeRemoveForce()
+	}
+
 	return client.Storage().VolumeRemove(ctx, vol.ID, opts)
 }
 
@@ -597,4 +602,8 @@ func (d *driver) mountDirPath() string {
 
 func (d *driver) volumeCreateImplicit() bool {
 	return d.config.GetBool(types.ConfigIgVolOpsCreateImplicit)
+}
+
+func (d *driver) volumeRemoveForce() bool {
+	return d.config.GetBool(types.ConfigIgVolOpsRemoveForce)
 }

--- a/imports/config/imports_config_99_gofig.go
+++ b/imports/config/imports_config_99_gofig.go
@@ -88,6 +88,7 @@ func init() {
 			rk(gofig.String, "5s", "", types.ConfigIgVolOpsMountRetryWait)
 			rk(gofig.Bool, false, "", types.ConfigIgVolOpsCreateDisable)
 			rk(gofig.Bool, false, "", types.ConfigIgVolOpsRemoveDisable)
+			rk(gofig.Bool, false, "", types.ConfigIgVolOpsRemoveForce)
 			rk(gofig.Bool, false, "", types.ConfigIgVolOpsUnmountIgnoreUsed)
 			rk(gofig.Bool, true, "", types.ConfigIgVolOpsPathCacheEnabled)
 			rk(gofig.Bool, true, "", types.ConfigIgVolOpsPathCacheAsync)


### PR DESCRIPTION
This patch enables forced volume removal via a configuration property `libstorage.integration.volume.operations.remove.force` for the integration driver. This will enable Docker modules in REX-Ray to be configured to force remove backend storage volumes for platforms that require such behavior, such as S3FS.

This patch is related to codedellemc/rexray#892.