### PR TITLE
Package-Level Makefiles for Testing

### DIFF
--- a/api/context/Makefile
+++ b/api/context/Makefile
@@ -1,0 +1,1 @@
+include ../../test-framework-pkg.mk

--- a/api/server/auth/Makefile
+++ b/api/server/auth/Makefile
@@ -1,0 +1,1 @@
+include ../../../test-framework-pkg.mk

--- a/api/types/Makefile
+++ b/api/types/Makefile
@@ -1,0 +1,1 @@
+include ../../test-framework-pkg.mk

--- a/api/utils/Makefile
+++ b/api/utils/Makefile
@@ -1,0 +1,1 @@
+include ../../test-framework-pkg.mk

--- a/api/utils/filters/Makefile
+++ b/api/utils/filters/Makefile
@@ -1,0 +1,1 @@
+include ../../../test-framework-pkg.mk

--- a/api/utils/schema/Makefile
+++ b/api/utils/schema/Makefile
@@ -1,0 +1,1 @@
+include ../../../test-framework-pkg.mk

--- a/drivers/storage/azureud/tests/Makefile
+++ b/drivers/storage/azureud/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/azureud/tests/coverage.mk
+++ b/drivers/storage/azureud/tests/coverage.mk
@@ -1,2 +1,0 @@
-AZUREUD_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/azureud
-TEST_COVERPKG_./drivers/storage/azureud/tests := $(AZUREUD_COVERPKG),$(AZUREUD_COVERPKG)/executor

--- a/drivers/storage/cinder/tests/Makefile
+++ b/drivers/storage/cinder/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/cinder/tests/coverage.mk
+++ b/drivers/storage/cinder/tests/coverage.mk
@@ -1,2 +1,0 @@
-CINDER_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/cinder
-TEST_COVERPKG_./drivers/storage/cinder/tests := $(CINDER_COVERPKG),$(CINDER_COVERPKG)/executor

--- a/drivers/storage/dobs/tests/Makefile
+++ b/drivers/storage/dobs/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/dobs/tests/coverage.mk
+++ b/drivers/storage/dobs/tests/coverage.mk
@@ -1,2 +1,0 @@
-DOBS_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/dobs
-TEST_COVERPKG_./drivers/storage/dobs/tests := $(DOBS_COVERPKG),$(DOBS_COVERPKG)/executor

--- a/drivers/storage/ebs/tests/Makefile
+++ b/drivers/storage/ebs/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/ebs/tests/coverage.mk
+++ b/drivers/storage/ebs/tests/coverage.mk
@@ -1,2 +1,0 @@
-EBS_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/ebs
-TEST_COVERPKG_./drivers/storage/ebs/tests := $(EBS_COVERPKG),$(EBS_COVERPKG)/executor

--- a/drivers/storage/efs/tests/Makefile
+++ b/drivers/storage/efs/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/efs/tests/coverage.mk
+++ b/drivers/storage/efs/tests/coverage.mk
@@ -1,2 +1,0 @@
-EFS_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/efs
-TEST_COVERPKG_./drivers/storage/efs/tests := $(EFS_COVERPKG),$(EFS_COVERPKG)/executor,$(EFS_COVERPKG)/storage

--- a/drivers/storage/fittedcloud/tests/Makefile
+++ b/drivers/storage/fittedcloud/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/fittedcloud/tests/coverage.mk
+++ b/drivers/storage/fittedcloud/tests/coverage.mk
@@ -1,2 +1,0 @@
-FITTEDCLOUD_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/fittedcloud
-TEST_COVERPKG_./drivers/storage/fittedcloud/tests := $(FITTEDCLOUD_COVERPKG),$(FITTEDCLOUD_COVERPKG)/executor,$(FITTEDCLOUD_COVERPKG)/fcagent,$(FITTEDCLOUD_COVERPKG)/utils

--- a/drivers/storage/gcepd/tests/Makefile
+++ b/drivers/storage/gcepd/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/gcepd/tests/coverage.mk
+++ b/drivers/storage/gcepd/tests/coverage.mk
@@ -1,2 +1,0 @@
-GCEPD_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/gcepd
-TEST_COVERPKG_./drivers/storage/gcepd/tests := $(GCEPD_COVERPKG),$(GCEPD_COVERPKG)/executor

--- a/drivers/storage/isilon/tests/Makefile
+++ b/drivers/storage/isilon/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/isilon/tests/coverage.mk
+++ b/drivers/storage/isilon/tests/coverage.mk
@@ -1,2 +1,0 @@
-ISILON_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/isilon
-TEST_COVERPKG_./drivers/storage/isilon/tests := $(ISILON_COVERPKG),$(ISILON_COVERPKG)/executor

--- a/drivers/storage/mock/tests/coverage.mk
+++ b/drivers/storage/mock/tests/coverage.mk
@@ -1,2 +1,0 @@
-MOCK_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/mock
-TEST_COVERPKG_./drivers/storage/mock/tests := $(MOCK_COVERPKG),$(MOCK_COVERPKG)/executor

--- a/drivers/storage/rbd/tests/Makefile
+++ b/drivers/storage/rbd/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/rbd/tests/coverage.mk
+++ b/drivers/storage/rbd/tests/coverage.mk
@@ -1,2 +1,0 @@
-RBD_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/rbd
-TEST_COVERPKG_./drivers/storage/rbd/tests := $(RBD_COVERPKG),$(RBD_COVERPKG)/executor

--- a/drivers/storage/s3fs/tests/Makefile
+++ b/drivers/storage/s3fs/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/s3fs/tests/coverage.mk
+++ b/drivers/storage/s3fs/tests/coverage.mk
@@ -1,2 +1,0 @@
-S3FS_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/s3fs
-TEST_COVERPKG_./drivers/storage/s3fs/tests := $(S3FS_COVERPKG),$(S3FS_COVERPKG)/executor

--- a/drivers/storage/scaleio/tests/Makefile
+++ b/drivers/storage/scaleio/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/scaleio/tests/coverage.mk
+++ b/drivers/storage/scaleio/tests/coverage.mk
@@ -1,2 +1,0 @@
-SCALEIO_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/scaleio
-TEST_COVERPKG_./drivers/storage/scaleio/tests := $(SCALEIO_COVERPKG),$(SCALEIO_COVERPKG)/executor

--- a/drivers/storage/vbox/tests/Makefile
+++ b/drivers/storage/vbox/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/vbox/tests/coverage.mk
+++ b/drivers/storage/vbox/tests/coverage.mk
@@ -1,2 +1,0 @@
-VBOX_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/vbox
-TEST_COVERPKG_./drivers/storage/vbox/tests := $(VBOX_COVERPKG),$(VBOX_COVERPKG)/executor

--- a/drivers/storage/vfs/tests/Makefile
+++ b/drivers/storage/vfs/tests/Makefile
@@ -1,0 +1,1 @@
+include ../../../../test-driver-pkg.mk

--- a/drivers/storage/vfs/tests/coverage.mk
+++ b/drivers/storage/vfs/tests/coverage.mk
@@ -1,2 +1,0 @@
-VFS_COVERPKG := $(ROOT_IMPORT_PATH)/drivers/storage/vfs
-TEST_COVERPKG_./drivers/storage/vfs/tests := $(VFS_COVERPKG),$(VFS_COVERPKG)/executor

--- a/test-driver-pkg.mk
+++ b/test-driver-pkg.mk
@@ -1,0 +1,37 @@
+# this Makefile can be reused by driver packages for testing
+
+SHELL := $(shell env which bash)
+
+# the name of the driver is grok'd from the basename
+# of the parent directory
+DRIVER := $(shell basename $$(dirname $$(pwd)))
+
+# a list of this package's Go sources, Go test sources, Go Xtest sources
+# (test sources in this directory but belonging to a different package)
+#, and Go sources for packages on which this package depends
+SRCS := $(shell \
+  go list -tags $(DRIVER) -f \
+  '{{join .GoFiles "\n"}}{{"\n"}}{{join .TestGoFiles "\n"}}{{"\n"}}{{join .XTestGoFiles "\n"}}' \
+  && \
+  go list -tags $(DRIVER) -f \
+  '{{with $$p := .}}{{if not $$p.Standard}}{{range $$f := $$p.GoFiles}}{{printf "%s/%s\n" $$p.Dir $$f }}{{end}}{{end}}{{end}}' \
+  $$(go list -tags $(DRIVER) -f '{{if not .Standard}}{{join .Deps "\n"}}{{end}}' \
+  . \
+  $$(go list -tags $(DRIVER) -f '{{join .TestImports "\n"}}{{"\n"}}{{join .XTestImports "\n"}}') | sort -u))
+
+# the test binary
+$(DRIVER).test: $(SRCS)
+	go test -tags $(patsubst %.test,%,$@) -cover -c -o $@ .
+
+# the coverage file
+$(DRIVER).test.out: $(DRIVER).test
+	./$< -test.coverprofile $@
+
+build: $(DRIVER).test
+
+test: $(DRIVER).test.out
+
+clean:
+	rm -f $(DRIVER).test $(DRIVER).test.out
+
+.PHONY: clean

--- a/test-framework-pkg.mk
+++ b/test-framework-pkg.mk
@@ -1,0 +1,36 @@
+# this Makefile can be reused by framework packages for testing
+
+SHELL := $(shell env which bash)
+
+# the name of the directory that contains this Makefile
+PKG := $(shell basename $$(pwd))
+
+# a list of this package's Go sources, Go test sources, Go Xtest sources
+# (test sources in this directory but belonging to a different package)
+#, and Go sources for packages on which this package depends
+SRCS := $(shell \
+  go list -f \
+  '{{join .GoFiles "\n"}}{{"\n"}}{{join .TestGoFiles "\n"}}{{"\n"}}{{join .XTestGoFiles "\n"}}' \
+  && \
+  go list -f \
+  '{{with $$p := .}}{{if not $$p.Standard}}{{range $$f := $$p.GoFiles}}{{printf "%s/%s\n" $$p.Dir $$f }}{{end}}{{end}}{{end}}' \
+  $$(go list -f '{{if not .Standard}}{{join .Deps "\n"}}{{end}}' \
+  . \
+  $$(go list -f '{{join .TestImports "\n"}}{{"\n"}}{{join .XTestImports "\n"}}') | sort -u))
+
+# the test binary
+$(PKG).test: $(SRCS)
+	go test -cover -c -o $@ .
+
+# the coverage file
+$(PKG).test.out: $(PKG).test
+	./$< -test.coverprofile $@
+
+build: $(PKG).test
+
+test: $(PKG).test.out
+
+clean:
+	rm -f $(PKG).test $(PKG).test.out
+
+.PHONY: clean


### PR DESCRIPTION
This patch introduces package-level Makefiles for driving tests for the libStorage framework as well as the storage drivers.