### PR TITLE
GCE translate underscores

### DIFF
--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -1013,6 +1013,7 @@ gcepd:
   statusMaxAttempts:  10
   statusInitialDelay: 100ms
   statusTimeout:      2m
+  convertUnderscores: false
 ```
 
 ##### Configuration Notes
@@ -1050,6 +1051,12 @@ gcepd:
 * `statusTimeout` is a maximum length of time that polling for volume status can
   occur. This serves as a backstop against a stuck request of malfunctioning API
   that never returns.
+* `convertUnderscores` is a boolean flag that controls whether the driver will
+  automatically convert underscores to dashes during a volume create request.
+  GCE does not allow underscores in the volume name, but some container
+  orchestrators (e.g. Docker Swarm) automatically prefix volume names
+  with a string containing a dash. This flag enables such requests to proceed,
+  but with the volume name modified.
 
 #### Runtime behavior
 * The GCEPD driver enforces the GCE requirements for disk sizing and naming.

--- a/drivers/storage/gcepd/gcepd.go
+++ b/drivers/storage/gcepd/gcepd.go
@@ -11,8 +11,9 @@ const (
 	// Name is the provider's name.
 	Name = "gcepd"
 
-	defaultStatusMaxAttempts = 10
-	defaultStatusInitDelay   = "100ms"
+	defaultStatusMaxAttempts  = 10
+	defaultStatusInitDelay    = "100ms"
+	defaultConvertUnderscores = false
 
 	/* This is hard deadline when waiting for the volume status to change to
 	a desired state. At minimum is has to be more than the expontential
@@ -61,6 +62,11 @@ const (
 	// ConfigStatusTimeout is the key for the time duration for a timeout
 	// on how long to wait for a desired volume status to appears
 	ConfigStatusTimeout = Name + ".statusTimeout"
+
+	// ConfigConvertUnderscores is the key for a boolean flag on whether
+	// incoming requests that have names with underscores should be
+	// converted to dashes to satisfy GCE naming requirements
+	ConfigConvertUnderscores = Name + ".convertUnderscores"
 )
 
 func init() {
@@ -80,6 +86,8 @@ func init() {
 		ConfigStatusInitDelay)
 	r.Key(gofig.String, "", defaultStatusTimeout, "Status Timeout",
 		ConfigStatusTimeout)
+	r.Key(gofig.Bool, "", defaultConvertUnderscores,
+		"Convert Underscores", ConfigConvertUnderscores)
 
 	gofigCore.Register(r)
 }

--- a/drivers/storage/gcepd/storage/gce_storage.go
+++ b/drivers/storage/gcepd/storage/gce_storage.go
@@ -300,7 +300,7 @@ func (d *driver) Volumes(
 	return vols, nil
 }
 
-// VolumeInspect inspects a single volume.
+// VolumeInspect inspects a single volume by ID.
 func (d *driver) VolumeInspect(
 	ctx types.Context,
 	volumeID string,
@@ -333,6 +333,20 @@ func (d *driver) VolumeInspect(
 	}
 
 	return vols[0], nil
+}
+
+// VolumeInspectByName inspects a single volume by name.
+func (d *driver) VolumeInspectByName(
+	ctx types.Context,
+	volumeName string,
+	opts *types.VolumeInspectOpts) (*types.Volume, error) {
+
+	// For GCE, name and ID are the same
+	return d.VolumeInspect(
+		ctx,
+		volumeName,
+		opts,
+	)
 }
 
 // VolumeCreate creates a new volume.


### PR DESCRIPTION
This is a bit experimental, but worked completely in my testing with Docker.

New config option, gcepd.convertUnderscores, enables the GCEPD driver to
replace any underscores with dashes during volume creation. When a
VolumeInspectByName request comes in, that name is also converted, and
the volume that was created with the dashes is returned.

It is important to note that the returned data from the driver is always
correct -- the name is never displayed as having underscores instead of
dashes, because no such volume exists.

Fixes #458

without patch:
```
$ docker volume create -d rexray test_me3 --opt size=10
Error response from daemon: create test_me3: VolumeDriver.Create: {"Error":"Volume name does not meet GCE naming requirements"}
```

with patch:
```
$ docker volume create -d rexray test_me4 --opt size=10
test_me4
$ ./rexray -s gcepd volume ls
ID          Name        Status     Size
test-me4    test-me4    available  10
$ docker volume ls
DRIVER              VOLUME NAME
rexray              test-me4
$ docker volume inspect test_me4
[
    {
        "Driver": "rexray",
        "Labels": {},
        "Mountpoint": "/",
        "Name": "test-me4",
        "Options": {
            "size": "10"
        },
        "Scope": "global",
        "Status": {
            "availabilityZone": "us-west1-b",
            "fields": null,
            "iops": 0,
            "name": "test-me4",
            "server": "gcepd",
            "service": "gcepd",
            "size": 10,
            "type": "pd-ssd"
        }
    }
]
$ docker run --rm --volume-driver=rexray -v test_me4:/data busybox mount | grep \/data
/dev/disk/by-id/google-test-me4 on /data type ext4 (rw,seclabel,relatime,data=ordered)
# docker volume rm test_me4
test_me4
```

So, at this point for docker, `test_me4` and `test-me4` are pretty much aliases for each other. Referencing either one works.

This PR depends on #579, and includes the commit from that PR. Once that PR is merged, this can be rebased to remove the additional commit.