### PR TITLE
DOBS translate underscores

### DIFF
--- a/.docs/user-guide/storage-providers.md
+++ b/.docs/user-guide/storage-providers.md
@@ -817,6 +817,7 @@ dobs:
   statusMaxAttempts: 10
   statusInitialDelay: 100ms
   statusTimeout: 2m
+  convertUnderscores: false
 ```
 
 ##### Configuration notes
@@ -831,6 +832,12 @@ dobs:
 - `statusTimeout` is a maximum length of time that polling for volume status can
   occur. This serves as a backstop against a stuck request of malfunctioning API
   that never returns.
+- `convertUnderscores` is a boolean flag that controls whether the driver will
+  automatically convert underscores to dashes during a volume create request.
+  Digital Ocean does not allow underscores in the volume name, but some
+  container orchestrators (e.g. Docker Swarm) automatically prefix volume names
+  with a string containing a dash. This flag enables such requests to proceed,
+  but with the volume name modified.
 
 !!! note
     The DigitalOcean service currently only supports block storage volumes in

--- a/drivers/storage/dobs/dobs.go
+++ b/drivers/storage/dobs/dobs.go
@@ -11,8 +11,9 @@ const (
 	// Name is the name of the driver
 	Name = "dobs"
 
-	defaultStatusMaxAttempts = 10
-	defaultStatusInitDelay   = "100ms"
+	defaultStatusMaxAttempts  = 10
+	defaultStatusInitDelay    = "100ms"
+	defaultConvertUnderscores = false
 
 	/* This is hard deadline when waiting for the volume status to change to
 	a desired state. At minimum is has to be more than the expontential
@@ -54,6 +55,11 @@ const (
 	// ConfigStatusTimeout is the key for the time duration for a timeout
 	// on how long to wait for a desired volume status to appears
 	ConfigStatusTimeout = Name + ".statusTimeout"
+
+	// ConfigConvertUnderscores is the key for a boolean flag on whether
+	// incoming requests that have names with underscores should be
+	// converted to dashes to satisfy DO naming requirements
+	ConfigConvertUnderscores = Name + ".convertUnderscores"
 )
 
 func init() {
@@ -72,5 +78,7 @@ func registerConfig() {
 		ConfigStatusInitDelay)
 	r.Key(gofig.String, "", defaultStatusTimeout, "Status Timeout",
 		ConfigStatusTimeout)
+	r.Key(gofig.Bool, "", defaultConvertUnderscores,
+		"Convert Underscores", ConfigConvertUnderscores)
 	gofigCore.Register(r)
 }


### PR DESCRIPTION
New config option, dobs.convertUnderscores, enables the DOBS driver to
replace any underscores with dashes during volume creation. When a
VolumeInspectByName request comes in, that name is also converted, and
the volume that was created with the dashes is returned.

It is important to note that the returned data from the driver is always
correct -- the name is never displayed as having underscores instead of
dashes, because no such volume exists.

Fixes #450

This is functionally equivalent to #580, so look there for even more info. This PR also has a dependent PR that has to go in first, and that is #581. Once that is in, this can be rebased to remove the 2nd commit.