### PR TITLE
Endpoint/Service Init Order Fix

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -164,15 +164,15 @@ func newServer(goCtx gocontext.Context, config gofig.Config) (*server, error) {
 
 	s.ctx.Info("initializing server")
 
-	if err := s.initEndpoints(s.ctx); err != nil {
-		return nil, err
-	}
-	s.ctx.Info("initialized endpoints")
-
 	if err := services.Init(s.ctx, s.config); err != nil {
 		return nil, err
 	}
 	s.ctx.Info("initialized services")
+
+	if err := s.initEndpoints(s.ctx); err != nil {
+		return nil, err
+	}
+	s.ctx.Info("initialized endpoints")
 
 	if logConfig.HTTPRequests || logConfig.HTTPResponses {
 		s.logHTTPEnabled = true


### PR DESCRIPTION
This patch fixes an issue where service init failures would cause libStorage endpoints that use UNIX sock files to leave those sock files in place instead of removing them on error. This fix causes the service init routine to now occur *before* the endpoint init routine, thereby causing any service failure to occur before an endpoint's sock file is even created.

There is no issue filed for this fix, but it was a _911_ issue raised by @kacole2 from the REX-Ray Slack channel. @cduchesne reproduced the error [with a log file](https://gist.github.com/cduchesne/3f05a69192b179debd40d81b9053a72c).