### PR TITLE
Fix Cinder support

### DIFF
--- a/api/types/types_localdevices.go
+++ b/api/types/types_localdevices.go
@@ -44,7 +44,9 @@ func (l *LocalDevices) MarshalText() ([]byte, error) {
 	keys := []string{}
 
 	for k := range l.DeviceMap {
-		keys = append(keys, k)
+		if k != "" {
+			keys = append(keys, k)
+		}
 	}
 
 	sort.Sort(byString(keys))
@@ -61,7 +63,7 @@ func (l *LocalDevices) MarshalText() ([]byte, error) {
 }
 
 var (
-	ldRX         = regexp.MustCompile(`^(.+?)=(\S+::\S+(?::\s*,\s*\S+::\S+)*)?$`)
+	ldRX         = regexp.MustCompile(`^(.+?)=(\S+::\S*(?::\s*,\s*\S+::\S*)*)?$`)
 	commaByteSep = []byte{','}
 	colonByteSep = []byte{':', ':'}
 )
@@ -82,10 +84,14 @@ func (l *LocalDevices) UnmarshalText(value []byte) error {
 
 	for _, p := range bytes.Split(m[2], commaByteSep) {
 		pp := bytes.Split(p, colonByteSep)
-		if len(pp) < 2 {
+		if len(pp) < 1 {
 			continue
 		}
-		l.DeviceMap[string(pp[0])] = string(pp[1])
+		val := ""
+		if len(pp) > 1 {
+			val = string(pp[1])
+		}
+		l.DeviceMap[string(pp[0])] = val
 	}
 
 	return nil

--- a/drivers/storage/libstorage/libstorage_client_xcli.go
+++ b/drivers/storage/libstorage/libstorage_client_xcli.go
@@ -231,13 +231,6 @@ func (c *client) LocalDevices(
 		return nil, err
 	}
 
-	// remove any local devices without values in the map
-	for k, v := range ld.DeviceMap {
-		if v == "" {
-			delete(ld.DeviceMap, k)
-		}
-	}
-
 	ctx.Debug("xli localdevices success")
 	return ld, nil
 }


### PR DESCRIPTION
Fix codedellemc/rexray#915
I tested on top of 0.6.2/0.9.2 tag (branch fix-cinder on my repo).

I can't test on master right now, trying to launch with `rexray -l info service start -f` complains about the -l flag and if I remove it it fails to initialize with no verbose error. No problem on 0.6.2.

ERRO[0001] default module(s) failed to initialize        time=1500856134548
ERRO[0001] daemon failed to initialize                   time=1500856134548
ERRO[0001] error starting rex-ray                        time=1500856134548