### PR TITLE
EFS SecurityGroup Warning

### DIFF
--- a/drivers/storage/efs/utils/utils.go
+++ b/drivers/storage/efs/utils/utils.go
@@ -93,7 +93,7 @@ func InstanceID(ctx types.Context) (*types.InstanceID, error) {
 		efs.InstanceIDFieldAvailabilityZone: iid.AvailabilityZone,
 	}
 
-	if len(secGroups) == 1 {
+	if len(secGroups) > 0 {
 		iidFields[efs.InstanceIDFieldSecurityGroups] = strings.Join(
 			secGroups, ";")
 	}


### PR DESCRIPTION
This patch fixes #511 by sending an instance's full SG list to the remote service where the EFS storage driver examines the server-side SG list with the client-side list. If any of the server-side SGs are not present in the client-side list a warning will be logged in order to assist with debugging.