### PR TITLE
No longer report invalid local devices

### DIFF
--- a/drivers/storage/cinder/executor/cinder_executor.go
+++ b/drivers/storage/cinder/executor/cinder_executor.go
@@ -202,28 +202,10 @@ func (d *driver) NextDevice(
 func (d *driver) LocalDevices(
 	ctx types.Context,
 	opts *types.LocalDevicesOpts) (*types.LocalDevices, error) {
-	devicesMap := make(map[string]string)
 
-	file := "/proc/partitions"
-	contentBytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil,
-			goof.WithFieldE("file", file, "error reading file", err)
-	}
-
-	content := string(contentBytes)
-
-	lines := strings.Split(content, "\n")
-	for _, line := range lines[2:] {
-		fields := strings.Fields(line)
-		if len(fields) >= 4 {
-			devicePath := "/dev/" + fields[3]
-			devicesMap[devicePath] = ""
-		}
-	}
-
-	return &types.LocalDevices{
-		Driver:    cinder.Name,
-		DeviceMap: devicesMap,
-	}, nil
+	/* There is no current method to look up what the volume ID is for
+	volumes attached to a host via Cinder. All lookups are done on the
+	server-side from the Cinder API
+	*/
+	return &types.LocalDevices{Driver: d.Name()}, nil
 }


### PR DESCRIPTION
The Cinder driver cannot completely fill out the local device struct
from the executor because it cannot lookup the source volume ID for
attached volumes. Instead, it was reporting an empty volume ID, which is
invalid and was subsequently removed by the libStorage client when
parsing output from the xcli. This just resulted in wasted cycles and
extra log messages.

Fixes #540