### PR TITLE
Support for more device nodes with EBS volumes

### DIFF
--- a/drivers/storage/ebs/executor/ebs_executor.go
+++ b/drivers/storage/ebs/executor/ebs_executor.go
@@ -120,7 +120,7 @@ func (d *driver) NextDevice(
 	}
 
 	// Find next available letter for device path
-	r := rand.New(rand.NewSource(time.Now().Unix()))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for _, pIndex := range r.Perm(len(parentLetters)) {
 		for _, cIndex := range r.Perm(len(childLetters)) {
 			suffix := parentLetters[pIndex] + childLetters[cIndex]

--- a/drivers/storage/ebs/executor/ebs_executor.go
+++ b/drivers/storage/ebs/executor/ebs_executor.go
@@ -6,10 +6,12 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"math/rand"
 	"os"
 	"path"
 	"regexp"
 	"strings"
+	"time"
 
 	gofig "github.com/akutz/gofig/types"
 	"github.com/akutz/goof"
@@ -118,9 +120,10 @@ func (d *driver) NextDevice(
 	}
 
 	// Find next available letter for device path
-	for _, p := range parentLetters {
-		for _, c := range childLetters {
-			suffix := p + c
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	for _, pIndex := range r.Perm(len(parentLetters)) {
+		for _, cIndex := range r.Perm(len(childLetters)) {
+			suffix := parentLetters[pIndex] + childLetters[cIndex]
 			if localDeviceNames[suffix] {
 				continue
 			}

--- a/drivers/storage/ebs/utils/utils_unix.go
+++ b/drivers/storage/ebs/utils/utils_unix.go
@@ -14,6 +14,6 @@ import (
 // it will appear locally as /dev/xvd*
 var NextDeviceInfo = &types.NextDeviceInfo{
 	Prefix:  "xvd",
-	Pattern: "[f-p]",
+	Pattern: "[b-c][a-z]",
 	Ignore:  false,
 }


### PR DESCRIPTION
Currently libstorage supports device nodes for EBS volumes within range `/dev/xvd[f-p]` which is in line with [Amazon's recommendations](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html). However, this is just a recommendation and typically it is not feasible for environments where volumes are used a lot more extensively. This is the case with any job scheduler that uses persistent storage such as Kubernetes or Nomad.

Kubernetes AWS device allocator uses a much broader device namespace `/dev/xvd[b-c][a-z]`. Related source code reference here: https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/device_allocator.go#L80-L92

Now, this issue has been discussed previously at least in codedellemc/rexray#773. This pull request changes the device range from `/dev/xvd[f-p]` to the much larger one `/dev/xvd[b-c][a-z]`. And in order to prevent ghost device issues such as codedellemc/rexray#410 the device allocator iterates the devices in a random order.