### PR TITLE
Add gcepd support for VolumeInspectByName

### DIFF
--- a/drivers/storage/gcepd/storage/gce_storage.go
+++ b/drivers/storage/gcepd/storage/gce_storage.go
@@ -300,7 +300,7 @@ func (d *driver) Volumes(
 	return vols, nil
 }
 
-// VolumeInspect inspects a single volume.
+// VolumeInspect inspects a single volume by ID.
 func (d *driver) VolumeInspect(
 	ctx types.Context,
 	volumeID string,
@@ -333,6 +333,20 @@ func (d *driver) VolumeInspect(
 	}
 
 	return vols[0], nil
+}
+
+// VolumeInspectByName inspects a single volume by name.
+func (d *driver) VolumeInspectByName(
+	ctx types.Context,
+	volumeName string,
+	opts *types.VolumeInspectOpts) (*types.Volume, error) {
+
+	// For GCE, name and ID are the same
+	return d.VolumeInspect(
+		ctx,
+		volumeName,
+		opts,
+	)
 }
 
 // VolumeCreate creates a new volume.


### PR DESCRIPTION
Implement `VolumeInspectByName` for the `gcepd` driver. This provides an optimized lookup when callers are wanting to lookup a volume by name instead of by ID. This prevents the framework (>= 0.6.1) or the integration driver (<= v0.6.0 and before from having to a `Volumes()` call and then string match on the name.

Just for fun, some simple performance numbers. This is using REX-Ray 0.9.0, 0.9.1, and 0.9.1+this patch on GCE with 10 volumes defined. Ran a loop 10 times with `docker inspect`. REX-Ray 0.9 would have called `Volumes()`, retrieving a list of all volumes and then finding the desired one to inspect. 0.9.1 Would call `VolumeInspect()` with a flag that has the framework do the `Volumes()` call followed by the string match instead of the integration driver (eliminating an entire API call between client and server, but it still occurs from the framework so there isn't a big different when doing all-in-one), and this patch would have the framework call `VolumeInsepectByName()` directly, eliminating the call to `Volumes()` entirely.

| 0.9.1+ | 0.9.1 | 0.9.0 |
| - | - | - |
real	0m0.211s | real	0m0.296s | real	0m0.281s
real	0m0.233s | real	0m0.386s | real	0m0.253s
real	0m0.202s | real	0m0.293s | real	0m0.288s
real	0m0.234s | real	0m0.269s | real	0m0.270s
real	0m0.204s | real	0m0.286s | real	0m0.278s
real	0m0.190s | real	0m0.313s | real	0m0.281s
real	0m0.203s | real	0m0.284s | real	0m0.273s
real	0m0.199s | real	0m0.351s | real	0m0.314s
real	0m0.356s | real	0m0.341s | real	0m0.319s
real	0m0.245s | real	0m0.294s | real	0m0.300s

This results in an average (in seconds) of:

| 0.9.1+ | 0.9.1 | 0.9.0 |
| - | - | - |
0.2277 | 0.3113 | 0.2857


As expected, there isn't much difference between 0.9.0 and 0.9.1 in this setup. Though I think 0.9.1 would win out if you scaled up the number of volumes and made it a distributed setup. But this patch has the biggest effect overall, because no call to `Volumes()` is needed at all. DIsparity between the two will only grow as the number of volumes increases.

FWIW, this performance improvement is only realizable by Docker and `docker volume` commands right now. Some changes would have to occur in REX-Ray to take advantage of this from the `rexray` CLI.


